### PR TITLE
medium: truememory_stats.health payload + sqlite-vec load tracking (F07+F08)

### DIFF
--- a/tests/test_health_stats.py
+++ b/tests/test_health_stats.py
@@ -1,0 +1,208 @@
+"""Regression lock for Hunter F07 + F08 — `truememory_stats.health` dict.
+
+F07: the MCP tool's stats payload must include a `health` key that
+reports per-subsystem status (reranker / hyde_llm / vectors). Without
+this, silent-failure modes surfaced by F05 (bad API key → HyDE off),
+F06 (missing sentence-transformers → reranker off), and F08
+(sqlite-vec load failure → FTS-only search) are invisible from the
+user's primary observability surface.
+
+F08: sqlite-vec load failure must log at WARNING (not DEBUG) and
+populate `engine._vectors_load_error` so F07 can surface it.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def server(monkeypatch, tmp_path):
+    """Scope ~/.truememory into tmp_path; reset all F05/F06 error state."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    db_path = tmp_path / "memories.db"
+    monkeypatch.setenv("TRUEMEMORY_DB", str(db_path))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    monkeypatch.setattr(ms, "_DB_PATH", str(db_path))
+    monkeypatch.setattr(ms, "_memory", None)
+    ms._clear_all_llm_errors()
+    ms._clear_reranker_error()
+    ms._current_llm_provider_name = None
+    # F08 state lives in engine module
+    import truememory.engine as engine
+    monkeypatch.setattr(engine, "_vectors_load_error", None)
+    yield ms
+    ms._clear_all_llm_errors()
+    ms._clear_reranker_error()
+    ms._current_llm_provider_name = None
+    monkeypatch.setattr(engine, "_vectors_load_error", None)
+
+
+# ---------------------------------------------------------------------------
+# F07 — health payload shape
+# ---------------------------------------------------------------------------
+
+
+def test_health_has_three_subsystems(server):
+    health = server._build_health_payload()
+    assert set(health.keys()) == {"reranker", "hyde_llm", "vectors"}
+    for sub in health.values():
+        assert "status" in sub
+        assert sub["status"] in ("ok", "degraded")
+
+
+def test_health_all_ok_when_no_errors_recorded(server):
+    health = server._build_health_payload()
+    assert health["reranker"]["status"] == "ok"
+    assert health["reranker"]["last_error"] is None
+    assert health["hyde_llm"]["status"] == "ok"
+    assert health["hyde_llm"]["last_error_by_provider"] is None
+    assert health["vectors"]["status"] == "ok"
+    assert health["vectors"]["last_error"] is None
+
+
+def test_health_reranker_degraded_when_error_recorded(server):
+    server._record_reranker_error("ImportError: boom")
+    health = server._build_health_payload()
+    assert health["reranker"]["status"] == "degraded"
+    assert "ImportError" in health["reranker"]["last_error"]
+
+
+def test_health_hyde_llm_degraded_reports_per_provider(server):
+    import truememory.mcp_server as ms
+    ms._record_llm_error("anthropic", RuntimeError("bad key"))
+    ms._record_llm_error("openai", RuntimeError("rate-limited"))
+    health = server._build_health_payload()
+    assert health["hyde_llm"]["status"] == "degraded"
+    errors = health["hyde_llm"]["last_error_by_provider"]
+    assert "anthropic" in errors
+    assert "openai" in errors
+    assert "RuntimeError" in errors["anthropic"]
+
+
+def test_health_hyde_llm_active_provider_reflects_current_resolve(server):
+    server._current_llm_provider_name = "openrouter"
+    health = server._build_health_payload()
+    assert health["hyde_llm"]["active_provider"] == "openrouter"
+
+
+def test_health_vectors_degraded_surfaces_engine_error(server, monkeypatch):
+    import truememory.engine as engine
+    monkeypatch.setattr(engine, "_vectors_load_error", "OSError: no wheel")
+    health = server._build_health_payload()
+    assert health["vectors"]["status"] == "degraded"
+    assert "no wheel" in health["vectors"]["last_error"]
+
+
+def test_truememory_stats_includes_health(server):
+    result_json = server.truememory_stats()
+    result = json.loads(result_json)
+    assert "health" in result
+    assert isinstance(result["health"], dict)
+    assert "reranker" in result["health"]
+    assert "hyde_llm" in result["health"]
+    assert "vectors" in result["health"]
+
+
+def test_health_does_not_leak_api_keys(server):
+    """What-NOT-to-do of F07: never expose API keys in health."""
+    import truememory.mcp_server as ms
+    ms._record_llm_error("anthropic", RuntimeError("sk-ant-abcd-secret-value"))
+    health = server._build_health_payload()
+    # The error string will contain the repr of the exception, which
+    # includes its message. The fix NAMES the exception type + its message;
+    # an API-key-leaking exception is a caller concern, not ours. But we
+    # shouldn't be synthesizing a message that INCLUDES any env-var key.
+    payload_text = json.dumps(health)
+    # ANTHROPIC_API_KEY env var is deleted in the fixture — no leak there
+    # to assert against. The real gate is that health has no "api_key",
+    # "anthropic_api_key", etc. keys.
+    for forbidden in ("api_key", "anthropic_api_key", "openrouter_api_key", "openai_api_key"):
+        assert forbidden not in payload_text
+
+
+# ---------------------------------------------------------------------------
+# F08 — sqlite-vec load failure populates engine state + logs at WARNING
+# ---------------------------------------------------------------------------
+
+
+def test_sqlite_vec_load_failure_logged_at_warning_and_stored(caplog, tmp_path, monkeypatch):
+    """Simulate a platform where `sqlite_vec.load(...)` raises."""
+    from truememory.engine import TrueMemoryEngine
+    import truememory.engine as engine
+
+    monkeypatch.setattr(engine, "_vectors_load_error", None)
+
+    db_path = tmp_path / "health.db"
+    # Create a DB first via ingest path isn't necessary — we just need
+    # open() to try sqlite_vec.load. Use a minimal bootstrap.
+    from truememory.storage import create_db
+    conn = create_db(db_path)
+    conn.close()
+
+    # Now monkeypatch sqlite_vec.load to raise. Import it first so the
+    # reference exists.
+    import sqlite_vec
+    def _boom(*args, **kwargs):
+        raise OSError("simulated: sqlite-vec wheel unavailable on this platform")
+    monkeypatch.setattr(sqlite_vec, "load", _boom)
+
+    eng = TrueMemoryEngine(db_path)
+    with caplog.at_level(logging.WARNING, logger="truememory.engine"):
+        # rebuild_vectors=False so we don't hit the rebuild branch (that
+        # would raise because sqlite-vec didn't load). We're only
+        # exercising the load path.
+        try:
+            eng.open(rebuild_vectors=False)
+        except Exception:
+            # After the sqlite-vec load failure, the rebuild branch is
+            # reached and re-raises; that's fine — we only care that the
+            # load-failure WARNING was emitted first.
+            pass
+
+    # F08 assertions
+    assert engine._vectors_load_error is not None
+    assert "OSError" in engine._vectors_load_error
+    assert any(
+        "sqlite-vec unavailable" in rec.message
+        for rec in caplog.records
+        if rec.levelname == "WARNING"
+    )
+
+
+def test_sqlite_vec_load_success_clears_error(server, tmp_path):
+    """A successful open() must clear any prior _vectors_load_error so
+    later stats calls report ok."""
+    import truememory.engine as engine
+    engine._vectors_load_error = "OSError: prior failure"
+
+    from truememory.storage import create_db
+    from truememory.engine import TrueMemoryEngine
+    db_path = tmp_path / "ok.db"
+    conn = create_db(db_path)
+    conn.close()
+
+    TrueMemoryEngine(db_path).open(rebuild_vectors=False)
+    # After a successful load, the error is cleared.
+    assert engine._vectors_load_error is None
+
+
+def test_get_vectors_load_error_public_helper(server):
+    """F07 consumes the engine state via `get_vectors_load_error()` so it
+    doesn't have to reach into module privates. The helper must exist and
+    return the current value."""
+    from truememory.engine import get_vectors_load_error
+    import truememory.engine as engine
+    assert get_vectors_load_error() is None
+    engine._vectors_load_error = "OSError: x"
+    assert get_vectors_load_error() == "OSError: x"
+    engine._vectors_load_error = None

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -59,6 +59,23 @@ try:
 except (ImportError, ModuleNotFoundError):
     pass
 
+
+# Hunter F08: module-level tracker for sqlite-vec load failures. On platforms
+# without a sqlite-vec wheel (Linux ARM musl, some BSDs, some sandboxed
+# runtimes) the extension load fails and search silently falls back to
+# FTS5-only. truememory_stats.health (F07) surfaces this via
+# get_vectors_load_error() so users can see the degradation.
+_vectors_load_error: str | None = None
+
+
+def get_vectors_load_error() -> str | None:
+    """Return the last sqlite-vec load failure message, or None if healthy.
+
+    Consumed by ``truememory_stats.health`` to surface the degraded-search
+    state. Module-level because ``sqlite_vec.load`` state is process-wide.
+    """
+    return _vectors_load_error
+
 _HAS_HYBRID = False
 try:
     from truememory.hybrid import search_hybrid
@@ -590,14 +607,26 @@ class TrueMemoryEngine:
             ).fetchall()
         }
 
-        # Load sqlite-vec extension if available
+        # Load sqlite-vec extension if available.
+        # Hunter F08: upgrade DEBUG → WARNING and track failure in a
+        # module-level state so ``truememory_stats.health`` can report
+        # "search is FTS-only because sqlite-vec failed to load".
+        global _vectors_load_error
         if _HAS_VECTOR:
             try:
                 import sqlite_vec
                 self.conn.enable_load_extension(True)
                 sqlite_vec.load(self.conn)
-            except Exception:
-                logger.debug("Failed to load sqlite-vec extension in open()", exc_info=True)
+                _vectors_load_error = None
+            except Exception as e:
+                _vectors_load_error = f"{type(e).__name__}: {e}"
+                logger.warning(
+                    "sqlite-vec unavailable (%s); falling back to FTS-only "
+                    "search for this process. See "
+                    "https://github.com/buildingjoshbetter/TrueMemory for "
+                    "platform notes.",
+                    _vectors_load_error,
+                )
 
         # Check for vector tables — rebuild if missing.
         # Hunter F32: if metadata names a different embedder, refuse silent

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -387,6 +387,54 @@ def _set_reranker(model_name: str):
         _record_reranker_error(f"{type(e).__name__}: {e}")
 
 
+# ---------------------------------------------------------------------------
+# Health payload (Hunter F07) — surfaces per-subsystem degradation so MCP
+# clients can diagnose "search quality is bad" without digging through logs.
+# Reads state written by F05 (_llm_last_error), F06 (_reranker_last_error),
+# and F08 (engine._vectors_load_error). Pure read — no mutation.
+# ---------------------------------------------------------------------------
+
+
+def _build_health_payload() -> dict:
+    """Return the `stats['health']` dict exposed by `truememory_stats`.
+
+    Each subsystem reports `{status, last_error, ...}`. ``status`` is one of
+    ``"ok"`` or ``"degraded"`` — the latter means a writer (F05 / F06 / F08)
+    stored a non-None error during the current process lifetime.
+    """
+    # Reranker — written by F06's _set_reranker.
+    with _reranker_error_lock:
+        reranker_err = _reranker_last_error
+
+    # HyDE LLM — written by F05's _build_llm_fn.
+    with _llm_error_lock:
+        llm_errors = dict(_llm_last_error) if _llm_last_error else None
+    active_provider = _current_llm_provider_name
+
+    # sqlite-vec — written by F08 in engine.open().
+    try:
+        from truememory.engine import get_vectors_load_error
+        vectors_err = get_vectors_load_error()
+    except ImportError:
+        vectors_err = None
+
+    return {
+        "reranker": {
+            "status": "ok" if reranker_err is None else "degraded",
+            "last_error": reranker_err,
+        },
+        "hyde_llm": {
+            "status": "ok" if not llm_errors else "degraded",
+            "active_provider": active_provider,
+            "last_error_by_provider": llm_errors,
+        },
+        "vectors": {
+            "status": "ok" if vectors_err is None else "degraded",
+            "last_error": vectors_err,
+        },
+    }
+
+
 def _parallel_search(queries, user_id, internal_limit, llm_fn, output_limit):
     """Run multiple agentic searches in parallel, merge and deduplicate."""
     db_path = _get_memory()._engine.db_path
@@ -550,6 +598,7 @@ def truememory_stats() -> str:
     stats["version"] = __version__
     stats["tier"] = config.get("tier", "edge")
     stats["tier_configured"] = "tier" in config
+    stats["health"] = _build_health_payload()
 
     if not stats["tier_configured"]:
         stats["setup_required"] = True


### PR DESCRIPTION
Closes #30, closes #31.

Hunter Bundle C — readers for the state Bundle A's writers populate. Completes the silent-failure → surfaced-health pipeline started in #45/#46.

## Summary
- **F08 (#31, medium):** \`engine.open()\` upgrades the sqlite-vec load-failure log from DEBUG to WARNING and stores the error in a module-level \`_vectors_load_error\` (exposed via \`get_vectors_load_error()\`). Previously a missing sqlite-vec wheel (Linux ARM musl, some BSDs, sandboxed runtimes) dropped search to FTS-only with zero user signal; now the warning fires once and the error is queryable.
- **F07 (#30, medium):** \`truememory_stats\` returns a new \`health\` dict:
  \`\`\`json
  "health": {
    "reranker":  {"status": "ok"|"degraded", "last_error": "..." | null},
    "hyde_llm":  {"status": "ok"|"degraded", "active_provider": "anthropic"|null, "last_error_by_provider": {...} | null},
    "vectors":   {"status": "ok"|"degraded", "last_error": "..." | null}
  }
  \`\`\`
  Reads state written by F05 (\`_llm_last_error\`), F06 (\`_reranker_last_error\`), and F08 (\`_vectors_load_error\`). Pure read — no mutation.

## Why now
- Bundle A (#46, merged) installed the three writers. Before Bundle A, F07 would have had nothing to read; the Hunter spec order is A → C for exactly this reason.

## Test plan
- [x] pytest: **180 passed / 1 skipped** (baseline 169 after #46 merge + 11 new regression locks; zero existing-test regressions).
- [x] \`ruff check truememory/ tests/\` — clean.
- [x] \`tests/test_health_stats.py\` (11 cases):
  - Health payload has exactly the 3 expected subsystems, each with \`status\`.
  - All-ok default: no errors → all three report \`"status": "ok"\`.
  - Reranker degraded: \`_record_reranker_error\` → status flips, error surfaced.
  - HyDE multi-provider: record errors on anthropic + openai → both appear in \`last_error_by_provider\`.
  - Active provider: \`_current_llm_provider_name = "openrouter"\` → reflected in \`health.hyde_llm.active_provider\`.
  - Vectors degraded: engine-level \`_vectors_load_error\` set → status + last_error propagate.
  - Integration: \`truememory_stats()\` JSON output has \`health\` key.
  - **API key leak guard**: payload JSON contains no \`api_key\` / \`anthropic_api_key\` / etc. keys (What-NOT-to-do of F07).
  - **F08 WARN + store**: monkeypatch \`sqlite_vec.load\` to raise → WARNING logged, \`_vectors_load_error\` populated with \`OSError: ...\`.
  - **F08 clear-on-success**: prior error cleared by a successful load.
  - **Helper contract**: \`get_vectors_load_error()\` exists and returns the current value.

## Notes for rustle
- F07's \`active_provider\` key is populated from \`_current_llm_provider_name\` (Bundle A addition). That field is set to the name of the provider that returned a working \`_build_*_llm\` function, or \`None\` if no provider succeeded. When all providers fail, \`status\` is \`"degraded"\` and \`active_provider\` is \`None\`.
- No changes to \`mcp_server._build_llm_fn\` or \`_set_reranker\` — the writers from Bundle A are consumed unchanged.

Hunter findings: F07 (#30), F08 (#31). See \`_working/HUNTER_FINDINGS.md\`.