### PR TITLE
low: CI hardening — add build-check job + dependabot config (F26+F27)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Hunter F27: weekly dep scan so stale caps (like the sentence-transformers
+# <4.0 that forced 3.4.1 when 5.4.1 was current — F19) surface within a week
+# instead of needing a full audit to catch. Weekly cadence is intentional —
+# daily is noisy for a ~10-dep project.
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,25 @@ jobs:
         run: pytest tests/ -v
       - name: Lint
         run: ruff check truememory/ tests/
+
+  # Hunter F26: catch packaging regressions (missing py.typed, metadata
+  # errors, broken README rendering, sdist contents) in CI instead of
+  # at release time. Runs once on 3.12 only — duplicating across the
+  # matrix wastes CI minutes without additional signal.
+  build-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+      - name: Install build tooling
+        run: pip install build twine
+      - name: Build sdist + wheel
+        run: python -m build
+      - name: Verify package metadata
+        run: twine check --strict dist/*


### PR DESCRIPTION
Closes #17, closes #18.

Hunter Bundle H — CI hardening, two .github/ additions.

## Summary
- **F26 (#17):** new \`build-check\` job in \`.github/workflows/ci.yml\` runs \`python -m build\` + \`twine check --strict dist/*\` on a single 3.12 cell (duplicating across the matrix just burns CI minutes — the artifact is architecture/Python-version neutral). Catches packaging regressions (missing \`py.typed\`, metadata errors, broken README rendering, sdist contents) at PR time instead of release time.
- **F27 (#18):** adds \`.github/dependabot.yml\` with weekly pip + github-actions scans. Stale caps like F19's \`sentence-transformers <4.0\` (which hid behind 3.4.1 while 5.4.1 was current) will now surface within a week. Weekly cadence is intentional — daily is noisy for a ~10-dep project; \`open-pull-requests-limit\` caps churn.

## NOTE on F27's CodeQL half
The finding also prescribes adding \`.github/workflows/codeql.yml\`. **CodeQL is already active on this repo via GitHub's default setup** — confirmed via \`gh api repos/buildingjoshbetter/TrueMemory/code-scanning/default-setup\`:
\`\`\`json
{"state":"configured","languages":["actions","python"],"query_suite":"default","schedule":"weekly"}
\`\`\`
Adding a custom \`codeql.yml\` would conflict with default setup (they're mutually exclusive). The F27 CodeQL intent is therefore already met; no workflow file added. This is a genuine change from what the audit saw — worth noting on the closing comment so it doesn't look like the PR half-addresses the finding.

## Test plan
- [x] Local \`python -m build\` — produces \`dist/truememory-0.4.0.tar.gz\` and \`dist/truememory-0.4.0-py3-none-any.whl\`.
- [x] Local \`twine check --strict dist/*\` — **PASSED** on both artifacts.
- [x] Local pytest: **185 passed / 1 skipped** (unchanged — this PR adds no code paths, only CI jobs).
- [x] Local ruff: clean (no touched Python files).
- [ ] CI build-check job runs green on this PR (automatic verification).
- [ ] Dependabot opens its first PR within a week (out-of-band verification).

## Why one PR, not split
Bundle H in the Hunter spec explicitly groups these as "CI hardening — \`.github/\` workflow additions". They touch only \`.github/\` files, don't interact with each other functionally, and benefit from a single CI run for verification.

Hunter audit findings: F26 (#17), F27 (#18). See \`_working/HUNTER_FINDINGS.md\`.