### PR TITLE
high: embedder-identity tracking (F01+F02+F32 — upgrade-path safety)

### DIFF
--- a/tests/test_upgrade_path.py
+++ b/tests/test_upgrade_path.py
@@ -1,0 +1,194 @@
+"""Regression locks for Hunter F01 / F02 / F32 — embedder-identity tracking.
+
+These tests exercise the upgrade path where a stored DB was built with a
+different embedder than the one currently configured. The code under test must:
+
+- F01: raise `TrueMemoryMigrationError` when `init_vec_table` finds an existing
+  `vec_messages` at a different dim.
+- F02: persist `(embed_model, embed_dim)` in a `metadata` key/value table on
+  every `build_vectors` / `build_separation_vectors`, and raise on model drift
+  at matching dim (the silent-quality-collapse case).
+- F32: refuse a silent auto-rebuild in `engine.open()` when metadata names a
+  different model than the currently-configured tier.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+import pytest
+
+from truememory import vector_search
+from truememory.storage import create_db
+from truememory.vector_search import (
+    EMBEDDING_MODEL,
+    TrueMemoryMigrationError,
+    _check_embedder_compatibility,
+    _check_rebuild_allowed,
+    _read_embedder_metadata,
+    _write_embedder_metadata,
+    build_vectors,
+    init_vec_table,
+)
+
+
+def _fresh_conn(tmp_path) -> sqlite3.Connection:
+    """Create a DB with full schema but no vec tables yet."""
+    return create_db(tmp_path / "upgrade.db")
+
+
+def _load_sqlite_vec(conn: sqlite3.Connection) -> None:
+    import sqlite_vec
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+
+
+# ---------------------------------------------------------------------------
+# F01 — dim mismatch on existing vec_messages is fatal
+# ---------------------------------------------------------------------------
+
+
+def test_dim_mismatch_raises_migration_error(tmp_path, monkeypatch):
+    """Simulates a v0.3.0 Pro (1024d) DB being opened on v0.4.0 (256d)."""
+    conn = _fresh_conn(tmp_path)
+    _load_sqlite_vec(conn)
+    conn.execute("CREATE VIRTUAL TABLE vec_messages USING vec0(embedding float[1024])")
+    conn.commit()
+
+    # Current tier advertises 256d (Edge / Base / Pro on v0.4.0 all = 256d)
+    monkeypatch.setattr(vector_search, "_embedding_dim", 256)
+
+    with pytest.raises(TrueMemoryMigrationError) as excinfo:
+        init_vec_table(conn)
+    msg = str(excinfo.value)
+    assert "1024d" in msg and "256d" in msg
+    assert "truememory_configure" in msg  # actionable hint present
+
+
+# ---------------------------------------------------------------------------
+# F02 — metadata is written on build and read on init
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_written_on_build_vectors(tmp_path):
+    """`build_vectors` must persist (embed_model, embed_dim) so later opens
+    can detect drift."""
+    conn = _fresh_conn(tmp_path)
+    init_vec_table(conn)
+
+    conn.execute("INSERT INTO messages(content) VALUES (?)", ("hello world",))
+    conn.execute("INSERT INTO messages(content) VALUES (?)", ("another message",))
+    conn.commit()
+
+    n = build_vectors(conn)
+    assert n == 2
+
+    model, dim = _read_embedder_metadata(conn)
+    assert model == EMBEDDING_MODEL
+    assert dim is not None and dim > 0
+
+
+def test_model_change_raises_migration_error_at_matching_dim(
+    tmp_path, monkeypatch
+):
+    """Simulates Model2Vec 256d → Qwen3 256d without re-embed (F02's core scenario).
+
+    Matching dims would otherwise mask a silent vector-space mismatch.
+    """
+    conn = _fresh_conn(tmp_path)
+    init_vec_table(conn)
+    # Pretend this DB was built with model2vec previously
+    _write_embedder_metadata(conn)
+    assert _read_embedder_metadata(conn)[0] == EMBEDDING_MODEL
+
+    # Now simulate the user switching tier (same dim, different model) WITHOUT
+    # going through truememory_configure()
+    monkeypatch.setattr(vector_search, "EMBEDDING_MODEL", "qwen3_256")
+    # dim stays the same
+
+    # init_vec_table must reject this silent drift
+    with pytest.raises(TrueMemoryMigrationError) as excinfo:
+        init_vec_table(conn)
+    msg = str(excinfo.value)
+    assert "truememory_configure" in msg
+
+
+def test_legacy_v030_db_warns_without_raising(tmp_path, caplog):
+    """v0.3.0 DBs have `vec_messages` but no metadata row. At matching dim,
+    we must warn (not raise) — letting the user keep working until they
+    re-embed intentionally.
+    """
+    conn = _fresh_conn(tmp_path)
+    _load_sqlite_vec(conn)
+    # Pre-create vec_messages at current dim with NO metadata row (legacy shape).
+    conn.execute(
+        f"CREATE VIRTUAL TABLE vec_messages USING vec0(embedding float[{vector_search._embedding_dim}])"
+    )
+    # Drop the metadata table that create_db gave us so we faithfully model
+    # a pre-F02 DB.
+    conn.execute("DROP TABLE IF EXISTS metadata")
+    conn.commit()
+
+    with caplog.at_level(logging.WARNING, logger="truememory.vector_search"):
+        # Should NOT raise — just warn.
+        _check_embedder_compatibility(conn)
+
+    assert any(
+        "without embedder metadata" in rec.message
+        for rec in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# fresh-DB / same-model — must not trip either check
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_db_init_vec_table_no_error(tmp_path):
+    """A brand-new DB has no vec table and no metadata — init must succeed."""
+    conn = _fresh_conn(tmp_path)
+    init_vec_table(conn)
+    # Idempotent: second call also fine.
+    init_vec_table(conn)
+
+
+def test_same_model_no_raise(tmp_path):
+    """Re-opening with the same model must not raise."""
+    conn = _fresh_conn(tmp_path)
+    init_vec_table(conn)
+    conn.execute("INSERT INTO messages(content) VALUES ('x')")
+    conn.commit()
+    build_vectors(conn)
+    # Second init should see matching metadata and pass cleanly.
+    init_vec_table(conn)
+
+
+# ---------------------------------------------------------------------------
+# F32 — engine.open() must refuse silent rebuild on model drift
+# ---------------------------------------------------------------------------
+
+
+def test_check_rebuild_allowed_raises_on_model_drift(tmp_path, monkeypatch):
+    conn = _fresh_conn(tmp_path)
+    _write_embedder_metadata(conn)  # records current EMBEDDING_MODEL
+
+    # Simulate live tier switch without a re-embed
+    monkeypatch.setattr(vector_search, "EMBEDDING_MODEL", "qwen3_256")
+
+    with pytest.raises(TrueMemoryMigrationError) as excinfo:
+        _check_rebuild_allowed(conn)
+    msg = str(excinfo.value)
+    assert "truememory_configure" in msg
+    assert "silent auto-rebuild" in msg.lower() or "refusing" in msg.lower()
+
+
+def test_check_rebuild_allowed_noop_without_metadata(tmp_path):
+    """No metadata = pre-F02 DB. Rebuild is allowed; metadata will be written
+    on the first build_vectors call."""
+    conn = _fresh_conn(tmp_path)
+    # Drop the metadata table so we're modelling a v0.3.0 DB
+    conn.execute("DROP TABLE IF EXISTS metadata")
+    conn.commit()
+    # Must not raise.
+    _check_rebuild_allowed(conn)

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -24,6 +24,7 @@ Design principles:
 from __future__ import annotations
 
 import logging
+import os
 import re
 import time
 import sqlite3
@@ -47,7 +48,13 @@ logger = logging.getLogger(__name__)
 
 _HAS_VECTOR = False
 try:
-    from truememory.vector_search import init_vec_table, build_vectors, build_separation_vectors
+    from truememory.vector_search import (
+        init_vec_table,
+        build_vectors,
+        build_separation_vectors,
+        TrueMemoryMigrationError,
+        _check_rebuild_allowed,
+    )
     _HAS_VECTOR = True
 except (ImportError, ModuleNotFoundError):
     pass
@@ -592,21 +599,35 @@ class TrueMemoryEngine:
             except Exception:
                 logger.debug("Failed to load sqlite-vec extension in open()", exc_info=True)
 
-        # Check for vector tables — rebuild if missing
+        # Check for vector tables — rebuild if missing.
+        # Hunter F32: if metadata names a different embedder, refuse silent
+        # rebuild; route the user through truememory_configure() instead.
         self._has_vectors = False
         if _HAS_VECTOR:
             try:
                 self.conn.execute("SELECT COUNT(*) FROM vec_messages").fetchone()
                 self._has_vectors = True
             except Exception:
-                logger.debug("vec_messages table not found, attempting rebuild", exc_info=True)
+                logger.warning(
+                    "vec_messages table missing; attempting rebuild with "
+                    "current model=%s",
+                    os.environ.get("TRUEMEMORY_EMBED_MODEL", "edge"),
+                )
                 if rebuild_vectors:
+                    _check_rebuild_allowed(self.conn)  # raises on model drift
                     try:
                         init_vec_table(self.conn)
                         n = build_vectors(self.conn)
                         self._has_vectors = n > 0
+                        logger.info(
+                            "vec_messages rebuilt with %d vectors (model=%s)",
+                            n,
+                            os.environ.get("TRUEMEMORY_EMBED_MODEL", "edge"),
+                        )
+                    except TrueMemoryMigrationError:
+                        raise
                     except Exception:
-                        logger.debug("Vector table rebuild failed", exc_info=True)
+                        logger.exception("Vector table rebuild failed")
                         self._has_vectors = False
 
         self._has_hybrid = _HAS_HYBRID and self._has_vectors

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -139,6 +139,16 @@ CREATE TABLE IF NOT EXISTS entity_relationships (
     dunbar_layer TEXT DEFAULT '',
     last_interaction TEXT DEFAULT ''
 );
+
+-- Embedder identity / schema version (Hunter F02: prevents silent quality
+-- collapse when a tier switch produces matching dims but different vector
+-- spaces — e.g. Model2Vec 256d → Qwen3 256d). Writers: build_vectors,
+-- build_separation_vectors. Readers: init_vec_table, engine.open().
+CREATE TABLE IF NOT EXISTS metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TEXT
+);
 """
 
 

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -26,7 +26,10 @@ Dependencies:
 
 from __future__ import annotations
 
+import datetime
+import logging
 import os
+import re
 import struct
 import sqlite3
 import threading
@@ -36,6 +39,19 @@ import numpy as np
 
 if TYPE_CHECKING:
     pass
+
+logger = logging.getLogger(__name__)
+
+
+class TrueMemoryMigrationError(Exception):
+    """Raised when the stored DB was built with a different embedder than the
+    currently-configured tier.
+
+    Upgrading between tiers that use different embedding dimensions (e.g.
+    v0.3.0 Pro @ 1024d → v0.4.0 Pro @ 256d) or different embedders at the
+    same dimension (e.g. Model2Vec 256d → Qwen3 256d) requires re-embedding
+    the stored messages. See the CHANGELOG for migration steps.
+    """
 
 # ---------------------------------------------------------------------------
 # Singleton model loader
@@ -141,6 +157,141 @@ def get_model():
 # Serialization helpers
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Embedder-identity metadata (Hunter F01 / F02 / F32)
+# ---------------------------------------------------------------------------
+
+
+def _ensure_metadata_table(conn: sqlite3.Connection) -> None:
+    """Idempotently create the key/value metadata table.
+
+    storage._SCHEMA_SQL also declares this table, but engine.open() connects
+    to existing v0.3.0 DBs without running that script, so a runtime-safe
+    CREATE IF NOT EXISTS is needed before any metadata read/write.
+    """
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS metadata ("
+        "key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT"
+        ")"
+    )
+
+
+def _write_embedder_metadata(conn: sqlite3.Connection) -> None:
+    """Record `(embed_model, embed_dim)` so later opens can detect drift."""
+    _ensure_metadata_table(conn)
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata(key, value, updated_at) VALUES (?, ?, ?)",
+        ("embed_model", EMBEDDING_MODEL, now),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata(key, value, updated_at) VALUES (?, ?, ?)",
+        ("embed_dim", str(_embedding_dim), now),
+    )
+    conn.commit()
+
+
+def _read_embedder_metadata(
+    conn: sqlite3.Connection,
+) -> tuple[str | None, int | None]:
+    """Return `(stored_model, stored_dim)` or `(None, None)` if not recorded."""
+    _ensure_metadata_table(conn)
+    rows = conn.execute(
+        "SELECT key, value FROM metadata WHERE key IN ('embed_model', 'embed_dim')"
+    ).fetchall()
+    stored = {r[0]: r[1] for r in rows}
+    model = stored.get("embed_model")
+    dim_str = stored.get("embed_dim")
+    try:
+        dim = int(dim_str) if dim_str else None
+    except ValueError:
+        dim = None
+    return model, dim
+
+
+def _detect_existing_vec_dim(conn: sqlite3.Connection) -> int | None:
+    """Parse the dimension declared in an existing `vec_messages` schema."""
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name='vec_messages'"
+    ).fetchone()
+    if not row or not row[0]:
+        return None
+    match = re.search(r"float\[(\d+)\]", row[0])
+    return int(match.group(1)) if match else None
+
+
+def _migration_hint() -> str:
+    return (
+        "Re-embed via `truememory_configure(tier=...)` (re-encodes existing "
+        "memories with the new model) or delete the DB (e.g. "
+        "`~/.truememory/memories.db`) to start fresh."
+    )
+
+
+def _check_embedder_compatibility(conn: sqlite3.Connection) -> None:
+    """Guard against silent dim- or model-mismatch when a vec table exists.
+
+    Called from :func:`init_vec_table`. Skips when `vec_messages` is absent
+    so that explicit re-embed flows (truememory_configure dropping + rebuilding)
+    aren't blocked by stale metadata from the previous embedder.
+    """
+    existing_dim = _detect_existing_vec_dim(conn)
+    if existing_dim is None:
+        return  # fresh DB or dropped-for-re-embed — nothing to protect
+
+    stored_model, _stored_dim = _read_embedder_metadata(conn)
+    current_dim = _embedding_dim
+
+    if existing_dim != current_dim:
+        stored_hint = (
+            f" (stored embed_model={stored_model!r})"
+            if stored_model
+            else " (no metadata — likely a legacy v0.3.0 DB)"
+        )
+        raise TrueMemoryMigrationError(
+            f"Database has a {existing_dim}d vec_messages table but the "
+            f"current embedder produces {current_dim}d vectors{stored_hint}. "
+            f"This commonly happens when upgrading between tiers with "
+            f"different embedding dimensions (e.g. v0.3.0 Pro @ 1024d → "
+            f"v0.4.0 Pro @ 256d). " + _migration_hint()
+        )
+
+    if stored_model is not None and stored_model != EMBEDDING_MODEL:
+        raise TrueMemoryMigrationError(
+            f"Database was built with embed_model={stored_model!r}; current "
+            f"is {EMBEDDING_MODEL!r}. Matching dims ({current_dim}d) would "
+            f"otherwise mask a silent vector-space mismatch. " + _migration_hint()
+        )
+
+    if stored_model is None:
+        logger.warning(
+            "vec_messages exists without embedder metadata (legacy v0.3.0-style "
+            "DB). Current embedder=%r at %dd. If you have switched embedding "
+            "models since ingestion, re-embed via truememory_configure() — "
+            "otherwise new vectors will carry the %r marker going forward.",
+            EMBEDDING_MODEL, current_dim, EMBEDDING_MODEL,
+        )
+
+
+def _check_rebuild_allowed(conn: sqlite3.Connection) -> None:
+    """Refuse a silent auto-rebuild if metadata names a different embedder.
+
+    Called from :func:`TrueMemoryEngine.open` when `vec_messages` is missing
+    and `rebuild_vectors=True`. The intent of that path is bootstrap — but if
+    the DB has metadata, an implicit rebuild with the current (possibly
+    different) model would silently re-encode against a different vector
+    space. Force the user to route through `truememory_configure`.
+    """
+    stored_model, _ = _read_embedder_metadata(conn)
+    if stored_model is not None and stored_model != EMBEDDING_MODEL:
+        raise TrueMemoryMigrationError(
+            f"Refusing silent auto-rebuild: DB metadata says "
+            f"embed_model={stored_model!r} but current is {EMBEDDING_MODEL!r}. "
+            f"Call truememory_configure() to re-embed explicitly, or delete "
+            f"the DB to start fresh."
+        )
+
+
 def serialize_f32(vector) -> bytes:
     """
     Serialize a float vector to raw little-endian bytes for sqlite-vec.
@@ -180,6 +331,10 @@ def init_vec_table(conn: sqlite3.Connection) -> None:
     conn.enable_load_extension(True)
     sqlite_vec.load(conn)
     conn.enable_load_extension(False)
+
+    _ensure_metadata_table(conn)
+    _check_embedder_compatibility(conn)
+
     dim = _embedding_dim
     # Completion embeddings (semantic similarity)
     conn.execute(
@@ -257,6 +412,7 @@ def build_vectors(
         total += len(batch)
 
     conn.commit()
+    _write_embedder_metadata(conn)
     return total
 
 
@@ -411,6 +567,7 @@ def build_separation_vectors(
         total += len(batch)
 
     conn.commit()
+    _write_embedder_metadata(conn)
     return total
 
 


### PR DESCRIPTION
Closes #6, closes #7, closes #10.

Hunter Bundle B (Phased PR). Internal order F02 → F01 → F32.

## Summary
- **F02 (new):** `storage.py` schema gains a `metadata(key, value, updated_at)` table; `build_vectors` + `build_separation_vectors` persist `(embed_model, embed_dim)` rows on every rebuild. No more silent quality collapse when a tier switch produces matching dims but different vector spaces (Model2Vec 256d → Qwen3 256d).
- **F01 (new):** `init_vec_table` raises a branded `TrueMemoryMigrationError` when an existing `vec_messages` has a different dim than the current embedder. Replaces the raw `sqlite3.OperationalError: Dimension mismatch` that v0.3.0 Pro (1024d) users hit on the first v0.4.0 search.
- **F32 (new):** `engine.open()` escalates the missing-vec-table log from DEBUG → WARNING, calls `_check_rebuild_allowed` before silent auto-rebuild, and refuses to proceed when metadata names a different embedder than the currently-configured tier. Logs the successful rebuild at INFO.

## Compatibility notes
- Legacy v0.3.0 DBs (`vec_messages` present, no metadata row) at matching dim log a one-line warning and keep working; the marker is written going forward.
- The `mcp_server.truememory_configure` re-embed path is untouched — `_check_embedder_compatibility` skips when `vec_messages` is absent, so the explicit DROP → init → build sequence isn't blocked by stale metadata. That path will be hardened further in Bundle A (F03).
- Zero changes to dependencies, CLI, or public Python API surface.

## Test plan
- [x] pytest passes: 152 passed, 1 skipped (baseline 144/1 + 8 new regression locks, zero existing-test regressions).
- [x] `ruff check truememory/ tests/` — clean.
- [x] `tests/test_upgrade_path.py` — 8 cases covering: dim mismatch raises (F01), metadata written by build_vectors (F02), model-drift-at-matching-dim raises (F02 core), legacy-DB warning-no-raise (F02 gotcha), fresh-DB no-error, same-model reopen idempotent, `_check_rebuild_allowed` raises on drift (F32), `_check_rebuild_allowed` no-op without metadata.
- [ ] Manual smoke on a real v0.3.0 Pro DB (1024d) upgrade — suggested but not runnable in CI.

## Phase audit
Local phase-audit log in `_working/PHASE_AUDIT_LOG.md` (gitignored). Rustle-the-feathers sub-agent will verify before merge.

Hunter audit findings: F01 (issue #6), F02 (issue #7), F32 (issue #10) — see `_working/HUNTER_FINDINGS.md`.