### PR TITLE
medium: bound subprocess timeouts in setup / pip-install flows (F23+F25)

### DIFF
--- a/tests/test_subprocess_timeouts.py
+++ b/tests/test_subprocess_timeouts.py
@@ -1,0 +1,142 @@
+"""Regression lock for Hunter F23 + F25 — subprocess.run timeouts.
+
+F23: the four `claude` CLI calls in `mcp_server._setup_claude` now route
+through a `_run_claude` helper that passes `timeout=30` and reports
+`TimeoutExpired` to stderr instead of hanging forever.
+
+F25: the `pip install truememory[gpu]` call in `ingest/cli.py` now has
+`timeout=600` and a clear stderr message + fallback to Edge tier on
+timeout.
+"""
+from __future__ import annotations
+
+import subprocess
+
+
+# ---------------------------------------------------------------------------
+# F23 — `claude` CLI calls bounded by timeout
+# ---------------------------------------------------------------------------
+
+
+def test_setup_claude_claude_add_timeout_reports_and_falls_through(monkeypatch, capsys):
+    """If `claude mcp add` times out, setup must print to stderr and not hang."""
+    import truememory.mcp_server as ms
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "/fake/claude" if name == "claude" else None)
+
+    def _boom(cmd, **kwargs):
+        assert "timeout" in kwargs, "subprocess.run must be called with timeout="
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs["timeout"])
+
+    # Bypass Claude Desktop path so this test is scoped to the CLI path.
+    from pathlib import Path
+    monkeypatch.setattr(
+        Path, "exists",
+        lambda self: False if "Application Support" in str(self) else True,
+    )
+    monkeypatch.setattr(subprocess, "run", _boom)
+    ms._setup_claude()
+    captured = capsys.readouterr()
+    assert "timed out" in captured.err.lower()
+    assert "claude code" in captured.err.lower()
+
+
+def test_setup_claude_uses_30s_timeout_on_add_call(monkeypatch):
+    """The first `claude mcp add` call must include a timeout kwarg."""
+    import truememory.mcp_server as ms
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "/fake/claude" if name == "claude" else None)
+
+    from pathlib import Path
+    monkeypatch.setattr(
+        Path, "exists",
+        lambda self: False if "Application Support" in str(self) else True,
+    )
+    seen_calls = []
+
+    def _capture(cmd, **kwargs):
+        seen_calls.append((cmd, kwargs))
+        # Simulate a successful add so _setup_claude short-circuits
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _capture)
+    ms._setup_claude()
+    assert seen_calls, "subprocess.run was never called"
+    first_cmd, first_kwargs = seen_calls[0]
+    assert "timeout" in first_kwargs
+    assert first_kwargs["timeout"] == 30  # the finding's recommendation
+
+
+def test_setup_claude_timeout_on_list_call_is_handled(monkeypatch, capsys):
+    """When add reports 'already exists' and the follow-up `claude mcp list`
+    times out, setup must NOT crash — it should fall through to Claude
+    Desktop (preserving the 'existing_cmd = ""' default path)."""
+    import truememory.mcp_server as ms
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "/fake/claude" if name == "claude" else None)
+    from pathlib import Path
+    monkeypatch.setattr(
+        Path, "exists",
+        lambda self: False if "Application Support" in str(self) else True,
+    )
+
+    call_count = [0]
+
+    def _flaky(cmd, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # First: `claude mcp add` → returns "already exists"
+            return subprocess.CompletedProcess(
+                cmd, 1, stdout="", stderr="MCP server 'truememory' already exists"
+            )
+        # Subsequent: `claude mcp list` times out
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 30))
+
+    monkeypatch.setattr(subprocess, "run", _flaky)
+    # Must not raise
+    ms._setup_claude()
+    captured = capsys.readouterr()
+    assert "timed out" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# F25 — `pip install truememory[gpu]` bounded by timeout
+# ---------------------------------------------------------------------------
+
+
+def test_pip_install_has_timeout_kwarg(monkeypatch):
+    """Source-level check: the pip install subprocess.run call must include
+    a timeout kwarg. This guards against accidental removal."""
+    import pathlib
+    cli_source = pathlib.Path(__file__).parent.parent / "truememory" / "ingest" / "cli.py"
+    text = cli_source.read_text()
+    # Locate the pip install call and verify timeout is declared nearby.
+    idx = text.find('"truememory[gpu]"]')
+    assert idx != -1, "pip install call for truememory[gpu] not found in cli.py"
+    surrounding = text[idx : idx + 300]
+    assert "timeout=600" in surrounding, (
+        "F25 regression: pip install must declare timeout=600 (10 min) "
+        "so PyPI/mirror stalls don't wedge `truememory-ingest setup`"
+    )
+
+
+def test_pip_install_timeout_handler_prints_stderr_and_falls_back_to_edge():
+    """Simulate the TimeoutExpired path by reading the source and
+    confirming the expected recovery behaviour is wired up."""
+    import pathlib
+    cli_source = pathlib.Path(__file__).parent.parent / "truememory" / "ingest" / "cli.py"
+    text = cli_source.read_text()
+    # Must have a TimeoutExpired handler for the pip call.
+    assert "subprocess.TimeoutExpired" in text, (
+        "F25 regression: TimeoutExpired must be caught, not propagated"
+    )
+    # Must warn the user to stderr with an actionable message.
+    assert "file=sys.stderr" in text
+    # Must fall back to edge tier on timeout.
+    pip_idx = text.find('"truememory[gpu]"]')
+    assert pip_idx != -1
+    post = text[pip_idx : pip_idx + 800]
+    assert 'tier = "edge"' in post, (
+        "F25 regression: on pip timeout, setup must fall back to Edge tier "
+        "rather than leave the user in an indeterminate state"
+    )

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -333,7 +333,25 @@ def _run_setup(args):
                 do_install = input("  Install now? [y/N]: ").strip().lower()
                 if do_install == "y":
                     import subprocess
-                    subprocess.run([sys.executable, "-m", "pip", "install", "truememory[gpu]"])
+                    # Hunter F25: bound pip with a 10-minute timeout —
+                    # long enough for model downloads from slow mirrors,
+                    # short enough that a dead mirror doesn't wedge setup.
+                    try:
+                        subprocess.run(
+                            [sys.executable, "-m", "pip", "install",
+                             "truememory[gpu]"],
+                            timeout=600,
+                        )
+                    except subprocess.TimeoutExpired:
+                        print(
+                            "  \033[33m⚠ pip install timed out after "
+                            "10 minutes. Try `pip install "
+                            "truememory[gpu]` directly, then re-run "
+                            "`truememory-ingest setup`.\033[0m",
+                            file=sys.stderr,
+                        )
+                        print("  Falling back to Edge tier.")
+                        tier = "edge"
                 else:
                     print("  Falling back to Edge tier.")
                     tier = "edge"

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -912,6 +912,30 @@ def _setup_claude():
     import subprocess
     import sys
 
+    # Hunter F23: bound every `claude` CLI call. Without a timeout, a stalled
+    # claude binary (auth prompt, blocked network, deadlock) wedges
+    # `truememory-mcp --setup` forever. 30s is generous — claude CLI calls
+    # should complete in well under a second.
+    _CLAUDE_TIMEOUT = 30
+
+    def _run_claude(cmd: list[str]) -> subprocess.CompletedProcess | None:
+        """Run a `claude ...` command with a bounded wait.
+
+        Returns None (and warns to stderr) if the command timed out so the
+        caller can fall through gracefully.
+        """
+        try:
+            return subprocess.run(
+                cmd, capture_output=True, text=True, timeout=_CLAUDE_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            print(
+                f"  Claude Code: `{' '.join(cmd[:4])}...` timed out after "
+                f"{_CLAUDE_TIMEOUT}s. Skip or re-run later.",
+                file=sys.stderr,
+            )
+            return None
+
     python_path = sys.executable
     mcp_args = ["-m", "truememory.mcp_server"]
     configured = []
@@ -927,17 +951,17 @@ def _setup_claude():
     if claude_bin:
         add_cmd = [claude_bin, "mcp", "add", "truememory", "--",
                    python_path, *mcp_args]
-        result = subprocess.run(add_cmd, capture_output=True, text=True)
-        if result.returncode == 0:
+        result = _run_claude(add_cmd)
+        if result is None:
+            pass  # Timeout already warned — fall through to Claude Desktop
+        elif result.returncode == 0:
             configured.append("Claude Code")
         elif "already exists" in (result.stderr or "").lower():
             # Inspect the existing entry. `claude mcp list` output format:
             #   truememory: /path/to/python -m truememory.mcp_server - ✓ Connected
-            list_result = subprocess.run(
-                [claude_bin, "mcp", "list"], capture_output=True, text=True,
-            )
+            list_result = _run_claude([claude_bin, "mcp", "list"])
             existing_cmd = ""
-            if list_result.returncode == 0:
+            if list_result is not None and list_result.returncode == 0:
                 for line in (list_result.stdout or "").splitlines():
                     stripped = line.strip()
                     if stripped.startswith("truememory:") or stripped.startswith("truememory "):
@@ -956,14 +980,11 @@ def _setup_claude():
                 configured.append("Claude Code (existing config preserved)")
             else:
                 # Stale entry — remove and re-add.
-                subprocess.run(
-                    [claude_bin, "mcp", "remove", "truememory"],
-                    capture_output=True, text=True,
-                )
-                retry = subprocess.run(add_cmd, capture_output=True, text=True)
-                if retry.returncode == 0:
+                _run_claude([claude_bin, "mcp", "remove", "truememory"])
+                retry = _run_claude(add_cmd)
+                if retry is not None and retry.returncode == 0:
                     configured.append("Claude Code (stale entry replaced)")
-                else:
+                elif retry is not None:
                     print(f"  Claude Code: update failed — {retry.stderr.strip()}")
         else:
             print(f"  Claude Code: failed — {result.stderr.strip()}")


### PR DESCRIPTION
Closes #13, closes #14.

Hunter Bundle G — same anti-pattern (subprocess.run without timeout) on two CLI surfaces.

## Summary
- **F23 (#13, medium):** \`mcp_server._setup_claude\` invokes the \`claude\` CLI four times (add / list / remove / retry-add); none of those calls had a \`timeout=\`. If the binary was prompting for auth, blocked on network, or deadlocked from a prior session, \`truememory-mcp --setup\` hung forever. All four calls now go through a new \`_run_claude()\` helper that passes \`timeout=30\` and reports \`TimeoutExpired\` to stderr (the finding suggests 30s — claude CLI ops should be well under a second; 30s is generous).
- **F25 (#14, low):** \`ingest/cli.py\` ran \`pip install truememory[gpu]\` with no timeout; a dead PyPI mirror wedged \`truememory-ingest setup\` indefinitely. Now bounded at \`timeout=600\` (10 min, enough for slow model downloads from HF Hub) with a clear stderr message on TimeoutExpired and a fallback to Edge tier so the user isn't left in an indeterminate state.

## Why pair them
Same anti-pattern, same one-line-per-call fix, related findings per the Hunter spec. Bundle ships as one PR.

## Test plan
- [x] pytest: **185 passed / 1 skipped** (baseline 180 after #47 merge + 5 new regression locks; zero existing-test regressions).
- [x] \`ruff check truememory/ tests/\` — clean.
- [x] \`tests/test_subprocess_timeouts.py\` (5 cases):
  - \`test_setup_claude_claude_add_timeout_reports_and_falls_through\` — monkeypatches \`subprocess.run\` to raise \`TimeoutExpired\`, asserts stderr message + no crash.
  - \`test_setup_claude_uses_30s_timeout_on_add_call\` — asserts the first \`claude mcp add\` call is passed \`timeout=30\`.
  - \`test_setup_claude_timeout_on_list_call_is_handled\` — simulates "add says already-exists, list times out"; asserts graceful fall-through.
  - \`test_pip_install_has_timeout_kwarg\` — source-level check: \`timeout=600\` appears near the \`pip install truememory[gpu]\` call site in \`ingest/cli.py\`.
  - \`test_pip_install_timeout_handler_prints_stderr_and_falls_back_to_edge\` — source-level check: \`subprocess.TimeoutExpired\` handler, \`file=sys.stderr\` write, and \`tier = \"edge\"\` fallback all appear in the same section.

Hunter audit findings: F23 (#13), F25 (#14). See \`_working/HUNTER_FINDINGS.md\`.