### PR TITLE
medium: stop-hook safety — concurrent-spawn cap + Popen-fail backlog queue (F21+F33)

### DIFF
--- a/tests/ingest/test_stop_hook_safety.py
+++ b/tests/ingest/test_stop_hook_safety.py
@@ -1,0 +1,260 @@
+"""Regression locks for Hunter F21 + F33 — stop-hook safety.
+
+F21: `_run_background_ingestion` now refuses to Popen when `SPAWN_CAP`
+concurrent ingest processes are already live — pre-fix, N parallel Stop
+hooks loaded N embedding models (~600MB each on Pro) and OOM-killed on
+laptops.
+
+F33: when Popen itself fails, the hook now writes a JSON marker to
+`BACKLOG_DIR` instead of falling back to synchronous inline ingestion
+(the old path blocked Claude Code's shutdown for 10–60s).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# F21 — spawn cap
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_cap_blocks_when_at_cap(monkeypatch, tmp_path):
+    """When `_count_active_ingest_processes()` reports >= SPAWN_CAP,
+    `_run_background_ingestion` must NOT call Popen and must write a
+    backlog marker explaining why."""
+    from truememory.ingest.hooks import stop as stop_mod
+
+    monkeypatch.setattr(stop_mod, "SPAWN_CAP", 2)
+    monkeypatch.setattr(stop_mod, "_count_active_ingest_processes", lambda: 2)
+    monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
+    monkeypatch.setattr(stop_mod, "TRACE_DIR", tmp_path / "traces")
+    monkeypatch.setattr(stop_mod, "LOG_DIR", tmp_path / "logs")
+
+    popen_calls = []
+
+    def _record_popen(*args, **kwargs):
+        popen_calls.append((args, kwargs))
+        return type("DummyProc", (), {"pid": 0})()
+
+    monkeypatch.setattr(subprocess, "Popen", _record_popen)
+
+    stop_mod._run_background_ingestion(
+        transcript_path="/fake/transcript.json",
+        session_id="sess-at-cap",
+        user_id="alice",
+        db_path="/tmp/fake.db",
+    )
+
+    assert popen_calls == [], (
+        "F21 regression: Popen was called despite cap reached"
+    )
+    markers = list((tmp_path / "backlog").glob("*.json"))
+    assert len(markers) == 1
+    data = json.loads(markers[0].read_text())
+    assert data["session_id"] == "sess-at-cap"
+    assert "spawn_cap_reached" in data["reason"]
+
+
+def test_spawn_cap_allows_spawn_under_cap(monkeypatch, tmp_path):
+    """Under the cap, Popen must be called and no backlog marker written."""
+    from truememory.ingest.hooks import stop as stop_mod
+
+    monkeypatch.setattr(stop_mod, "SPAWN_CAP", 4)
+    monkeypatch.setattr(stop_mod, "_count_active_ingest_processes", lambda: 1)
+    monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
+    monkeypatch.setattr(stop_mod, "TRACE_DIR", tmp_path / "traces")
+    monkeypatch.setattr(stop_mod, "LOG_DIR", tmp_path / "logs")
+    (tmp_path / "logs").mkdir()
+
+    popen_calls = []
+
+    def _record_popen(*args, **kwargs):
+        popen_calls.append((args, kwargs))
+        return type("DummyProc", (), {"pid": 123})()
+
+    monkeypatch.setattr(subprocess, "Popen", _record_popen)
+
+    stop_mod._run_background_ingestion(
+        transcript_path="/fake/transcript.json",
+        session_id="sess-ok",
+        user_id="alice",
+        db_path="/tmp/fake.db",
+    )
+
+    assert len(popen_calls) == 1, "Popen must be called when under the cap"
+    backlog = tmp_path / "backlog"
+    assert not backlog.exists() or not list(backlog.glob("*.json"))
+
+
+def test_count_active_ingest_processes_windows_noop(monkeypatch):
+    """On Windows, `_count_active_ingest_processes` returns 0 so the cap
+    check doesn't become a hard fence (pgrep is POSIX-only)."""
+    from truememory.ingest.hooks import stop as stop_mod
+    import sys as _sys
+
+    monkeypatch.setattr(_sys, "platform", "win32")
+    # Even if pgrep would exist, the win32 branch short-circuits
+    assert stop_mod._count_active_ingest_processes() == 0
+
+
+def test_count_active_ingest_processes_pgrep_missing(monkeypatch):
+    """If pgrep isn't on PATH (sandboxed runtime), return 0 rather than
+    crash the hook."""
+    from truememory.ingest.hooks import stop as stop_mod
+    import sys as _sys
+
+    monkeypatch.setattr(_sys, "platform", "linux")
+
+    def _no_pgrep(*args, **kwargs):
+        raise FileNotFoundError("pgrep not found")
+
+    monkeypatch.setattr(subprocess, "run", _no_pgrep)
+    assert stop_mod._count_active_ingest_processes() == 0
+
+
+# ---------------------------------------------------------------------------
+# F33 — Popen failure → backlog marker, NOT inline ingestion
+# ---------------------------------------------------------------------------
+
+
+def test_popen_failure_queues_backlog_not_inline(monkeypatch, tmp_path):
+    """When subprocess.Popen raises (disk full, permission denied, etc.),
+    the hook must write a backlog marker and NOT fall back to inline
+    ingestion — that path blocks Claude Code's shutdown."""
+    from truememory.ingest.hooks import stop as stop_mod
+
+    monkeypatch.setattr(stop_mod, "SPAWN_CAP", 99)
+    monkeypatch.setattr(stop_mod, "_count_active_ingest_processes", lambda: 0)
+    monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
+    monkeypatch.setattr(stop_mod, "TRACE_DIR", tmp_path / "traces")
+    monkeypatch.setattr(stop_mod, "LOG_DIR", tmp_path / "logs")
+    (tmp_path / "logs").mkdir()
+
+    def _popen_boom(*args, **kwargs):
+        raise OSError("simulated: disk full for log file")
+
+    monkeypatch.setattr(subprocess, "Popen", _popen_boom)
+
+    inline_called = {"n": 0}
+
+    def _spy_inline(*args, **kwargs):
+        inline_called["n"] += 1
+        return {}
+
+    # If the old inline-fallback code path had survived, it would call
+    # `truememory.ingest.ingest`. Monkeypatch that name on the import
+    # site (truememory.ingest.__init__) so any call would trip the spy.
+    import truememory.ingest as _ingest_pkg
+    monkeypatch.setattr(_ingest_pkg, "ingest", _spy_inline, raising=False)
+
+    # Must not raise, must not call inline ingest, must queue to backlog.
+    stop_mod._run_background_ingestion(
+        transcript_path="/fake/transcript.json",
+        session_id="sess-popen-fail",
+        user_id="alice",
+        db_path="/tmp/fake.db",
+    )
+
+    assert inline_called["n"] == 0, (
+        "F33 regression: inline ingestion was called after Popen failure; "
+        "this blocks Claude Code shutdown"
+    )
+    markers = list((tmp_path / "backlog").glob("*.json"))
+    assert len(markers) == 1
+    data = json.loads(markers[0].read_text())
+    assert data["session_id"] == "sess-popen-fail"
+    assert "popen_failed" in data["reason"]
+    assert "OSError" in data["reason"]
+
+
+def test_backlog_write_failure_is_swallowed(monkeypatch, tmp_path):
+    """Best-effort: if the backlog directory itself is unwritable (disk
+    full, chmod 000), the hook logs an error but must NOT raise — the
+    session's memories are just lost, and the primary contract (don't
+    block Claude Code) is preserved."""
+    from truememory.ingest.hooks import stop as stop_mod
+
+    # Point BACKLOG_DIR at a path that will fail on mkdir (nested inside
+    # a file, not a dir)
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir")
+    monkeypatch.setattr(stop_mod, "BACKLOG_DIR", blocker / "subdir" / "backlog")
+
+    # Should not raise
+    stop_mod._queue_to_backlog(
+        transcript_path="/fake/transcript.json",
+        session_id="sess-backlog-fail",
+        user_id="alice",
+        db_path="/tmp/fake.db",
+        reason="test",
+    )
+
+
+def test_backlog_marker_schema(monkeypatch, tmp_path):
+    """Document the backlog marker schema — a later session_start drain
+    path will rely on these keys."""
+    from truememory.ingest.hooks import stop as stop_mod
+
+    monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
+    stop_mod._queue_to_backlog(
+        transcript_path="/conv/transcript.json",
+        session_id="sess-abc",
+        user_id="alice",
+        db_path="/tmp/alice.db",
+        reason="test:reason",
+    )
+
+    marker = tmp_path / "backlog" / "sess-abc.json"
+    assert marker.exists()
+    data = json.loads(marker.read_text())
+    required_keys = {
+        "transcript_path", "session_id", "user_id",
+        "db_path", "queued_at", "reason",
+    }
+    assert required_keys <= set(data.keys())
+    assert data["session_id"] == "sess-abc"
+    assert data["reason"] == "test:reason"
+    # ISO-8601 timestamp
+    assert "T" in data["queued_at"]
+
+
+def test_empty_session_id_still_queues(monkeypatch, tmp_path):
+    """If session_id is missing, still write a marker (under 'unknown.json')
+    so we don't silently drop the memories."""
+    from truememory.ingest.hooks import stop as stop_mod
+
+    monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
+    stop_mod._queue_to_backlog(
+        transcript_path="/conv/transcript.json",
+        session_id="",
+        user_id="",
+        db_path="",
+        reason="no-session-id",
+    )
+    assert (tmp_path / "backlog" / "unknown.json").exists()
+
+
+def test_spawn_cap_env_var_override(monkeypatch):
+    """`TRUEMEMORY_INGEST_SPAWN_CAP` env var must control the cap."""
+    monkeypatch.setenv("TRUEMEMORY_INGEST_SPAWN_CAP", "5")
+    import importlib
+    from truememory.ingest.hooks import stop as stop_mod
+    importlib.reload(stop_mod)
+    assert stop_mod.SPAWN_CAP == 5
+
+    monkeypatch.setenv("TRUEMEMORY_INGEST_SPAWN_CAP", "1")
+    importlib.reload(stop_mod)
+    assert stop_mod.SPAWN_CAP == 1
+
+
+def test_backlog_dir_env_var_override(monkeypatch, tmp_path):
+    """`TRUEMEMORY_BACKLOG_DIR` env var must control the path."""
+    override = tmp_path / "custom_backlog"
+    monkeypatch.setenv("TRUEMEMORY_BACKLOG_DIR", str(override))
+    import importlib
+    from truememory.ingest.hooks import stop as stop_mod
+    importlib.reload(stop_mod)
+    assert Path(str(stop_mod.BACKLOG_DIR)) == override

--- a/truememory/ingest/hooks/stop.py
+++ b/truememory/ingest/hooks/stop.py
@@ -37,6 +37,17 @@ LOG_DIR = Path(os.environ.get(
     "TRUEMEMORY_LOG_DIR",
     str(Path.home() / ".truememory" / "logs"),
 ))
+# Hunter F33: when Popen fails we queue the ingestion here instead of
+# running inline (which would block Claude Code shutdown).
+BACKLOG_DIR = Path(os.environ.get(
+    "TRUEMEMORY_BACKLOG_DIR",
+    str(Path.home() / ".truememory" / "backlog"),
+))
+# Hunter F21: cap concurrent ingest processes. N parallel Stop hooks
+# (multi-session close, session-restart loop) would otherwise load N
+# embedding models at once — ~600MB RSS each on Pro, easy OOM on laptops.
+# Tunable via env var; POSIX-only via pgrep (on Windows the cap is a no-op).
+SPAWN_CAP = int(os.environ.get("TRUEMEMORY_INGEST_SPAWN_CAP", "2"))
 
 
 def _parse_args() -> argparse.Namespace:
@@ -174,6 +185,60 @@ def _has_enough_messages(transcript_path: str, min_messages: int) -> bool:
     return len(content) > min_messages * 50
 
 
+def _count_active_ingest_processes() -> int:
+    """Return a best-effort count of live ``truememory.ingest.cli`` children.
+
+    Hunter F21: used to bound concurrent hook-spawned ingestions. pgrep
+    is POSIX-only; on Windows this returns 0 (cap disabled) to avoid a
+    platform-dependent hard stop — the typical burst-close scenario is
+    rare on Windows anyway. Any pgrep failure is swallowed (return 0)
+    so the cap never becomes a hard fence that prevents ingestion.
+    """
+    if sys.platform == "win32":
+        return 0
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "truememory.ingest.cli"],
+            capture_output=True, text=True, timeout=1,
+        )
+        return len([ln for ln in (result.stdout or "").splitlines() if ln.strip()])
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return 0
+
+
+def _queue_to_backlog(
+    transcript_path: str,
+    session_id: str,
+    user_id: str,
+    db_path: str,
+    reason: str,
+) -> None:
+    """Drop a queue marker so a later session can re-attempt this ingestion.
+
+    Hunter F33: when Popen fails (disk full for log file, permission error,
+    etc.) we used to fall back to synchronous inline ingestion — which
+    blocked Claude Code's shutdown for 10–60s. Now we write a marker to
+    BACKLOG_DIR and let the next session's startup hook drain it (drain
+    path is a follow-up item).
+    """
+    try:
+        from datetime import datetime, timezone
+        BACKLOG_DIR.mkdir(parents=True, exist_ok=True)
+        marker = BACKLOG_DIR / f"{session_id or 'unknown'}.json"
+        marker.write_text(json.dumps({
+            "transcript_path": transcript_path,
+            "session_id": session_id,
+            "user_id": user_id,
+            "db_path": db_path,
+            "queued_at": datetime.now(timezone.utc).isoformat(),
+            "reason": reason,
+        }))
+    except Exception as e:
+        # Best-effort: if we can't write the backlog marker, the session's
+        # memories are lost — log and move on. Must not raise.
+        log.error("stop hook: failed to queue backlog marker: %s", e)
+
+
 def _run_background_ingestion(
     transcript_path: str,
     session_id: str,
@@ -185,6 +250,12 @@ def _run_background_ingestion(
     Captures stderr/stdout to a log file so silent failures are recoverable.
     Handles Windows (CREATE_NEW_PROCESS_GROUP) and POSIX (start_new_session)
     subprocess detachment.
+
+    Hunter F21: bounds concurrent spawns via ``SPAWN_CAP`` so a burst of
+    Stop hooks doesn't load N embedding models at once.
+    Hunter F33: on Popen failure, queue the ingestion to ``BACKLOG_DIR``
+    for a later session to re-attempt — NEVER fall back to synchronous
+    inline ingestion (that blocks Claude Code's shutdown).
     """
     # Log the effective config for debugging. Operators commonly wire up
     # multiple profiles and need to confirm which user/db the hook actually
@@ -226,6 +297,21 @@ def _run_background_ingestion(
     else:
         detach_kwargs["start_new_session"] = True
 
+    # Hunter F21: refuse to spawn if we're already at the concurrent-ingest
+    # cap. Over-cap events queue to the backlog so the memories aren't lost.
+    active = _count_active_ingest_processes()
+    if active >= SPAWN_CAP:
+        log.warning(
+            "stop hook: at spawn cap (%d active / cap %d); queueing session "
+            "%r to backlog for later",
+            active, SPAWN_CAP, session_id,
+        )
+        _queue_to_backlog(
+            transcript_path, session_id, user_id, db_path,
+            reason=f"spawn_cap_reached:{active}>=SPAWN_CAP={SPAWN_CAP}",
+        )
+        return
+
     log_file = None
     try:
         # Open the log file and hand it to the subprocess. We MUST close our
@@ -242,25 +328,18 @@ def _run_background_ingestion(
             **detach_kwargs,
         )
     except Exception as e:
-        # If background launch fails, try inline (blocking)
-        log.warning("Background launch failed: %s, running inline", e)
-        try:
-            from truememory.ingest import ingest
-            result = ingest(
-                transcript_path=transcript_path,
-                user_id=user_id,
-                db_path=db_path or None,
-                gate_threshold=GATE_THRESHOLD,
-                session_id=session_id,
-            )
-            from truememory.ingest.pipeline import save_trace
-            save_trace(result, trace_path)
-        except Exception as e2:
-            log.error("Inline ingestion also failed: %s", e2)
-            try:
-                log_path.write_text(f"Inline ingestion failed: {e2}\n", encoding="utf-8")
-            except Exception:
-                pass
+        # Hunter F33: NEVER fall back to synchronous inline ingestion —
+        # that blocks Claude Code's shutdown for 10–60s. Queue instead;
+        # a later session's drain path will re-attempt.
+        log.warning(
+            "stop hook: background launch failed (%s); queueing session "
+            "%r to backlog for later",
+            e, session_id,
+        )
+        _queue_to_backlog(
+            transcript_path, session_id, user_id, db_path,
+            reason=f"popen_failed:{type(e).__name__}:{e}",
+        )
     finally:
         # Always close our parent-side handle to prevent FD leaks.
         # The subprocess still has its own dup'd copy of the FD and will


### PR DESCRIPTION
Closes #5, closes #11.

Two related \`stop.py\` safety fixes. They coordinate: both route to the same new backlog-queue path.

## Summary
- **F21 (#5, medium):** before calling Popen, \`_run_background_ingestion\` now counts live \`truememory.ingest.cli\` children via pgrep and refuses to spawn when already at \`SPAWN_CAP\` (default 2, overridable via \`TRUEMEMORY_INGEST_SPAWN_CAP\`). Over-cap events queue to \`BACKLOG_DIR\` instead of silently dropping. Pre-fix, N parallel Stop hooks (multi-session close, session-restart loop) loaded N embedding models at once — ~600MB RSS each on Pro, easy OOM on laptops.
- **F33 (#11, low):** the old inline-fallback path (\`from truememory.ingest import ingest; result = ingest(...)\`) is gone. When Popen fails (disk full for log file, permission error), the hook now writes a JSON marker to \`BACKLOG_DIR\` and returns immediately. Pre-fix, the inline path blocked Claude Code's shutdown for 10–60s — exact behaviour the background-spawn pattern was designed to avoid.

## Backlog marker schema
\`\`\`json
{
  "transcript_path": "...",
  "session_id": "...",
  "user_id": "...",
  "db_path": "...",
  "queued_at": "<ISO-8601 UTC>",
  "reason": "spawn_cap_reached:N>=SPAWN_CAP=M | popen_failed:<exc>"
}
\`\`\`

## Not in this PR (follow-up)
**Drain path.** \`session_start.py\` should iterate \`~/.truememory/backlog/\` at session start and re-attempt each marker (then delete on successful Popen). The finding itself scopes this as optional ("Estimated size: ~25 lines + optional drain-in-session_start work"). Shipping the queue-write side first keeps the PR minimal and means memories start accumulating in the backlog now — the drain path can be added later without changing the marker format.

## Test plan
- [x] pytest: **212 passed / 1 skipped** (baseline 202 after #55 merge + 10 new regression locks).
- [x] \`ruff check truememory/ tests/\` — clean.
- [x] Local \`python -m build && twine check --strict\` — still green (no packaging surface touched).
- [x] \`tests/ingest/test_stop_hook_safety.py\` (10 cases):
  - **F21 cap at/under boundary**: at-cap → no Popen, marker written; under-cap → Popen called, no marker.
  - **F21 platform safety**: Windows returns 0 (cap disabled); pgrep-missing returns 0; neither crashes the hook.
  - **F33 inline-fallback spy**: \`truememory.ingest.ingest\` monkeypatched with a spy that counts calls; Popen raises OSError; assert spy count == 0 AND marker written with \`popen_failed:OSError\` reason.
  - **Backlog best-effort**: \`BACKLOG_DIR\` pointed at an unwritable path; \`_queue_to_backlog\` logs but does NOT raise (hook invariant: never block shutdown).
  - **Marker schema completeness**: all 6 required keys present; \`queued_at\` is ISO-8601.
  - **Empty session_id**: marker still written under \`unknown.json\`, no silent drop.
  - **Env overrides**: \`TRUEMEMORY_INGEST_SPAWN_CAP\` and \`TRUEMEMORY_BACKLOG_DIR\` propagate correctly via \`importlib.reload\`.

## What NOT to do — adherence
- F21: did NOT remove detachment (\`start_new_session=True\`); did NOT make the hook synchronous; did NOT rely on the pipeline's dedup-store lock (too late to bound memory).
- F33: did NOT silently drop (marker is always written); did NOT run inline synchronously; did NOT keep the fallback with a timeout (timeouts during mid-pipeline can corrupt DB).

Hunter findings: F21 (#5), F33 (#11). See \`_working/HUNTER_FINDINGS.md\`.