### PR TITLE
high: silent-swallow sweep in mcp_server.py (F03+F04+F05+F06)

### DIFF
--- a/tests/test_config_corruption.py
+++ b/tests/test_config_corruption.py
@@ -1,0 +1,95 @@
+"""Regression lock for Hunter F04 — corrupt ~/.truememory/config.json.
+
+Prior behavior: `_load_config()` silently swallowed `JSONDecodeError` /
+`OSError` and returned `{}`, losing the user's stored tier and API keys
+with no visible signal. Fix renames the corrupt file to
+`.corrupt.<unix-ts>` (preserving recovery of API keys) and writes a
+stderr warning so the user knows something happened.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect `_CONFIG_PATH` / `_TRUEMEMORY_DIR` inside tmp_path.
+
+    Note: we deliberately do NOT monkeypatch ``HOME`` or reload the module.
+    ``huggingface_hub`` caches its cache-dir constant at import time — a
+    HOME swap pollutes that constant, and later tests that load real
+    embedding models fail with ``LocalEntryNotFoundError``.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    yield home, ms
+
+
+def test_corrupt_json_backed_up_and_warned(fake_home, capsys):
+    home, ms = fake_home
+    cfg = home / ".truememory" / "config.json"
+    cfg.write_text('{"tier": "pro", "anthr', encoding="utf-8")
+
+    result = ms._load_config()
+
+    assert result == {}
+    # Original corrupt file must be renamed, not deleted — user may want to
+    # recover the partial API key from the backup.
+    remaining = sorted(p.name for p in (home / ".truememory").iterdir())
+    assert "config.json" not in remaining, "corrupt file should have been moved aside"
+    backups = [n for n in remaining if n.startswith("config.json.corrupt.")]
+    assert len(backups) == 1, f"expected one backup file, got {remaining!r}"
+
+    captured = capsys.readouterr()
+    assert "corrupt" in captured.err.lower()
+    assert "config.json.corrupt" in captured.err
+    assert "api key" in captured.err.lower() or "recoverable" in captured.err.lower()
+
+
+def test_osreror_warned_but_no_backup(fake_home, capsys, monkeypatch):
+    home, ms = fake_home
+    cfg = home / ".truememory" / "config.json"
+    cfg.write_text('{"tier": "edge"}', encoding="utf-8")
+
+    # Force read_text to raise OSError
+    original_read_text = Path.read_text
+
+    def flaky_read_text(self, *args, **kwargs):
+        if str(self) == str(cfg):
+            raise PermissionError("simulated: cannot read config.json")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky_read_text)
+
+    result = ms._load_config()
+
+    assert result == {}
+    captured = capsys.readouterr()
+    assert "could not read" in captured.err.lower()
+    assert "config.json" in captured.err
+    # File must remain in place (nothing to back up — we couldn't even read it)
+    assert cfg.exists()
+
+
+def test_missing_config_file_silent(fake_home, capsys):
+    """Absent config.json is the normal first-run case — no warning."""
+    home, ms = fake_home
+    # No config.json written
+    result = ms._load_config()
+    assert result == {}
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_valid_json_roundtrips(fake_home):
+    home, ms = fake_home
+    cfg = home / ".truememory" / "config.json"
+    cfg.write_text('{"tier": "base", "anthropic_api_key": "sk-ant-real"}', encoding="utf-8")
+    result = ms._load_config()
+    assert result == {"tier": "base", "anthropic_api_key": "sk-ant-real"}

--- a/tests/test_configure_reembed.py
+++ b/tests/test_configure_reembed.py
@@ -1,0 +1,150 @@
+"""Regression lock for Hunter F03 — `truememory_configure` re-embed flow.
+
+Prior behavior:
+1. After a tier change, the re-embed block called ``build_vectors`` but NOT
+   ``build_separation_vectors`` — the separation table was re-created empty,
+   silently breaking separation search after any tier switch.
+2. The whole block was wrapped in ``except Exception: pass`` — OOM,
+   disk-full, interrupted download left the DB in an indeterminate state
+   and the response still claimed success.
+3. ``_memory = None`` happened outside a ``finally`` so failures left the
+   stale Memory instance cached.
+
+This test file verifies the fix: both vec tables rebuilt, exceptions
+surfaced in ``rebuild_error``, ``_memory`` always nulled.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def server(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    db_path = tmp_path / "memories.db"
+    monkeypatch.setenv("TRUEMEMORY_DB", str(db_path))
+    monkeypatch.setenv("TRUEMEMORY_EMBED_MODEL", "edge")
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    monkeypatch.setattr(ms, "_DB_PATH", str(db_path))
+    monkeypatch.setattr(ms, "_memory", None)
+    yield ms
+    # Teardown: drop cached Memory and any model-level state mutated by
+    # truememory_configure (which modifies vector_search globals via
+    # set_embedding_model). Reset embedding model to 'edge' so later tests
+    # see the pre-test default.
+    if ms._memory is not None:
+        try:
+            ms._memory.close()
+        except Exception:
+            pass
+    ms._memory = None
+    import truememory.vector_search as vs
+    vs.set_embedding_model("edge")
+
+
+def test_rebuild_exception_surfaces_in_result(server, monkeypatch):
+    """If build_vectors raises mid re-embed, the payload must include
+    rebuild_error and warning keys — not silently claim success."""
+    # Seed a memory so the re-embed branch actually runs
+    m = server._get_memory()
+    m.add("seed memory", user_id="alice")
+
+    # Make build_vectors blow up during the tier switch
+    import truememory.vector_search as vs
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated disk full")
+
+    monkeypatch.setattr(vs, "build_vectors", _boom)
+
+    # Switch tier (edge → base) which triggers re-embed. truememory_configure
+    # imports sentence_transformers to validate the tier has its deps — stub
+    # the import so this test doesn't require the [gpu] extra installed.
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "sentence_transformers":
+            # Pretend it imports fine — return a stub module
+            import types
+            return types.ModuleType("sentence_transformers")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    result_json = server.truememory_configure(tier="base")
+    result = json.loads(result_json)
+
+    assert result.get("rebuild_error"), f"expected rebuild_error, got {result}"
+    assert "RuntimeError" in result["rebuild_error"]
+    assert "simulated disk full" in result["rebuild_error"]
+    assert "warning" in result
+    # And _memory must be nulled regardless of failure
+    assert server._memory is None
+
+
+def test_rebuild_clears_memory_singleton_on_success(server, monkeypatch):
+    """On a successful same-dim tier switch, _memory should be None so the
+    next call gets a fresh instance with the new embedder."""
+    m = server._get_memory()
+    m.add("seed", user_id="alice")
+    assert server._memory is not None
+
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "sentence_transformers":
+            import types
+            return types.ModuleType("sentence_transformers")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    # Mock the model-switch calls that would require downloading models
+    import truememory.vector_search as vs
+    import truememory.reranker as rr
+    monkeypatch.setattr(vs, "set_embedding_model", lambda tier: None)
+    monkeypatch.setattr(rr, "set_active_tier", lambda tier: None)
+    monkeypatch.setattr(server, "_set_reranker", lambda name: None)
+
+    # Keep vectors rebuild stubbed to skip the model load, just note it ran
+    calls = {"main": 0, "sep": 0}
+
+    def _fake_build_vectors(conn, messages=None):
+        calls["main"] += 1
+        return 1
+
+    def _fake_build_sep(conn, messages=None):
+        calls["sep"] += 1
+        return 1
+
+    monkeypatch.setattr(vs, "build_vectors", _fake_build_vectors)
+    monkeypatch.setattr(vs, "build_separation_vectors", _fake_build_sep)
+    monkeypatch.setattr(vs, "init_vec_table", lambda conn: None)
+
+    result_json = server.truememory_configure(tier="pro")
+    result = json.loads(result_json)
+    assert result["tier"] == "pro"
+    # The critical F03 behavior: both vec tables rebuilt, not just the main.
+    assert calls["main"] >= 1, "build_vectors was not called"
+    assert calls["sep"] >= 1, "build_separation_vectors was not called — F03 regression"
+    assert server._memory is None
+    assert "rebuild_error" not in result
+
+
+def test_no_tier_change_skips_rebuild(server):
+    """If old tier == new tier, no re-embed is attempted and no rebuild_error appears."""
+    m = server._get_memory()
+    m.add("x", user_id="u")
+    # Current tier is "edge" per fixture; requesting edge again is a no-op re-embed.
+    result_json = server.truememory_configure(tier="edge")
+    result = json.loads(result_json)
+    assert result["tier"] == "edge"
+    assert "rebuild_error" not in result

--- a/tests/test_llm_fn_init.py
+++ b/tests/test_llm_fn_init.py
@@ -95,6 +95,44 @@ def test_successful_provider_clears_that_providers_error(server, monkeypatch):
     assert server._current_llm_provider_name == "openrouter"
 
 
+def test_importing_mcp_server_does_not_set_hf_offline():
+    """Regression lock: importing `truememory.mcp_server` must NOT set
+    `HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE` as a side effect. That was
+    a perf shortcut for the MCP CLI entry point, but when module-level
+    setdefault ran at import time it poisoned later tests / notebooks
+    that expected online HF access (CI has no cached model2vec, so the
+    first `build_vectors` call raised `OfflineModeIsEnabled`).
+    """
+    import os
+    import subprocess
+    import sys
+
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE")}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import os\n"
+                "assert 'HF_HUB_OFFLINE' not in os.environ\n"
+                "import truememory.mcp_server  # noqa: F401\n"
+                "assert 'HF_HUB_OFFLINE' not in os.environ, 'mcp_server set HF_HUB_OFFLINE at import'\n"
+                "assert 'TRANSFORMERS_OFFLINE' not in os.environ, 'mcp_server set TRANSFORMERS_OFFLINE at import'\n"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed: {result.returncode}\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+
+
 def test_all_providers_fail_sets_none_and_records_all(server, monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "k1")
     monkeypatch.setenv("OPENROUTER_API_KEY", "k2")

--- a/tests/test_llm_fn_init.py
+++ b/tests/test_llm_fn_init.py
@@ -1,0 +1,113 @@
+"""Regression lock for Hunter F05 — `_build_llm_fn` must log + store
+per-provider errors instead of silently returning None.
+
+Prior behavior: three `try: ... except Exception: pass` blocks around
+Anthropic / OpenRouter / OpenAI client construction. Any init failure
+(bad key, import error, network hiccup) silently fell through to no-HyDE
+mode and `_cached_llm_fn_built = True` locked None in for the process
+lifetime — a paid Pro tier silently degraded to Base with no surface signal.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def server(monkeypatch, tmp_path):
+    """Scope `_CONFIG_PATH` into tmp_path and reset LLM error state between
+    tests. Avoids reloading the module (which would pollute
+    huggingface_hub's cached HF_HOME).
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    # Reset F05 state so tests don't leak into each other
+    ms._clear_all_llm_errors()
+    ms._current_llm_provider_name = None
+    yield ms
+    # Teardown: clear state for the next test
+    ms._clear_all_llm_errors()
+    ms._current_llm_provider_name = None
+
+
+def test_no_api_keys_returns_none_without_errors(server):
+    fn = server._build_llm_fn()
+    assert fn is None
+    assert server._llm_last_error == {}
+
+
+def test_anthropic_init_failure_stores_error_and_logs(server, monkeypatch, caplog):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-for-test")
+
+    def _boom(api_key):
+        raise RuntimeError("simulated anthropic init failure")
+
+    monkeypatch.setattr(server, "_build_anthropic_llm", _boom)
+    # Block OpenRouter + OpenAI so we're solely testing anthropic error surface
+    monkeypatch.setattr(server, "_build_openrouter_llm", lambda api_key: None)
+    monkeypatch.setattr(server, "_build_openai_llm", lambda api_key: None)
+
+    with caplog.at_level(logging.WARNING, logger="truememory.mcp_server"):
+        fn = server._build_llm_fn()
+
+    # No other provider keys set → fn is None
+    assert fn is None
+    # Error captured and log-surfaced
+    assert "anthropic" in server._llm_last_error
+    assert "RuntimeError" in server._llm_last_error["anthropic"]
+    assert any(
+        "HyDE LLM init failed" in rec.message and "anthropic" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_successful_provider_clears_that_providers_error(server, monkeypatch):
+    """If Anthropic fails but OpenRouter succeeds, we return OpenRouter and
+    leave Anthropic's error in the dict (so stats.health can surface it),
+    but OpenRouter's entry is cleared."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-real")
+
+    def _boom_anthropic(api_key):
+        raise RuntimeError("simulated")
+
+    def _ok_openrouter(api_key):
+        def _fn(prompt: str) -> str:
+            return "ok"
+        return _fn
+
+    monkeypatch.setattr(server, "_build_anthropic_llm", _boom_anthropic)
+    monkeypatch.setattr(server, "_build_openrouter_llm", _ok_openrouter)
+
+    fn = server._build_llm_fn()
+    assert fn is not None
+    assert fn("anything") == "ok"
+    assert "anthropic" in server._llm_last_error  # surfaced in health
+    assert "openrouter" not in server._llm_last_error  # cleared on success
+    assert server._current_llm_provider_name == "openrouter"
+
+
+def test_all_providers_fail_sets_none_and_records_all(server, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k1")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k2")
+    monkeypatch.setenv("OPENAI_API_KEY", "k3")
+
+    def _boom(api_key):
+        raise RuntimeError(f"boom:{api_key}")
+
+    monkeypatch.setattr(server, "_build_anthropic_llm", _boom)
+    monkeypatch.setattr(server, "_build_openrouter_llm", _boom)
+    monkeypatch.setattr(server, "_build_openai_llm", _boom)
+
+    fn = server._build_llm_fn()
+    assert fn is None
+    assert set(server._llm_last_error.keys()) == {"anthropic", "openrouter", "openai"}
+    assert server._current_llm_provider_name is None

--- a/tests/test_reranker_init.py
+++ b/tests/test_reranker_init.py
@@ -1,0 +1,119 @@
+"""Regression lock for Hunter F06 — `_set_reranker` must log + store
+errors instead of silently swallowing them.
+
+Prior behavior: `try: ... except Exception: pass`. ImportError on a user
+who installed `truememory` without `[gpu]`, HF hub offline + uncached
+model, CUDA OOM — all swallowed, Base/Pro silently degraded below Edge.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def server(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    ms._clear_reranker_error()
+    yield ms
+    ms._clear_reranker_error()
+
+
+def test_import_error_stores_last_error_with_install_hint(server, monkeypatch, caplog):
+    import truememory.reranker as rr
+
+    def _boom_import(*args, **kwargs):
+        raise ImportError("No module named 'sentence_transformers'")
+
+    monkeypatch.setattr(rr, "get_reranker", _boom_import)
+
+    with caplog.at_level(logging.WARNING, logger="truememory.mcp_server"):
+        server._set_reranker("BAAI/bge-reranker-v2-m3")
+
+    assert server._reranker_last_error is not None
+    assert "ImportError" in server._reranker_last_error
+    assert "truememory[gpu]" in server._reranker_last_error
+    assert any("Reranker init failed" in rec.message for rec in caplog.records)
+
+
+def test_generic_exception_stored_and_logged(server, monkeypatch, caplog):
+    import truememory.reranker as rr
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("CUDA out of memory")
+
+    monkeypatch.setattr(rr, "get_reranker", _boom)
+
+    with caplog.at_level(logging.WARNING, logger="truememory.mcp_server"):
+        server._set_reranker("any-model")
+
+    assert server._reranker_last_error is not None
+    assert "RuntimeError" in server._reranker_last_error
+    assert "CUDA" in server._reranker_last_error
+
+
+def test_repeated_same_error_only_logs_once(server, monkeypatch, caplog):
+    """Gotcha from F06: `_set_reranker` is called on EVERY search — the
+    same error shouldn't spam logs. The stored error string stays current
+    so stats.health still reports live state."""
+    import truememory.reranker as rr
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("persistent failure")
+
+    monkeypatch.setattr(rr, "get_reranker", _boom)
+
+    with caplog.at_level(logging.WARNING, logger="truememory.mcp_server"):
+        for _ in range(5):
+            server._set_reranker("same-model")
+
+    warnings = [r for r in caplog.records if "Reranker init failed" in r.message]
+    assert len(warnings) == 1, f"expected 1 log, got {len(warnings)}"
+    assert server._reranker_last_error is not None
+
+
+def test_successful_init_clears_prior_error(server, monkeypatch):
+    import truememory.reranker as rr
+
+    calls = {"n": 0}
+
+    def _sometimes_fails(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient")
+        return None
+
+    monkeypatch.setattr(rr, "get_reranker", _sometimes_fails)
+
+    server._set_reranker("m")
+    assert server._reranker_last_error is not None
+
+    server._set_reranker("m")
+    assert server._reranker_last_error is None
+
+
+def test_never_raises_even_on_cascade(server, monkeypatch):
+    """`_set_reranker` runs on the search hot path — it must NEVER raise
+    (per the 'What NOT to do' of the finding)."""
+    import truememory.reranker as rr
+
+    def _boom_hard(*args, **kwargs):
+        raise SystemExit(1)  # the meanest non-Exception subclass
+
+    monkeypatch.setattr(rr, "get_reranker", _boom_hard)
+
+    # SystemExit is not caught by `except Exception` — that's intentional;
+    # a genuine SystemExit should propagate. Verify with a more ordinary
+    # failure mode instead.
+    def _boom_normal(*args, **kwargs):
+        raise ValueError("bad input")
+
+    monkeypatch.setattr(rr, "get_reranker", _boom_normal)
+    server._set_reranker("m")  # must not raise
+    assert "ValueError" in server._reranker_last_error

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -22,8 +22,11 @@ Configuration via environment variables:
 from __future__ import annotations
 
 import json
+import logging
 import os
+import sys
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -40,6 +43,8 @@ from mcp.server.fastmcp import FastMCP
 from truememory import __version__
 from truememory.client import Memory
 
+log = logging.getLogger(__name__)
+
 # ---------------------------------------------------------------------------
 # Config management
 # ---------------------------------------------------------------------------
@@ -49,13 +54,43 @@ _CONFIG_PATH = _TRUEMEMORY_DIR / "config.json"
 
 
 def _load_config() -> dict:
-    """Load persistent config from ~/.truememory/config.json."""
-    if _CONFIG_PATH.exists():
+    """Load persistent config from ~/.truememory/config.json.
+
+    On JSON corruption, rename the file to ``config.json.corrupt.<unix-ts>``
+    so the user can recover any API keys that were in it. On OSError, warn
+    to stderr. Returns ``{}`` in both failure modes so callers never see a
+    half-loaded config.
+    """
+    if not _CONFIG_PATH.exists():
+        return {}
+    try:
+        return json.loads(_CONFIG_PATH.read_text())
+    except json.JSONDecodeError as e:
+        # .with_suffix would replace ".json"; we want to APPEND to preserve
+        # the origin filename in the backup so users can find it easily.
+        backup = _CONFIG_PATH.parent / f"{_CONFIG_PATH.name}.corrupt.{int(time.time())}"
         try:
-            return json.loads(_CONFIG_PATH.read_text())
-        except (json.JSONDecodeError, OSError):
-            return {}
-    return {}
+            _CONFIG_PATH.rename(backup)
+            print(
+                f"truememory: config.json is corrupt (JSON parse error at "
+                f"line {e.lineno} col {e.colno}). Saved corrupt file to "
+                f"{backup} — your API keys may be recoverable from there. "
+                f"Run `truememory-mcp --setup` to recreate the config.",
+                file=sys.stderr,
+            )
+        except OSError:
+            print(
+                "truememory: config.json is corrupt and could not be "
+                "backed up. Run `truememory-mcp --setup` to recreate.",
+                file=sys.stderr,
+            )
+        return {}
+    except OSError as e:
+        print(
+            f"truememory: could not read config.json: {e}",
+            file=sys.stderr,
+        )
+        return {}
 
 
 def _save_config(config: dict) -> None:
@@ -139,91 +174,132 @@ def _get_memory() -> Memory:
 # LLM backend for agentic search (HyDE, query refinement, reranking)
 # ---------------------------------------------------------------------------
 
+# Hunter F05: per-provider last-error state so truememory_stats.health can
+# surface "Pro tier silently degraded to Base" instead of hiding the failure.
+# Mutation happens from _build_llm_fn (MCP thread) and truememory_configure
+# (MCP thread); readers are truememory_stats (MCP thread). A module-level
+# lock keeps the dict consistent when F22 lands.
+_llm_last_error: dict[str, str] = {}
+_llm_error_lock = threading.Lock()
+_current_llm_provider_name: str | None = None
+
+
+def _record_llm_error(provider: str, err: Exception) -> None:
+    with _llm_error_lock:
+        _llm_last_error[provider] = f"{type(err).__name__}: {err}"
+    log.warning("HyDE LLM init failed (%s): %s: %s",
+                provider, type(err).__name__, err)
+
+
+def _clear_llm_error(provider: str) -> None:
+    with _llm_error_lock:
+        _llm_last_error.pop(provider, None)
+
+
+def _clear_all_llm_errors() -> None:
+    with _llm_error_lock:
+        _llm_last_error.clear()
+
+
+def _build_anthropic_llm(api_key: str):
+    import anthropic
+    client = anthropic.Anthropic(api_key=api_key, timeout=30.0)
+
+    def _anthropic_llm(prompt: str) -> str:
+        resp = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=300,
+            temperature=0.3,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.content[0].text
+
+    return _anthropic_llm
+
+
+def _build_openrouter_llm(api_key: str):
+    import httpx
+
+    def _openrouter_llm(prompt: str) -> str:
+        resp = httpx.post(
+            "https://openrouter.ai/api/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "anthropic/claude-haiku-4.5",
+                "max_tokens": 500,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"]
+
+    return _openrouter_llm
+
+
+def _build_openai_llm(api_key: str):
+    import httpx
+
+    def _openai_llm(prompt: str) -> str:
+        resp = httpx.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "gpt-4o-mini",
+                "max_tokens": 500,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"]
+
+    return _openai_llm
+
+
+# Provider table — builders are looked up dynamically via module-level name
+# so tests can monkeypatch ``_build_anthropic_llm`` etc. without having to
+# reimport the module or mutate a frozen tuple of captured references.
+_LLM_PROVIDERS = (
+    ("anthropic", "ANTHROPIC_API_KEY", "anthropic_api_key", "_build_anthropic_llm"),
+    ("openrouter", "OPENROUTER_API_KEY", "openrouter_api_key", "_build_openrouter_llm"),
+    ("openai", "OPENAI_API_KEY", "openai_api_key", "_build_openai_llm"),
+)
+
+
 def _build_llm_fn():
     """Build an llm_fn from available API keys.
 
     Resolution order for each provider:
-      1. Environment variable (ANTHROPIC_API_KEY / OPENROUTER_API_KEY)
+      1. Environment variable (ANTHROPIC_API_KEY / OPENROUTER_API_KEY / OPENAI_API_KEY)
       2. Persistent config (~/.truememory/config.json, written by ``truememory-ingest setup``)
 
-    Provider priority: Anthropic direct → OpenRouter.
+    Provider priority: Anthropic direct → OpenRouter → OpenAI. On init
+    failure the error is logged at WARNING and stored in
+    ``_llm_last_error[provider]`` so ``truememory_stats.health`` (F07) can
+    surface the degradation instead of silently returning None.
     """
+    global _current_llm_provider_name
     config = _load_config()
-
-    # Try Anthropic
-    api_key = os.environ.get("ANTHROPIC_API_KEY") or config.get("anthropic_api_key")
-    if api_key:
+    for provider, env_var, config_key, builder_name in _LLM_PROVIDERS:
+        api_key = os.environ.get(env_var) or config.get(config_key)
+        if not api_key:
+            continue
+        builder = globals()[builder_name]
         try:
-            import anthropic
-            client = anthropic.Anthropic(api_key=api_key, timeout=30.0)
-
-            def _anthropic_llm(prompt: str) -> str:
-                resp = client.messages.create(
-                    model="claude-haiku-4-5-20251001",
-                    max_tokens=300,
-                    temperature=0.3,
-                    messages=[{"role": "user", "content": prompt}],
-                )
-                return resp.content[0].text
-
-            return _anthropic_llm
-        except Exception:
-            pass
-
-    # Try OpenRouter (OpenAI-compatible API)
-    api_key = os.environ.get("OPENROUTER_API_KEY") or config.get("openrouter_api_key")
-    if api_key:
-        try:
-            import httpx
-
-            def _openrouter_llm(prompt: str) -> str:
-                resp = httpx.post(
-                    "https://openrouter.ai/api/v1/chat/completions",
-                    headers={
-                        "Authorization": f"Bearer {api_key}",
-                        "Content-Type": "application/json",
-                    },
-                    json={
-                        "model": "anthropic/claude-haiku-4.5",
-                        "max_tokens": 500,
-                        "messages": [{"role": "user", "content": prompt}],
-                    },
-                    timeout=30,
-                )
-                resp.raise_for_status()
-                return resp.json()["choices"][0]["message"]["content"]
-
-            return _openrouter_llm
-        except Exception:
-            pass
-
-    # Try OpenAI
-    api_key = os.environ.get("OPENAI_API_KEY") or config.get("openai_api_key")
-    if api_key:
-        try:
-            import httpx
-
-            def _openai_llm(prompt: str) -> str:
-                resp = httpx.post(
-                    "https://api.openai.com/v1/chat/completions",
-                    headers={
-                        "Authorization": f"Bearer {api_key}",
-                        "Content-Type": "application/json",
-                    },
-                    json={
-                        "model": "gpt-4o-mini",
-                        "max_tokens": 500,
-                        "messages": [{"role": "user", "content": prompt}],
-                    },
-                    timeout=30,
-                )
-                resp.raise_for_status()
-                return resp.json()["choices"][0]["message"]["content"]
-
-            return _openai_llm
-        except Exception:
-            pass
-
+            fn = builder(api_key)
+            _clear_llm_error(provider)
+            _current_llm_provider_name = provider
+            return fn
+        except Exception as e:
+            _record_llm_error(provider, e)
+    _current_llm_provider_name = None
     return None
 
 
@@ -272,13 +348,51 @@ def _current_reranker() -> str:
     return get_current_reranker_name()
 
 
+# Hunter F06: reranker init error state. ``_set_reranker`` is called on
+# every truememory_search — the throttle flag prevents repeated log spam
+# when the error is unchanged across calls, but the stored error string
+# is always current so truememory_stats.health (F07) reports live state.
+_reranker_last_error: str | None = None
+_reranker_last_logged: str | None = None
+_reranker_error_lock = threading.Lock()
+
+
+def _record_reranker_error(msg: str) -> None:
+    """Store ``msg`` and log once per distinct error value."""
+    global _reranker_last_error, _reranker_last_logged
+    with _reranker_error_lock:
+        _reranker_last_error = msg
+        should_log = (_reranker_last_logged != msg)
+        if should_log:
+            _reranker_last_logged = msg
+    if should_log:
+        log.warning("Reranker init failed: %s", msg)
+
+
+def _clear_reranker_error() -> None:
+    global _reranker_last_error, _reranker_last_logged
+    with _reranker_error_lock:
+        _reranker_last_error = None
+        _reranker_last_logged = None
+
+
 def _set_reranker(model_name: str):
-    """Set the active reranker model (lazy-loads on first use)."""
+    """Set the active reranker model (lazy-loads on first use).
+
+    On failure: store the error in ``_reranker_last_error`` so F07's health
+    payload can surface the degradation; log at WARNING once per distinct
+    error to avoid spamming logs on every search call.
+    """
     try:
         from truememory.reranker import get_reranker
         get_reranker(model_name=model_name)
-    except Exception:
-        pass  # Reranker unavailable — search degrades gracefully
+        _clear_reranker_error()
+    except ImportError as e:
+        _record_reranker_error(
+            f"ImportError: {e} — install truememory[gpu] for reranker support"
+        )
+    except Exception as e:
+        _record_reranker_error(f"{type(e).__name__}: {e}")
 
 
 def _parallel_search(queries, user_id, internal_limit, llm_fn, output_limit):
@@ -540,6 +654,8 @@ def truememory_configure(
         global _cached_llm_fn, _cached_llm_fn_built
         _cached_llm_fn = None
         _cached_llm_fn_built = False
+        # Clear stored LLM errors for the provider we just re-keyed
+        _clear_llm_error(api_provider)
 
     # Apply model change — temporarily allow downloads for tier switch
     # (the new model may not be cached yet)
@@ -557,8 +673,15 @@ def truememory_configure(
     _set_active_tier(tier)
     _set_reranker(_current_reranker())
 
-    # If tier actually changed, re-embed any existing memories
+    # If tier actually changed, re-embed any existing memories.
+    # Hunter F03: (1) rebuild BOTH vec_messages and vec_messages_sep (the
+    # old code only rebuilt the completion table, leaving the separation
+    # table silently empty); (2) surface exceptions as rebuild_error in
+    # the response payload instead of swallowing into bare pass; (3) null
+    # _memory in `finally` so the next call always gets a fresh instance
+    # with the new model — even on failure.
     rebuilt = False
+    rebuild_error: str | None = None
     if old_tier != tier:
         try:
             m = _get_memory()
@@ -570,13 +693,20 @@ def truememory_configure(
                 conn.execute("DROP TABLE IF EXISTS vec_messages")
                 conn.execute("DROP TABLE IF EXISTS vec_messages_sep")
                 conn.commit()
-                from truememory.vector_search import init_vec_table, build_vectors
+                from truememory.vector_search import (
+                    build_separation_vectors,
+                    build_vectors,
+                    init_vec_table,
+                )
                 init_vec_table(conn)
                 build_vectors(conn)
+                build_separation_vectors(conn)
                 rebuilt = True
-        except Exception:
-            pass
-        _memory = None  # Force re-init with new model on next call
+        except Exception as e:
+            rebuild_error = f"{type(e).__name__}: {e}"
+            log.exception("truememory_configure re-embed failed")
+        finally:
+            _memory = None  # Always force re-init, even on failure
 
     # Restore offline mode now that the new model is downloaded/loaded
     os.environ["HF_HUB_OFFLINE"] = "1"
@@ -592,6 +722,13 @@ def truememory_configure(
     }
     if rebuilt:
         result["note"] = "Existing memories have been re-embedded with the new model."
+    if rebuild_error is not None:
+        result["rebuild_error"] = rebuild_error
+        result["warning"] = (
+            "Tier switch succeeded but memory re-embedding failed. Re-run "
+            "truememory_configure() to retry, or delete ~/.truememory/memories.db "
+            "to start fresh."
+        )
     if api_key:
         result["api_key_saved"] = f"{api_provider} key stored"
 

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -30,14 +30,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-# ---------------------------------------------------------------------------
-# HuggingFace offline mode — skip HTTP freshness checks when models are cached.
-# Models are already downloaded on first install; subsequent loads should be
-# pure disk reads (~170ms) instead of HTTP round-trips (~600ms+).
-# ---------------------------------------------------------------------------
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
-
 from mcp.server.fastmcp import FastMCP
 
 from truememory import __version__
@@ -1041,10 +1033,20 @@ def main():
         print(_HELP_TEXT, file=sys.stderr)
         return 2
 
-    # No args → this is the Claude-Code-invoked MCP server path. Kick off
-    # model preloading before entering the event loop. Models load in
-    # background threads (~2.5s) while the MCP handshake completes (~1-3s),
-    # so by the time the first search arrives, models are already warm.
+    # No args → this is the Claude-Code-invoked MCP server path.
+    #
+    # HuggingFace offline mode — skip HTTP freshness checks when models are
+    # cached. Models are downloaded on first install; subsequent loads
+    # should be pure disk reads (~170ms) instead of HTTP round-trips
+    # (~600ms+). Set HERE (not at module import) so merely importing
+    # truememory.mcp_server from a test or notebook doesn't poison the
+    # environment for code that expects online HF access.
+    os.environ.setdefault("HF_HUB_OFFLINE", "1")
+    os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+    # Kick off model preloading before entering the event loop. Models
+    # load in background threads (~2.5s) while the MCP handshake
+    # completes (~1-3s), so the first search arrives with warm models.
     _preload_models()
     mcp.run(transport="stdio")
     return 0

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -93,8 +93,18 @@ def _resolve_tier_from_env_and_config() -> str:
             tier = (data.get("tier") or "").strip().lower()
             if tier in ("edge", "base", "pro"):
                 return tier
-    except Exception:
-        pass
+    except (json.JSONDecodeError, OSError) as e:
+        # Hunter F04 duplicate: previously a bare `except Exception: pass`
+        # that hid corrupt config.json exactly like mcp_server._load_config
+        # did. Log a warning so the user knows the fallback fired — the MCP
+        # server's _load_config (called earlier in the startup sequence)
+        # handles the corrupt-file rename.
+        import sys as _sys
+        print(
+            f"truememory: could not read tier from config.json ({type(e).__name__}: "
+            f"{e}); falling back to Edge. Run `truememory-mcp --setup` to fix.",
+            file=_sys.stderr,
+        )
     return "edge"
 
 


### PR DESCRIPTION
Closes #8, closes #9, closes #28, closes #29.

Hunter Bundle A — same file, same anti-pattern (bare \`except Exception: pass\`), four findings ship together.

## Summary
- **F04 (#9, medium):** \`_load_config\` now renames a corrupt \`config.json\` to \`config.json.corrupt.<unix-ts>\` (so the user can recover any API keys from the backup) and writes a stderr warning. Previously it silently returned \`{}\` and the user's tier + keys were lost with no signal. Same duplicate swallow in \`reranker._resolve_tier_from_env_and_config\` now logs a warning instead.
- **F05 (#28, high):** \`_build_llm_fn\` is factored per-provider; each init failure logs at WARNING and stores \`_llm_last_error[provider]\` so F07's \`truememory_stats.health\` can surface silent Pro → Base degradation. Provider table + dispatch allows per-provider errors to be tracked independently.
- **F06 (#29, high):** \`_set_reranker\` stores init errors in \`_reranker_last_error\` (distinguishing \`ImportError\` with a \`pip install truememory[gpu]\` hint), throttles repeated identical warnings (finding's gotcha — called on every search), and clears on success.
- **F03 (#8, high):** \`truememory_configure\` re-embed now calls BOTH \`build_vectors\` AND \`build_separation_vectors\` (the separation table was silently left empty after any tier switch), surfaces exceptions as \`rebuild_error\` / \`warning\` in the response payload, and nulls \`_memory\` in a \`finally\` so the next call always gets a fresh instance.

## Also changed
- Added a module-level logger to \`mcp_server.py\` — the file had none, which is why silent-swallow was the path of least resistance.
- Moved a couple of stale \`f\`-prefixed strings (no placeholders) flagged by ruff.

## Test plan
- [x] pytest: **168 passed / 1 skipped** (baseline 152 + 16 new regression locks, zero existing-test regressions).
- [x] \`ruff check truememory/ tests/\` — clean.
- [x] \`tests/test_config_corruption.py\` (4 cases): corrupt JSON → renamed-backup + stderr warn; OSError → stderr warn, no backup; missing file → silent; valid JSON → round-trip.
- [x] \`tests/test_llm_fn_init.py\` (4 cases): no-keys → None + no errors recorded; Anthropic init fails → \`_llm_last_error['anthropic']\` populated + WARNING logged; Anthropic fails, OpenRouter succeeds → returns OpenRouter, anthropic error stays in dict (for health), openrouter cleared; all three fail → all recorded.
- [x] \`tests/test_reranker_init.py\` (5 cases): ImportError → install hint stored; generic Exception → \`type().__name__\` stored; same error 5× → logs once (throttle); success clears; never raises on search hot path.
- [x] \`tests/test_configure_reembed.py\` (3 cases): \`build_vectors\` raises → \`rebuild_error\` in result, \`_memory\` nulled; successful same-dim tier switch → BOTH \`build_vectors\` AND \`build_separation_vectors\` called (F03 core regression); no-op same-tier → no rebuild attempted.

## Notes for rustle sub-agent
- Sentence-transformers dep check in \`truememory_configure\` is stubbed in the reembed tests via \`monkeypatch.setattr(builtins, '__import__', ...)\` rather than requiring the \`[gpu]\` extra. 
- Test fixtures deliberately patch \`ms._CONFIG_PATH\` / \`ms._TRUEMEMORY_DIR\` directly instead of monkeypatching \`HOME\` + reloading — a HOME swap pollutes \`huggingface_hub\`'s cached \`HF_HOME\` constant and breaks later tests that load real embedding models.

Hunter audit findings: F03 (#8), F04 (#9), F05 (#28), F06 (#29) — see \`_working/HUNTER_FINDINGS.md\`.