### PR TITLE
low: three mcp_server.py safety cleanups — LLM-cache lock, context manager, HF offline try/finally (F22+F30+F31)

### DIFF
--- a/tests/test_mcp_safety.py
+++ b/tests/test_mcp_safety.py
@@ -1,0 +1,233 @@
+"""Regression locks for Hunter F22, F30, F31 — mcp_server.py concurrency /
+safety cleanups.
+
+F22: `_get_llm_fn` uses double-checked locking so concurrent first-callers
+don't both build the LLM client.
+
+F30: `_parallel_search._run_query` uses `with Memory()` context manager so
+KeyboardInterrupt between construction and `try:` still closes the DB.
+
+F31: `truememory_configure` pops HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE
+inside a try/finally so any raise between pop and restore doesn't leak
+offline-mode-disabled state for the process lifetime.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+
+# ---------------------------------------------------------------------------
+# F22 — double-checked locking on _get_llm_fn
+# ---------------------------------------------------------------------------
+
+
+def test_get_llm_fn_builds_exactly_once_under_concurrency(monkeypatch):
+    """10 threads call `_get_llm_fn` simultaneously; `_build_llm_fn` must
+    be called exactly once. Without F22's lock, the pre-fix code races
+    and calls it up to 10 times."""
+    import truememory.mcp_server as ms
+
+    # Reset state so the fast path doesn't bypass the build on first call
+    monkeypatch.setattr(ms, "_cached_llm_fn", None)
+    monkeypatch.setattr(ms, "_cached_llm_fn_built", False)
+
+    call_count = {"n": 0}
+    build_start_barrier = threading.Event()
+
+    def _slow_build():
+        # Block until all threads are queued — forces the race window wide
+        build_start_barrier.wait(timeout=5)
+        call_count["n"] += 1
+        time.sleep(0.01)  # widen the window further
+        def _fn(prompt: str) -> str:
+            return "ok"
+        return _fn
+
+    monkeypatch.setattr(ms, "_build_llm_fn", _slow_build)
+
+    results = [None] * 10
+    threads = []
+
+    def _worker(i):
+        results[i] = ms._get_llm_fn()
+
+    for i in range(10):
+        t = threading.Thread(target=_worker, args=(i,))
+        threads.append(t)
+        t.start()
+
+    # All threads now queued in `_get_llm_fn`; release them into the build
+    build_start_barrier.set()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert call_count["n"] == 1, (
+        f"F22 regression: _build_llm_fn was called {call_count['n']} times "
+        f"across 10 concurrent first-callers; expected exactly 1"
+    )
+    # All threads must see the same cached function
+    assert all(r is results[0] for r in results)
+
+
+def test_get_llm_fn_fast_path_skips_lock(monkeypatch):
+    """Once built, subsequent calls must NOT re-acquire the lock (fast
+    path). Confirm by monkeypatching the lock to raise if acquired."""
+    import truememory.mcp_server as ms
+
+    def _build():
+        def _fn(prompt: str) -> str:
+            return "ok"
+        return _fn
+
+    monkeypatch.setattr(ms, "_cached_llm_fn", None)
+    monkeypatch.setattr(ms, "_cached_llm_fn_built", False)
+    monkeypatch.setattr(ms, "_build_llm_fn", _build)
+
+    # Prime the cache
+    first = ms._get_llm_fn()
+    assert first is not None
+
+    # Now poison the lock — if the fast path works, this is never touched
+    class _PoisonedLock:
+        def __enter__(self):
+            raise AssertionError("F22 fast-path regression: lock acquired on cached call")
+        def __exit__(self, *a):
+            pass
+
+    monkeypatch.setattr(ms, "_llm_cache_lock", _PoisonedLock())
+    # Must not raise — fast path bypasses the lock
+    second = ms._get_llm_fn()
+    assert second is first
+
+
+# ---------------------------------------------------------------------------
+# F30 — _run_query uses context manager
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_search_run_query_uses_context_manager():
+    """Source-level check: the `_run_query` helper inside
+    `_parallel_search` must use `with Memory(...) as ...:` (NOT
+    `Memory(...); try/finally m.close()`). The pre-F30 form leaks a
+    sqlite FD if KeyboardInterrupt arrives between construction and
+    the `try:` — a narrow race that shows up in stress tests and on
+    Ctrl-C during a long search."""
+    import pathlib
+    src = pathlib.Path(__file__).parent.parent / "truememory" / "mcp_server.py"
+    text = src.read_text()
+    # Find the _run_query body — must contain the context-manager form
+    idx = text.find("def _run_query(")
+    assert idx != -1, "_run_query helper not found in mcp_server.py"
+    body = text[idx : idx + 400]
+    assert "with Memory(" in body, (
+        "F30 regression: _run_query must use `with Memory(...)` context "
+        "manager for interrupt-safe cleanup"
+    )
+    # And must NOT fall back to the explicit try/finally m.close() form
+    assert "thread_m.close()" not in body, (
+        "F30 regression: _run_query should not use explicit close() anymore"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F31 — HF offline-mode restore in try/finally
+# ---------------------------------------------------------------------------
+
+
+def test_configure_restores_hf_offline_on_success(monkeypatch, tmp_path):
+    """Happy path: after a successful `truememory_configure`,
+    HF_HUB_OFFLINE and TRANSFORMERS_OFFLINE are set to "1"."""
+    import truememory.mcp_server as ms
+
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    db_path = tmp_path / "memories.db"
+    monkeypatch.setenv("TRUEMEMORY_DB", str(db_path))
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    monkeypatch.setattr(ms, "_DB_PATH", str(db_path))
+    monkeypatch.setattr(ms, "_memory", None)
+
+    # Stub sentence_transformers + model-switch calls so we don't need GPU
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "sentence_transformers":
+            import types
+            return types.ModuleType("sentence_transformers")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    import truememory.vector_search as vs
+    import truememory.reranker as rr
+    monkeypatch.setattr(vs, "set_embedding_model", lambda tier: None)
+    monkeypatch.setattr(rr, "set_active_tier", lambda tier: None)
+    monkeypatch.setattr(ms, "_set_reranker", lambda name: None)
+
+    # Clear env first
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+
+    import os as _os
+    result_json = ms.truememory_configure(tier="edge")
+    _ = json.loads(result_json)
+    assert _os.environ.get("HF_HUB_OFFLINE") == "1"
+    assert _os.environ.get("TRANSFORMERS_OFFLINE") == "1"
+
+
+def test_configure_restores_hf_offline_on_set_embedding_model_raise(
+    monkeypatch, tmp_path
+):
+    """Failure path: if `set_embedding_model` raises mid-configure, the
+    finally must still restore HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE so
+    subsequent searches don't silently hit the network."""
+    import truememory.mcp_server as ms
+
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    db_path = tmp_path / "memories.db"
+    monkeypatch.setenv("TRUEMEMORY_DB", str(db_path))
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    monkeypatch.setattr(ms, "_DB_PATH", str(db_path))
+    monkeypatch.setattr(ms, "_memory", None)
+
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "sentence_transformers":
+            import types
+            return types.ModuleType("sentence_transformers")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    import truememory.vector_search as vs
+
+    def _boom(tier):
+        raise ValueError("simulated: model removed")
+
+    monkeypatch.setattr(vs, "set_embedding_model", _boom)
+
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+
+    # truememory_configure wraps the tier switch; ValueError propagates
+    # out per Python semantics after finally runs.
+    import os as _os
+    import pytest
+    with pytest.raises(ValueError):
+        ms.truememory_configure(tier="pro")
+
+    # Critical F31 assertion: offline mode was RESTORED despite the raise
+    assert _os.environ.get("HF_HUB_OFFLINE") == "1", (
+        "F31 regression: set_embedding_model raised and offline mode was "
+        "left disabled; subsequent searches will silently hit HF Hub"
+    )
+    assert _os.environ.get("TRANSFORMERS_OFFLINE") == "1"

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -317,15 +317,29 @@ def _build_llm_fn():
 
 _cached_llm_fn = None
 _cached_llm_fn_built = False
+# Hunter F22: double-checked locking around first-call construction.
+# Without this, two concurrent first-searches both observe
+# `_cached_llm_fn_built == False`, both call `_build_llm_fn()`, both
+# race to write — benign (no data corruption) but wasteful (duplicate
+# API-key validation + client construction).
+_llm_cache_lock = threading.Lock()
 
 
 def _get_llm_fn():
-    """Build and cache the LLM function. Only rebuilt on first call."""
+    """Build and cache the LLM function. First caller wins the build.
+
+    Fast path bypasses the lock once ``_cached_llm_fn_built`` is True,
+    so steady-state searches don't pay synchronization cost.
+    """
     global _cached_llm_fn, _cached_llm_fn_built
-    if not _cached_llm_fn_built:
+    if _cached_llm_fn_built:
+        return _cached_llm_fn  # fast path, no lock
+    with _llm_cache_lock:
+        if _cached_llm_fn_built:
+            return _cached_llm_fn  # another thread won the race
         _cached_llm_fn = _build_llm_fn()
         _cached_llm_fn_built = True
-    return _cached_llm_fn
+        return _cached_llm_fn
 
 
 # ---------------------------------------------------------------------------
@@ -456,13 +470,14 @@ def _parallel_search(queries, user_id, internal_limit, llm_fn, output_limit):
     db_path = _get_memory()._engine.db_path
 
     def _run_query(q):
-        thread_m = Memory(path=db_path)
-        try:
+        # Hunter F30: context manager ensures the sqlite connection is
+        # closed even if `KeyboardInterrupt` lands between construction
+        # and entry into the old explicit `try:` block. `Memory.__exit__`
+        # already handles close; this form is just interrupt-safe.
+        with Memory(path=db_path) as thread_m:
             return thread_m.search_deep(
                 q, user_id=user_id, limit=internal_limit, llm_fn=llm_fn,
             )
-        finally:
-            thread_m.close()
 
     with ThreadPoolExecutor(max_workers=min(len(queries), 5)) as pool:
         futures = [pool.submit(_run_query, q) for q in queries]
@@ -715,59 +730,68 @@ def truememory_configure(
         _clear_llm_error(api_provider)
 
     # Apply model change — temporarily allow downloads for tier switch
-    # (the new model may not be cached yet)
-    os.environ.pop("HF_HUB_OFFLINE", None)
-    os.environ.pop("TRANSFORMERS_OFFLINE", None)
-    os.environ["TRUEMEMORY_EMBED_MODEL"] = tier
-    from truememory.vector_search import set_embedding_model
-    set_embedding_model(tier)
-
-    # Tell the reranker module about the new tier so get_reranker(model_name=None)
-    # calls (from direct Python-API users via rerank_with_modality_fusion etc.)
-    # resolve to the tier-correct model. Then pre-load that reranker so the
-    # first post-configure search doesn't pay a cold-start.
-    from truememory.reranker import set_active_tier as _set_active_tier
-    _set_active_tier(tier)
-    _set_reranker(_current_reranker())
-
-    # If tier actually changed, re-embed any existing memories.
-    # Hunter F03: (1) rebuild BOTH vec_messages and vec_messages_sep (the
-    # old code only rebuilt the completion table, leaving the separation
-    # table silently empty); (2) surface exceptions as rebuild_error in
-    # the response payload instead of swallowing into bare pass; (3) null
-    # _memory in `finally` so the next call always gets a fresh instance
-    # with the new model — even on failure.
+    # (the new model may not be cached yet).
+    #
+    # Hunter F31: wrap pop + restore in try/finally. Without this, any
+    # exception between the pop (line below) and the restore at the
+    # bottom (e.g. `set_embedding_model` raising on a removed model,
+    # model-download failure, disk-full during re-embed) leaves offline
+    # mode PERMANENTLY disabled for the process, and subsequent
+    # searches silently hit the network on every cache miss.
     rebuilt = False
     rebuild_error: str | None = None
-    if old_tier != tier:
-        try:
-            m = _get_memory()
-            engine = m._engine
-            engine._ensure_connection()
-            conn = engine.conn
-            count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
-            if count > 0:
-                conn.execute("DROP TABLE IF EXISTS vec_messages")
-                conn.execute("DROP TABLE IF EXISTS vec_messages_sep")
-                conn.commit()
-                from truememory.vector_search import (
-                    build_separation_vectors,
-                    build_vectors,
-                    init_vec_table,
-                )
-                init_vec_table(conn)
-                build_vectors(conn)
-                build_separation_vectors(conn)
-                rebuilt = True
-        except Exception as e:
-            rebuild_error = f"{type(e).__name__}: {e}"
-            log.exception("truememory_configure re-embed failed")
-        finally:
-            _memory = None  # Always force re-init, even on failure
+    os.environ.pop("HF_HUB_OFFLINE", None)
+    os.environ.pop("TRANSFORMERS_OFFLINE", None)
+    try:
+        os.environ["TRUEMEMORY_EMBED_MODEL"] = tier
+        from truememory.vector_search import set_embedding_model
+        set_embedding_model(tier)
 
-    # Restore offline mode now that the new model is downloaded/loaded
-    os.environ["HF_HUB_OFFLINE"] = "1"
-    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+        # Tell the reranker module about the new tier so get_reranker(model_name=None)
+        # calls (from direct Python-API users via rerank_with_modality_fusion etc.)
+        # resolve to the tier-correct model. Then pre-load that reranker so the
+        # first post-configure search doesn't pay a cold-start.
+        from truememory.reranker import set_active_tier as _set_active_tier
+        _set_active_tier(tier)
+        _set_reranker(_current_reranker())
+
+        # If tier actually changed, re-embed any existing memories.
+        # Hunter F03: (1) rebuild BOTH vec_messages and vec_messages_sep (the
+        # old code only rebuilt the completion table, leaving the separation
+        # table silently empty); (2) surface exceptions as rebuild_error in
+        # the response payload instead of swallowing into bare pass; (3) null
+        # _memory in `finally` so the next call always gets a fresh instance
+        # with the new model — even on failure.
+        if old_tier != tier:
+            try:
+                m = _get_memory()
+                engine = m._engine
+                engine._ensure_connection()
+                conn = engine.conn
+                count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+                if count > 0:
+                    conn.execute("DROP TABLE IF EXISTS vec_messages")
+                    conn.execute("DROP TABLE IF EXISTS vec_messages_sep")
+                    conn.commit()
+                    from truememory.vector_search import (
+                        build_separation_vectors,
+                        build_vectors,
+                        init_vec_table,
+                    )
+                    init_vec_table(conn)
+                    build_vectors(conn)
+                    build_separation_vectors(conn)
+                    rebuilt = True
+            except Exception as e:
+                rebuild_error = f"{type(e).__name__}: {e}"
+                log.exception("truememory_configure re-embed failed")
+            finally:
+                _memory = None  # Always force re-init, even on failure
+    finally:
+        # Always restore offline mode, even if set_embedding_model or the
+        # rebuild block raised before we got to their own cleanup.
+        os.environ["HF_HUB_OFFLINE"] = "1"
+        os.environ["TRANSFORMERS_OFFLINE"] = "1"
 
     # Build result with onboarding info
     result = {


### PR DESCRIPTION
Closes #35, closes #36, closes #32.

Three narrow-but-real edge cases in \`mcp_server.py\`. Each is a small fix; bundling saves a rustle cycle.

## Summary
- **F22 (#35, low):** \`_get_llm_fn\` uses double-checked locking. Pre-fix, two concurrent first-searches both observed \`_cached_llm_fn_built == False\`, both built the LLM client (API-key validation, imports), raced to write. Benign (no data corruption) but wasteful — and unreliable if you're trying to reason about cold-start cost. New \`_llm_cache_lock\`; fast path bypasses the lock once built, so steady-state searches pay no synchronization cost.
- **F30 (#36, low):** \`_parallel_search._run_query\` now uses \`with Memory(path=db_path) as thread_m:\` instead of \`Memory(...); try/finally m.close()\`. Pre-fix, \`KeyboardInterrupt\` arriving in the microsecond window between construction and the \`try:\` leaked the sqlite connection. The context manager is both more idiomatic and interrupt-safe (\`Memory.__exit__\` already handled close correctly).
- **F31 (#32, low):** \`truememory_configure\`'s HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE pop-and-restore is now wrapped in try/finally. Pre-fix, any raise between the pop (before \`set_embedding_model\`) and the restore (after rebuild) left offline mode permanently disabled for the process, and subsequent searches silently hit HF Hub on every cache miss. F31's gotcha explicitly cites \`set_embedding_model\` ValueError as a trigger.

## Test plan
- [x] pytest: **202 passed / 1 skipped** (baseline 197 after #54 merge + 5 new regression locks).
- [x] \`ruff check truememory/ tests/\` — clean.
- [x] Local build-check + \`twine check --strict\` still green (no packaging surface touched).
- [x] \`tests/test_mcp_safety.py\` (5 cases):
  - **F22 thread-bench**: 10 threads call \`_get_llm_fn\` simultaneously; \`_build_llm_fn\` is monkeypatched with a synchronized barrier to widen the race window. Pre-fix would call build up to 10 times; new code calls exactly 1.
  - **F22 fast-path**: after first build, poison the lock with a \`_PoisonedLock\` that raises on \`__enter__\`; assert the second call doesn't touch it.
  - **F30 context-manager**: source-level check — \`_run_query\` uses \`with Memory(...\` AND no \`thread_m.close()\` fallback remains.
  - **F31 happy-path restore**: after a successful configure, \`HF_HUB_OFFLINE == "1"\` and \`TRANSFORMERS_OFFLINE == "1"\`.
  - **F31 failure-path restore (critical)**: monkeypatch \`set_embedding_model\` to raise ValueError; assert the ValueError propagates AND offline mode is still restored after the raise.

## What NOT to do — adherence
- F22: no async conversion (caller expects sync).
- F30: no shared Memory across threads; no global connection registry.
- F31: the existing try/except/finally for the rebuild block is preserved and now nested inside the outer try/finally — behaviour unchanged on success.

Hunter findings: F22, F30, F31. See \`_working/HUNTER_FINDINGS.md\`.