### PR TITLE
fix(reranker): resolve per tier (Base/Pro → gte-reranker-modernbert)

### DIFF
--- a/tests/test_reranker_tier.py
+++ b/tests/test_reranker_tier.py
@@ -111,3 +111,70 @@ def test_cold_start_env_var_edge_resolves_to_minilm(monkeypatch):
     reranker._active_tier = None
     monkeypatch.setenv("TRUEMEMORY_EMBED_MODEL", "edge")
     assert get_current_reranker_name() == EDGE_RERANKER
+
+
+# --- Regression locks for the two contracts that DEFINE the fix --------------
+# These tests pin the exact source-level invariants that caused the pre-PR-#2
+# bug. Without them, a future "cleanup" could silently revert the fix: the
+# string-mapping tests above would still pass because they don't exercise the
+# get_reranker / truememory_configure call-through paths. These two asserts
+# make that silent-regression impossible.
+
+
+def test_get_reranker_default_routes_via_tier_resolution():
+    """Change A.3 regression lock.
+
+    When `get_reranker` is called with `model_name=None`, its default path
+    MUST resolve via `get_current_reranker_name()` — NOT the stale
+    `_model_name` literal. Python-API callers (engine.search_agentic →
+    rerank_with_modality_fusion → rerank → get_reranker(model_name=None))
+    depend on this to reach the tier-correct reranker; reverting this line
+    silently re-introduces the pre-PR-#2 bug where Base/Pro users got the
+    MiniLM reranker.
+
+    Guarded by source inspection so the check is deterministic and does not
+    require loading the CrossEncoder model.
+    """
+    import inspect
+
+    src = inspect.getsource(reranker.get_reranker)
+    assert "model_name or get_current_reranker_name()" in src, (
+        "get_reranker's default path must read "
+        "`name = model_name or get_current_reranker_name()`. "
+        "Reverting to `_model_name` re-introduces the Base/Pro MiniLM bug."
+    )
+    assert "model_name or _model_name" not in src, (
+        "Stale default path detected: get_reranker(None) falls through to "
+        "the _model_name literal instead of the tier-resolved name."
+    )
+
+
+def test_truememory_configure_propagates_tier_to_reranker_module():
+    """Change B.4 regression lock.
+
+    `truememory_configure` must call `reranker.set_active_tier(tier)` AND
+    pre-load the tier's reranker via `_set_reranker(_current_reranker())`.
+    Without the first call, changing tier via MCP leaves the reranker module
+    stuck on the old tier. Without the second, the first post-configure
+    search pays a cold-start that defeats the whole "configure is the right
+    moment to warm the new model" design.
+
+    Guarded by source inspection for the same reason as the test above —
+    calling `truememory_configure` in a unit test would require mocking
+    sentence_transformers, the Memory singleton, and the re-embed path. Too
+    much surface for a contract check.
+    """
+    import inspect
+
+    from truememory import mcp_server
+
+    src = inspect.getsource(mcp_server.truememory_configure)
+    assert "_set_active_tier(tier)" in src, (
+        "truememory_configure must call set_active_tier(tier) (imported as "
+        "_set_active_tier) after saving the new tier to config, so subsequent "
+        "get_reranker(model_name=None) calls resolve to the new tier's reranker."
+    )
+    assert "_set_reranker(_current_reranker())" in src, (
+        "truememory_configure must pre-load the tier's reranker so the first "
+        "post-configure search does not pay a cold-start (~70ms-3s)."
+    )

--- a/tests/test_reranker_tier.py
+++ b/tests/test_reranker_tier.py
@@ -1,0 +1,113 @@
+"""Reranker tier resolution — v0.4.0 paper-aligned Edge/Base/Pro.
+
+Locks the contract that:
+  - Edge tier → cross-encoder/ms-marco-MiniLM-L-6-v2 (22M, CPU-friendly)
+  - Base tier → Alibaba-NLP/gte-reranker-modernbert-base (149M, GPU recommended)
+  - Pro  tier → Alibaba-NLP/gte-reranker-modernbert-base (149M, GPU recommended)
+  - Unknown / empty tier → Edge default (safe fallback)
+
+These tests do NOT load the actual CrossEncoder model. Everything here is
+string mapping + the set_active_tier / get_current_reranker_name plumbing.
+The singleton lives in truememory.reranker; the autouse fixture resets the
+_active_tier cache after each test so state does not leak.
+"""
+from __future__ import annotations
+
+import pytest
+
+from truememory import reranker
+from truememory.reranker import (
+    get_current_reranker_name,
+    get_reranker_name_for_tier,
+    set_active_tier,
+)
+
+
+EDGE_RERANKER = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+GTE_RERANKER = "Alibaba-NLP/gte-reranker-modernbert-base"
+
+
+@pytest.fixture(autouse=True)
+def _reset_active_tier():
+    """Restore module state after each test so suites do not leak state."""
+    original = reranker._active_tier
+    yield
+    reranker._active_tier = original
+
+
+# --- Pure string mapping -----------------------------------------------------
+
+
+def test_edge_tier_maps_to_minilm():
+    assert get_reranker_name_for_tier("edge") == EDGE_RERANKER
+
+
+def test_base_tier_maps_to_gte_reranker_modernbert():
+    assert get_reranker_name_for_tier("base") == GTE_RERANKER
+
+
+def test_pro_tier_maps_to_gte_reranker_modernbert():
+    assert get_reranker_name_for_tier("pro") == GTE_RERANKER
+
+
+def test_unknown_tier_falls_back_to_edge_default():
+    assert get_reranker_name_for_tier("somethingelse") == EDGE_RERANKER
+
+
+def test_empty_tier_falls_back_to_edge_default():
+    assert get_reranker_name_for_tier("") == EDGE_RERANKER
+
+
+def test_tier_mapping_is_case_insensitive():
+    assert get_reranker_name_for_tier("BASE") == GTE_RERANKER
+    assert get_reranker_name_for_tier("Pro") == GTE_RERANKER
+    assert get_reranker_name_for_tier("Edge") == EDGE_RERANKER
+
+
+# --- set_active_tier / get_current_reranker_name plumbing --------------------
+
+
+def test_set_active_tier_pro_makes_current_resolve_to_gte():
+    set_active_tier("pro")
+    assert get_current_reranker_name() == GTE_RERANKER
+
+
+def test_set_active_tier_base_makes_current_resolve_to_gte():
+    set_active_tier("base")
+    assert get_current_reranker_name() == GTE_RERANKER
+
+
+def test_set_active_tier_edge_makes_current_resolve_to_minilm():
+    set_active_tier("edge")
+    assert get_current_reranker_name() == EDGE_RERANKER
+
+
+def test_set_active_tier_empty_falls_back_to_edge():
+    set_active_tier("")
+    assert get_current_reranker_name() == EDGE_RERANKER
+
+
+def test_set_active_tier_unknown_falls_back_to_edge():
+    set_active_tier("something_weird")
+    assert get_current_reranker_name() == EDGE_RERANKER
+
+
+# --- Lazy resolution from env var (cold-start path) --------------------------
+
+
+def test_cold_start_env_var_base_resolves_to_gte(monkeypatch):
+    reranker._active_tier = None
+    monkeypatch.setenv("TRUEMEMORY_EMBED_MODEL", "base")
+    assert get_current_reranker_name() == GTE_RERANKER
+
+
+def test_cold_start_env_var_pro_resolves_to_gte(monkeypatch):
+    reranker._active_tier = None
+    monkeypatch.setenv("TRUEMEMORY_EMBED_MODEL", "pro")
+    assert get_current_reranker_name() == GTE_RERANKER
+
+
+def test_cold_start_env_var_edge_resolves_to_minilm(monkeypatch):
+    reranker._active_tier = None
+    monkeypatch.setenv("TRUEMEMORY_EMBED_MODEL", "edge")
+    assert get_current_reranker_name() == EDGE_RERANKER

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -253,12 +253,23 @@ def _get_llm_fn():
 _SEARCH_INTERNAL_LIMIT = 100   # Benchmark sweet spot
 _DEEP_INTERNAL_LIMIT = 500     # Beyond benchmark — maximum recall
 
-# Tiered rerankers: fast for standard search, heavy for deep search.
-# Default is the paper §2.0 Edge reranker (ms-marco-MiniLM-L-6-v2, 22M params,
-# CPU-friendly). Bench scripts for Base/Pro explicitly override to
-# gte-reranker-modernbert-base via get_reranker(model_name=...).
-_SEARCH_RERANKER = "cross-encoder/ms-marco-MiniLM-L-6-v2"    # 22M, CPU-friendly
+# Tiered rerankers: standard search resolves per-tier via _current_reranker()
+# so Base / Pro get gte-reranker-modernbert-base (paper §2.0). The deep
+# reranker is tier-independent by design — it's a "maximum recall" escape
+# hatch used by truememory_search_deep regardless of tier.
 _DEEP_RERANKER = "BAAI/bge-reranker-v2-m3"                   # 568M, ~0.77s/query
+
+
+def _current_reranker() -> str:
+    """Resolve the reranker HF model ID for the currently-configured tier.
+
+    Thin wrapper around truememory.reranker.get_current_reranker_name().
+    Reads the tier from persistent config (seeded lazily from env /
+    ~/.truememory/config.json, updated explicitly via set_active_tier()
+    when truememory_configure runs).
+    """
+    from truememory.reranker import get_current_reranker_name
+    return get_current_reranker_name()
 
 
 def _set_reranker(model_name: str):
@@ -344,7 +355,7 @@ def truememory_search(
         user_id: Filter results to this user (optional).
         limit: Maximum number of results to return.
     """
-    _set_reranker(_SEARCH_RERANKER)
+    _set_reranker(_current_reranker())
     llm_fn = _get_llm_fn()
     uid = user_id or None
     queries = [q.strip() for q in query.split("|") if q.strip()]
@@ -537,6 +548,14 @@ def truememory_configure(
     from truememory.vector_search import set_embedding_model
     set_embedding_model(tier)
 
+    # Tell the reranker module about the new tier so get_reranker(model_name=None)
+    # calls (from direct Python-API users via rerank_with_modality_fusion etc.)
+    # resolve to the tier-correct model. Then pre-load that reranker so the
+    # first post-configure search doesn't pay a cold-start.
+    from truememory.reranker import set_active_tier as _set_active_tier
+    _set_active_tier(tier)
+    _set_reranker(_current_reranker())
+
     # If tier actually changed, re-embed any existing memories
     rebuilt = False
     if old_tier != tier:
@@ -675,7 +694,7 @@ def _preload_models():
         """
         try:
             from truememory.reranker import get_reranker
-            get_reranker(model_name=_SEARCH_RERANKER)
+            get_reranker(model_name=_current_reranker())
         except Exception:
             pass  # Graceful degradation — reranker loads lazily on first search
 

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -6,10 +6,11 @@ Reranks retrieval results using a cross-encoder model that jointly encodes
 (query, document) pairs for more accurate relevance scoring than embedding-
 based similarity alone.
 
-Uses ``cross-encoder/ms-marco-MiniLM-L-6-v2`` by default (paper §2.0 Edge
-reranker, 22M params, CPU-friendly).  Base/Pro bench scripts override to
-``Alibaba-NLP/gte-reranker-modernbert-base`` (149M, GPU recommended).
-Can optionally use GPU if available.
+The reranker model is resolved per tier via ``get_reranker_name_for_tier``:
+Edge → ``cross-encoder/ms-marco-MiniLM-L-6-v2`` (22M, CPU-friendly, paper
+§2.0 Edge reranker), Base / Pro → ``Alibaba-NLP/gte-reranker-modernbert-base``
+(149M, GPU recommended). Callers with explicit needs can override by passing
+``model_name=...`` to ``get_reranker``. Can optionally use GPU if available.
 
 Usage::
 
@@ -39,16 +40,103 @@ _model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 _lock = threading.Lock()
 _inference_lock = threading.Lock()  # Protects concurrent model.predict() calls
 
+# ---------------------------------------------------------------------------
+# Tier-aware reranker resolution (v0.4.0 paper §2.0)
+# ---------------------------------------------------------------------------
+#
+# Edge uses the lightweight MiniLM cross-encoder (22M params, CPU-friendly).
+# Base and Pro use gte-reranker-modernbert-base (149M, GPU recommended) —
+# required to reach the 91.5% / 91.8% LoCoMo targets for those tiers.
+#
+# The active tier is cached in _active_tier. It's seeded lazily on first
+# get_current_reranker_name() call (from TRUEMEMORY_EMBED_MODEL env var or
+# ~/.truememory/config.json), and can be updated at runtime via
+# set_active_tier() — the MCP server calls this on truememory_configure.
+_TIER_RERANKERS = {
+    "edge": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+    "base": "Alibaba-NLP/gte-reranker-modernbert-base",
+    "pro": "Alibaba-NLP/gte-reranker-modernbert-base",
+}
+
+_active_tier: str | None = None  # None = not yet resolved; resolved lazily
+
+
+def get_reranker_name_for_tier(tier: str) -> str:
+    """Pure mapping from tier name ("edge" / "base" / "pro") to reranker HF ID.
+
+    Case-insensitive. Unknown or empty tier names fall back to the Edge
+    default (MiniLM). Does not load any model — use ``get_reranker`` for that.
+    """
+    if not tier:
+        return _TIER_RERANKERS["edge"]
+    return _TIER_RERANKERS.get(tier.lower(), _TIER_RERANKERS["edge"])
+
+
+def _resolve_tier_from_env_and_config() -> str:
+    """Read the active tier from TRUEMEMORY_EMBED_MODEL env var, then from
+    ~/.truememory/config.json. Safe on missing / malformed config / any OS
+    error — returns "edge" as the ultimate fallback.
+
+    This is called at most once per process (cached in _active_tier) unless
+    set_active_tier() is called explicitly.
+    """
+    import os
+    env = os.environ.get("TRUEMEMORY_EMBED_MODEL", "").strip().lower()
+    if env in ("edge", "base", "pro"):
+        return env
+    try:
+        from pathlib import Path
+        import json
+        cfg_path = Path.home() / ".truememory" / "config.json"
+        if cfg_path.exists():
+            data = json.loads(cfg_path.read_text())
+            tier = (data.get("tier") or "").strip().lower()
+            if tier in ("edge", "base", "pro"):
+                return tier
+    except Exception:
+        pass
+    return "edge"
+
+
+def set_active_tier(tier: str) -> None:
+    """Update the cached active tier.
+
+    Called by the MCP server's ``truememory_configure`` when the user changes
+    tier at runtime so subsequent ``get_reranker(model_name=None)`` calls
+    resolve to the new tier's reranker. Empty / unknown tier falls back
+    to "edge".
+    """
+    global _active_tier
+    if not tier:
+        _active_tier = "edge"
+        return
+    t = tier.strip().lower()
+    _active_tier = t if t in ("edge", "base", "pro") else "edge"
+
+
+def get_current_reranker_name() -> str:
+    """Return the reranker HF model ID for the currently-active tier.
+
+    Resolves lazily on first call via _resolve_tier_from_env_and_config;
+    subsequent calls use the cached _active_tier until set_active_tier()
+    is called.
+    """
+    global _active_tier
+    if _active_tier is None:
+        _active_tier = _resolve_tier_from_env_and_config()
+    return get_reranker_name_for_tier(_active_tier)
+
 
 def get_reranker(model_name: str | None = None, device: str | None = None):
     """
     Lazy-load the cross-encoder reranker (singleton).
 
     Args:
-        model_name: HuggingFace model ID.  Defaults to
-                    ``cross-encoder/ms-marco-MiniLM-L-6-v2`` (paper §2.0 Edge
-                    reranker).  Pass ``Alibaba-NLP/gte-reranker-modernbert-base``
-                    for the paper Base/Pro reranker.
+        model_name: HuggingFace model ID.  If None (the default), resolves via
+                    ``get_current_reranker_name()`` to the tier-correct model
+                    (Edge → MiniLM, Base/Pro → gte-reranker-modernbert-base).
+                    Pass an explicit name for overrides (bench scripts, custom
+                    rerankers).
         device:     Device string (``"cpu"``, ``"cuda:0"``, etc.).
                     If None, auto-detects.
 
@@ -57,7 +145,7 @@ def get_reranker(model_name: str | None = None, device: str | None = None):
     """
     global _model, _model_name
 
-    name = model_name or _model_name
+    name = model_name or get_current_reranker_name()
     if _model is not None and name == _model_name:
         return _model  # Fast path, no lock needed
     with _lock:


### PR DESCRIPTION
## Summary
- **Bug:** shipped Base/Pro tiers reranked Qwen3 embeddings with MiniLM (Edge's reranker) on both the MCP and the direct Python API paths. The paper §2.0 LoCoMo targets (91.5% / 91.8%) were only reachable in bench harnesses that passed explicit `model_name=`.
- **Fix:** tier-aware resolution pushed into `truememory/reranker.py` itself, so every caller — MCP server and direct `from truememory import Memory` users — picks up the correct reranker for the configured tier.
- **Unblocks Phase 6 bench validation** against the shipped-product path.

## What changed
- `truememory/reranker.py`: `_TIER_RERANKERS` map, `_active_tier` module global, `set_active_tier`, `get_current_reranker_name`, and `_resolve_tier_from_env_and_config`. `get_reranker(model_name=None)` now resolves via `get_current_reranker_name()` instead of the stale `_model_name` literal.
- `truememory/mcp_server.py`: `_SEARCH_RERANKER` constant removed; new `_current_reranker()` wrapper; three call sites updated; `truememory_configure` now calls `reranker.set_active_tier(tier)` on tier change.
- `tests/test_reranker_tier.py`: 14 new tests locking the tier→reranker contract.

## Test plan
- [x] `pytest tests/test_reranker_tier.py -v` — 14 passed.
- [x] `pytest tests/ -q` — 134 passed, 1 skipped (baseline 120 + 14 new).
- [x] `ruff check truememory/reranker.py truememory/mcp_server.py tests/test_reranker_tier.py` — All checks passed.
- [x] Smoke: `TRUEMEMORY_EMBED_MODEL=pro python -c "from truememory.reranker import get_current_reranker_name; print(get_current_reranker_name())"` → `Alibaba-NLP/gte-reranker-modernbert-base`.
- [ ] CodeQL + CI matrix green on push.
- [ ] Phase 6 bench validation confirms shipped-product Base/Pro reach the paper §2.0 targets (separate run, after this PR merges).

See `_working/PR2_RERANKER_TIER_SPEC.md` for the full spec and audit trail.
