### PR TITLE
medium: platform compat — Claude Desktop path + Windows permission warning (F28+F29)

### DIFF
--- a/tests/test_platform_compat.py
+++ b/tests/test_platform_compat.py
@@ -1,0 +1,175 @@
+"""Regression lock for Hunter F28 + F29 — platform compatibility.
+
+F28: POSIX ``chmod(0o600)`` / ``chmod(0o700)`` silently no-op on Windows,
+leaving `~/.truememory/config.json` (which stores API keys in plaintext)
+readable by any local user. Both `mcp_server._save_config` and
+`ingest/cli._save_truememory_config` now warn to stderr when persisting
+an API key on Windows.
+
+F29: `_setup_claude` previously hardcoded the macOS Claude Desktop path,
+so Linux and Windows users got "Claude Desktop not detected" even when
+it was installed. Resolution is now per-platform via
+`_claude_desktop_config_path`.
+"""
+from __future__ import annotations
+
+import json
+
+
+# ---------------------------------------------------------------------------
+# F29 — per-platform Claude Desktop config path
+# ---------------------------------------------------------------------------
+
+
+def test_claude_desktop_path_macos(monkeypatch):
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms.sys, "platform", "darwin")
+    p = ms._claude_desktop_config_path()
+    assert "Library/Application Support/Claude/claude_desktop_config.json" in str(p)
+
+
+def test_claude_desktop_path_linux(monkeypatch):
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms.sys, "platform", "linux")
+    p = ms._claude_desktop_config_path()
+    assert ".config/Claude/claude_desktop_config.json" in str(p)
+
+
+def test_claude_desktop_path_linux_variant(monkeypatch):
+    """Any non-darwin, non-win32 platform should resolve to the Linux path
+    (the fall-through branch — covers OpenBSD, FreeBSD, etc.)."""
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms.sys, "platform", "freebsd14")
+    p = ms._claude_desktop_config_path()
+    assert ".config/Claude/claude_desktop_config.json" in str(p)
+
+
+def test_claude_desktop_path_windows_with_appdata(monkeypatch):
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms.sys, "platform", "win32")
+    monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
+    p = ms._claude_desktop_config_path()
+    as_str = str(p)
+    assert "Roaming" in as_str
+    assert "Claude" in as_str
+    assert "claude_desktop_config.json" in as_str
+
+
+def test_claude_desktop_path_windows_without_appdata(monkeypatch):
+    """If APPDATA is unset we fall back to the canonical Roaming path
+    under the user's home directory."""
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms.sys, "platform", "win32")
+    monkeypatch.delenv("APPDATA", raising=False)
+    p = ms._claude_desktop_config_path()
+    as_str = str(p)
+    assert "AppData" in as_str or "appdata" in as_str.lower()
+    assert "Roaming" in as_str
+    assert "claude_desktop_config.json" in as_str
+
+
+# ---------------------------------------------------------------------------
+# F28 — Windows permission warning in _save_config
+# ---------------------------------------------------------------------------
+
+
+def _tmp_config_dir(tmp_path, monkeypatch, ms):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    return home
+
+
+def test_save_config_warns_on_windows_when_api_key_present(
+    tmp_path, monkeypatch, capsys
+):
+    import truememory.mcp_server as ms
+    _tmp_config_dir(tmp_path, monkeypatch, ms)
+    monkeypatch.setattr(ms.sys, "platform", "win32")
+
+    ms._save_config({"tier": "pro", "anthropic_api_key": "sk-ant-fake"})
+
+    captured = capsys.readouterr()
+    assert "windows" in captured.err.lower()
+    assert "config.json" in captured.err.lower()
+    assert "environment variable" in captured.err.lower()
+
+
+def test_save_config_silent_on_windows_without_api_key(
+    tmp_path, monkeypatch, capsys
+):
+    """The warning fires only when a secret is being persisted — a bare
+    tier-only config is not sensitive, so don't nag."""
+    import truememory.mcp_server as ms
+    _tmp_config_dir(tmp_path, monkeypatch, ms)
+    monkeypatch.setattr(ms.sys, "platform", "win32")
+
+    ms._save_config({"tier": "edge"})
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_save_config_silent_on_posix_with_api_key(
+    tmp_path, monkeypatch, capsys
+):
+    """On macOS / Linux the chmod(0o600) is real; the warning must NOT
+    fire there (would be false alarm)."""
+    import truememory.mcp_server as ms
+    _tmp_config_dir(tmp_path, monkeypatch, ms)
+    monkeypatch.setattr(ms.sys, "platform", "darwin")
+
+    ms._save_config({"tier": "pro", "anthropic_api_key": "sk-ant-fake"})
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_save_config_roundtrip_writes_file(tmp_path, monkeypatch):
+    """Baseline: the save path still produces a readable JSON file on
+    POSIX (no regression to the happy path)."""
+    import truememory.mcp_server as ms
+    home = _tmp_config_dir(tmp_path, monkeypatch, ms)
+    monkeypatch.setattr(ms.sys, "platform", "darwin")
+
+    ms._save_config({"tier": "base", "anthropic_api_key": "sk-ant-xyz"})
+
+    cfg = home / ".truememory" / "config.json"
+    assert cfg.exists()
+    data = json.loads(cfg.read_text())
+    assert data["tier"] == "base"
+    assert data["anthropic_api_key"] == "sk-ant-xyz"
+
+
+# ---------------------------------------------------------------------------
+# F28 — duplicate in ingest/cli.py
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_cli_save_warns_on_windows_when_api_key_present(
+    tmp_path, monkeypatch, capsys
+):
+    from truememory.ingest import cli as ic
+    cfg_path = tmp_path / ".truememory" / "config.json"
+    monkeypatch.setattr(ic, "_TRUEMEMORY_CONFIG_PATH", cfg_path)
+    monkeypatch.setattr(ic.sys, "platform", "win32")
+
+    ic._save_truememory_config({"tier": "pro", "openrouter_api_key": "sk-or-fake"})
+
+    captured = capsys.readouterr()
+    assert "windows" in captured.err.lower()
+    assert "environment variable" in captured.err.lower()
+
+
+def test_ingest_cli_save_silent_on_posix(tmp_path, monkeypatch, capsys):
+    from truememory.ingest import cli as ic
+    cfg_path = tmp_path / ".truememory" / "config.json"
+    monkeypatch.setattr(ic, "_TRUEMEMORY_CONFIG_PATH", cfg_path)
+    monkeypatch.setattr(ic.sys, "platform", "linux")
+
+    ic._save_truememory_config({"tier": "pro", "openrouter_api_key": "sk-or-fake"})
+
+    captured = capsys.readouterr()
+    assert captured.err == ""

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -292,11 +292,26 @@ def _load_truememory_config() -> dict:
 
 
 def _save_truememory_config(config: dict) -> None:
-    """Save config to ~/.truememory/config.json."""
+    """Save config to ~/.truememory/config.json.
+
+    Hunter F28: chmod calls below are silent no-ops on Windows. When an
+    API key is being persisted on Windows we warn to stderr so the user
+    knows the plaintext file is readable by other local users and can
+    route keys through env vars instead on shared machines.
+    """
     _TRUEMEMORY_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     _TRUEMEMORY_CONFIG_PATH.parent.chmod(0o700)
     _TRUEMEMORY_CONFIG_PATH.write_text(json.dumps(config, indent=2))
     _TRUEMEMORY_CONFIG_PATH.chmod(0o600)
+    if sys.platform == "win32" and any(k.endswith("_api_key") for k in config):
+        print(
+            "truememory: warning — on Windows, ~/.truememory/config.json "
+            "permissions are inherited from the parent directory and may be "
+            "readable by other local users. If this is a shared machine, set "
+            "the API key via the ANTHROPIC_API_KEY / OPENROUTER_API_KEY / "
+            "OPENAI_API_KEY environment variable instead.",
+            file=sys.stderr,
+        )
 
 
 def _run_setup(args):

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -86,11 +86,27 @@ def _load_config() -> dict:
 
 
 def _save_config(config: dict) -> None:
-    """Save config to ~/.truememory/config.json."""
+    """Save config to ~/.truememory/config.json.
+
+    Hunter F28: the POSIX `chmod` calls below are silent no-ops on Windows;
+    the config file (which stores API keys in plaintext) inherits the
+    parent-directory ACL — typically readable by all local users. When
+    storing a key on Windows we warn to stderr and suggest the env-var
+    route, which is the actually-private channel.
+    """
     _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
     _TRUEMEMORY_DIR.chmod(0o700)
     _CONFIG_PATH.write_text(json.dumps(config, indent=2))
     _CONFIG_PATH.chmod(0o600)
+    if sys.platform == "win32" and any(k.endswith("_api_key") for k in config):
+        print(
+            "truememory: warning — on Windows, ~/.truememory/config.json "
+            "permissions are inherited from the parent directory and may be "
+            "readable by other local users. If this is a shared machine, set "
+            "the API key via the ANTHROPIC_API_KEY / OPENROUTER_API_KEY / "
+            "OPENAI_API_KEY environment variable instead.",
+            file=sys.stderr,
+        )
 
 
 # Apply saved tier on startup (before any model loading)
@@ -892,6 +908,31 @@ def _preload_models():
 # Auto-setup for Claude Code and Claude Desktop
 # ---------------------------------------------------------------------------
 
+def _claude_desktop_config_path() -> Path:
+    """Return the per-platform Claude Desktop config file location.
+
+    Hunter F29: previously hardcoded to macOS. Claude Desktop stores this
+    file in a platform-specific app-data location:
+      - macOS:   ``~/Library/Application Support/Claude/claude_desktop_config.json``
+      - Windows: ``%APPDATA%/Claude/claude_desktop_config.json`` (fallback
+                 ``~/AppData/Roaming/Claude/...`` when APPDATA is unset)
+      - Linux:   ``~/.config/Claude/claude_desktop_config.json``
+
+    The caller still gates on ``desktop_config_path.parent.exists()`` — if
+    Claude Desktop isn't installed on this platform, ``_setup_claude`` will
+    correctly report "not detected" instead of creating the directory.
+    """
+    if sys.platform == "darwin":
+        return (Path.home() / "Library" / "Application Support"
+                / "Claude" / "claude_desktop_config.json")
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
+        return base / "Claude" / "claude_desktop_config.json"
+    # Linux / BSD / other POSIX
+    return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
 def _setup_claude():
     """Auto-configure TrueMemory as an MCP server in Claude Code and/or Claude Desktop.
 
@@ -990,7 +1031,11 @@ def _setup_claude():
             print(f"  Claude Code: failed — {result.stderr.strip()}")
 
     # --- Claude Desktop ---
-    desktop_config_path = Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    # Hunter F29: pre-PR49, this path was hardcoded to the macOS
+    # `~/Library/Application Support/Claude/...` location, so Linux and
+    # Windows users silently got "Claude Desktop not detected" even with
+    # Desktop installed. Resolve per-platform instead.
+    desktop_config_path = _claude_desktop_config_path()
     if desktop_config_path.parent.exists():
         try:
             if desktop_config_path.exists():


### PR DESCRIPTION
Closes #33, closes #34.

Hunter Bundle I — both findings are about silent platform-specific behavior that leaves non-macOS users degraded. Ships as one PR per the Hunter bundle spec (erred UP from F28's direct-to-main classification since Bundle I already includes PR+rustle F29).

## Summary
- **F29 (#34, medium):** \`_setup_claude\` hard-coded the macOS path \`~/Library/Application Support/Claude/claude_desktop_config.json\`, so Linux and Windows users with Claude Desktop installed saw "Claude Desktop not detected" and only got the manual fallback. New helper \`_claude_desktop_config_path()\` picks per platform:
  - **macOS** → \`~/Library/Application Support/Claude/claude_desktop_config.json\`
  - **Windows** → \`%APPDATA%/Claude/...\` (or \`~/AppData/Roaming/Claude/...\` when \`APPDATA\` is unset)
  - **Linux / BSD / other POSIX** → \`~/.config/Claude/claude_desktop_config.json\`
- **F28 (#33, low):** POSIX \`chmod(0o600)\` / \`chmod(0o700)\` calls in \`mcp_server._save_config\` AND \`ingest/cli._save_truememory_config\` silently no-op on Windows — the plaintext-API-key config file inherits the parent-directory ACL and is readable by all local users. When an \`*_api_key\` value is being persisted on Windows, both save paths now warn to stderr pointing users to the \`ANTHROPIC_API_KEY\` / \`OPENROUTER_API_KEY\` / \`OPENAI_API_KEY\` env-var route for shared machines. POSIX behavior unchanged.

## Why one PR
Both findings are platform-compat improvements in the same two files (\`mcp_server.py\` + \`ingest/cli.py\`) touching adjacent surfaces of the setup flow. The Hunter spec groups them as "Bundle I: F28+F29 (platform compat)".

## Test plan
- [x] pytest: **196 passed / 1 skipped** (baseline 185 after #49 merge + 11 new regression locks; zero existing-test regressions).
- [x] \`ruff check truememory/ tests/\` — clean.
- [x] \`tests/test_platform_compat.py\` (11 cases):
  - F29: path resolution for darwin / linux / freebsd (fall-through) / win32-with-APPDATA / win32-without-APPDATA — 5 cases.
  - F28 (mcp_server): warning fires on Windows + api_key; silent on Windows + no api_key; silent on POSIX + api_key; happy-path JSON round-trip preserved — 4 cases.
  - F28 (ingest/cli duplicate): warning fires on Windows + api_key; silent on POSIX — 2 cases.
- [ ] Manual cross-platform (Linux / Windows) smoke — suggested but not runnable in CI.

## What NOT to do — adherence
- F28: did NOT silently accept Windows' default permission inheritance for secrets; did NOT touch the POSIX path (would be false-alarm noise).
- F29: did NOT fall back to creating the Claude Desktop directory when absent — "not installed" and "installed" stay distinct via the existing \`parent.exists()\` gate.

Hunter findings: F28 (#33), F29 (#34). See \`_working/HUNTER_FINDINGS.md\`.