### PR TITLE
low: unify PRAGMA busy_timeout + validate empty Memory.add content (F35+F38)

### DIFF
--- a/tests/test_memory_api_safety.py
+++ b/tests/test_memory_api_safety.py
@@ -1,0 +1,220 @@
+"""Regression locks for Hunter F35 + F38 — Memory API safety.
+
+F35: `storage.py:create_db` and `pipeline._set_busy_timeout` both derive
+their `PRAGMA busy_timeout` value from a single source of truth
+(`storage.DEFAULT_BUSY_TIMEOUT_MS`) so the two code paths can't drift
+apart (pre-fix: 5000ms in storage vs 10_000ms in pipeline, producing
+asymmetric lock-wait under contention).
+
+F38: `Memory.add("")` and `Memory.add("   \\t\\n  ")` must issue a warning
+and return a skip-marker (id=None, created_at=None) — pre-fix they
+silently inserted useless rows that polluted `stats().message_count`.
+"""
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from truememory import Memory
+
+
+# ---------------------------------------------------------------------------
+# F35 — PRAGMA busy_timeout unification
+# ---------------------------------------------------------------------------
+
+
+def test_busy_timeout_single_source_of_truth():
+    """Both code paths must derive their default from
+    `storage.DEFAULT_BUSY_TIMEOUT_MS`."""
+    from truememory.storage import DEFAULT_BUSY_TIMEOUT_MS
+    assert DEFAULT_BUSY_TIMEOUT_MS == 10_000, (
+        "F35 regression: the shared constant changed; verify all callers "
+        "still intend the same value"
+    )
+
+
+def test_create_db_uses_shared_constant(tmp_path):
+    """The sqlite connection created by `create_db` must actually have
+    `busy_timeout` set to the shared constant — not some stale literal."""
+    from truememory.storage import DEFAULT_BUSY_TIMEOUT_MS, create_db
+    db_path = tmp_path / "check.db"
+    conn = create_db(db_path)
+    result = conn.execute("PRAGMA busy_timeout").fetchone()
+    conn.close()
+    assert result[0] == DEFAULT_BUSY_TIMEOUT_MS, (
+        f"F35 regression: create_db set busy_timeout={result[0]}, expected "
+        f"DEFAULT_BUSY_TIMEOUT_MS={DEFAULT_BUSY_TIMEOUT_MS}"
+    )
+
+
+def test_pipeline_set_busy_timeout_defaults_to_shared_constant():
+    """`pipeline._set_busy_timeout()` with no timeout argument must pull
+    the shared constant. Pre-fix default was 10_000 as a literal; the
+    fix removes the literal by defaulting the param to None + pulling
+    the constant at call time."""
+    import inspect
+    from truememory.ingest.pipeline import _set_busy_timeout
+    sig = inspect.signature(_set_busy_timeout)
+    # Default should be None (pull constant at call time), NOT a literal int
+    assert sig.parameters["timeout_ms"].default is None, (
+        "F35 regression: pipeline._set_busy_timeout has a literal default, "
+        "which lets it drift from storage.DEFAULT_BUSY_TIMEOUT_MS"
+    )
+
+
+def test_pipeline_set_busy_timeout_applies_shared_constant(tmp_path):
+    """End-to-end: call `_set_busy_timeout(memory)` with default and
+    verify the connection's pragma matches the shared constant."""
+    from truememory.ingest.pipeline import _set_busy_timeout
+    from truememory.storage import DEFAULT_BUSY_TIMEOUT_MS
+
+    m = Memory(path=str(tmp_path / "m.db"))
+    try:
+        # Engine needs a live connection for the helper to write the pragma
+        m._engine._ensure_connection()
+        # Reset it to a different value so we can detect the write
+        m._engine.conn.execute("PRAGMA busy_timeout=1")
+        assert m._engine.conn.execute("PRAGMA busy_timeout").fetchone()[0] == 1
+
+        _set_busy_timeout(m)  # no timeout_ms → shared constant
+        observed = m._engine.conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        assert observed == DEFAULT_BUSY_TIMEOUT_MS
+    finally:
+        m.close()
+
+
+# ---------------------------------------------------------------------------
+# F38 — Memory.add rejects empty / whitespace-only content
+# ---------------------------------------------------------------------------
+
+
+def test_add_empty_string_warns_and_skips():
+    m = Memory(":memory:")
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = m.add("")
+        assert result["id"] is None
+        assert result["created_at"] is None
+        assert result["content"] == ""
+        # Stats must NOT count the skipped add
+        assert m.stats().get("message_count", 0) == 0
+        # Warning was emitted
+        messages = [str(w.message) for w in caught]
+        assert any("empty" in msg.lower() for msg in messages)
+    finally:
+        m.close()
+
+
+def test_add_whitespace_only_warns_and_skips():
+    m = Memory(":memory:")
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = m.add("   \t\n  ")
+        assert result["id"] is None
+        assert m.stats().get("message_count", 0) == 0
+        assert any("whitespace" in str(w.message).lower() for w in caught)
+    finally:
+        m.close()
+
+
+def test_add_real_content_still_works():
+    """Regression: the new validation must NOT affect the happy path."""
+    m = Memory(":memory:")
+    try:
+        result = m.add("Alice prefers dark mode")
+        assert result["id"] is not None
+        assert isinstance(result["id"], int)
+        assert result["content"] == "Alice prefers dark mode"
+        assert result["created_at"] is not None
+        assert m.stats().get("message_count", 0) == 1
+    finally:
+        m.close()
+
+
+def test_add_content_with_leading_trailing_whitespace_still_stored():
+    """Content with real text + surrounding whitespace is NOT empty —
+    it should be stored as-is (F38's 'What NOT to do': don't trim
+    silently; surface the warning so callers can decide)."""
+    m = Memory(":memory:")
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = m.add("  real content  ")
+        assert result["id"] is not None
+        # Content stored as-passed, NOT trimmed
+        assert result["content"] == "  real content  "
+        assert m.stats().get("message_count", 0) == 1
+        # No warning for non-empty content
+        empty_warnings = [w for w in caught if "empty" in str(w.message).lower()]
+        assert not empty_warnings
+    finally:
+        m.close()
+
+
+def test_add_skip_marker_preserves_user_id():
+    """The skip-marker should echo the `user_id` the caller passed so
+    batch callers can correlate the skip to their input row."""
+    m = Memory(":memory:")
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = m.add("", user_id="alice")
+        assert result["user_id"] == "alice"
+        assert result["id"] is None
+    finally:
+        m.close()
+
+
+def test_add_skip_marker_on_none_like_input():
+    """None content is a programmer error but shouldn't crash."""
+    m = Memory(":memory:")
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # `not None` is True, so the branch fires without even calling .strip()
+            result = m.add(None)  # type: ignore[arg-type]
+        assert result["id"] is None
+    finally:
+        m.close()
+
+
+def test_stats_reflects_only_real_adds():
+    """Integration: mix valid and empty adds, confirm stats counts
+    only the valid ones."""
+    m = Memory(":memory:")
+    try:
+        m.add("first")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            m.add("")
+            m.add("   ")
+        m.add("second")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            m.add("\t\n")
+        assert m.stats().get("message_count", 0) == 2
+    finally:
+        m.close()
+
+
+@pytest.mark.parametrize(
+    "bad_content",
+    ["", " ", "\t", "\n", "\r\n", "   \t\n  ", " "],  # non-breaking space
+)
+def test_add_rejects_various_empty_forms(bad_content):
+    """A broad parameterized regression — any `str.strip()` → `""` is
+    treated as empty."""
+    m = Memory(":memory:")
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = m.add(bad_content)
+        assert result["id"] is None, (
+            f"F38 regression: content={bad_content!r} was stored instead "
+            f"of being skipped"
+        )
+    finally:
+        m.close()

--- a/truememory/client.py
+++ b/truememory/client.py
@@ -60,7 +60,28 @@ class Memory:
 
         Returns:
             Dict with ``id``, ``content``, ``user_id``, ``created_at``.
+            When ``content`` is empty / whitespace-only the memory is
+            NOT stored — a warning is issued and a skip-marker is
+            returned (``id`` is ``None``, ``created_at`` is ``None``).
         """
+        # Hunter F38: skip empty / whitespace-only content. Callers
+        # passing through user-generated text (parsed transcripts,
+        # partial JSON) used to pollute the DB with useless rows that
+        # inflated `stats().message_count`. Warn rather than raise so
+        # batch callers can continue; the skip-marker lets them detect.
+        if not content or not content.strip():
+            import warnings
+            warnings.warn(
+                "Memory.add called with empty or whitespace-only content; "
+                "skipping (no row inserted).",
+                stacklevel=2,
+            )
+            return {
+                "id": None,
+                "content": content,
+                "user_id": user_id or "",
+                "created_at": None,
+            }
         now = datetime.datetime.now(datetime.timezone.utc).isoformat()
         result = self._engine.add(
             content=content,

--- a/truememory/ingest/pipeline.py
+++ b/truememory/ingest/pipeline.py
@@ -110,7 +110,7 @@ def _dedup_store_lock():
             pass
 
 
-def _set_busy_timeout(memory, timeout_ms: int = 10_000) -> None:
+def _set_busy_timeout(memory, timeout_ms: int | None = None) -> None:
     """Best-effort: set ``PRAGMA busy_timeout`` on the underlying connection.
 
     Older truememory versions may not expose ``_engine`` / ``conn``.
@@ -119,7 +119,13 @@ def _set_busy_timeout(memory, timeout_ms: int = 10_000) -> None:
     already serializes the critical section, and even without busy_timeout
     sqlite will raise ``OperationalError`` which the caller already catches
     and records in the trace.
+
+    Hunter F35: defaults come from ``storage.DEFAULT_BUSY_TIMEOUT_MS`` so
+    this helper and :func:`truememory.storage.create_db` never drift apart.
     """
+    if timeout_ms is None:
+        from truememory.storage import DEFAULT_BUSY_TIMEOUT_MS
+        timeout_ms = DEFAULT_BUSY_TIMEOUT_MS
     try:
         engine = getattr(memory, "_engine", None)
         if engine is None:

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -152,6 +152,14 @@ CREATE TABLE IF NOT EXISTS metadata (
 """
 
 
+# Hunter F35: single source of truth for the sqlite busy_timeout pragma.
+# Pre-fix, create_db used 5000ms and pipeline._set_busy_timeout used
+# 10_000ms — same DB, asymmetric lock-wait behaviour that surfaced as
+# sporadic "database is locked" errors under concurrent ingest + MCP
+# search load. Both paths now import this constant.
+DEFAULT_BUSY_TIMEOUT_MS = 10_000
+
+
 # ---------------------------------------------------------------------------
 # Database creation
 # ---------------------------------------------------------------------------
@@ -173,7 +181,7 @@ def create_db(db_path: str | Path) -> sqlite3.Connection:
     """
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
     conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute("PRAGMA busy_timeout=5000")
+    conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
     conn.executescript(_SCHEMA_SQL)
     conn.commit()
     return conn


### PR DESCRIPTION
Closes #12, closes #39.

Two Memory-API standalones bundled to save a rustle cycle. Both small, both independent.

## Summary
- **F35 (#12, low):** new \`storage.DEFAULT_BUSY_TIMEOUT_MS = 10_000\` constant. Both \`create_db\` (was 5000ms literal) and \`pipeline._set_busy_timeout\` (was 10_000ms literal default) now pull from it. Pre-fix, same DB opened via the two paths had asymmetric lock-wait behaviour — one gave up at 5s, the other at 10s — surfacing as sporadic "database is locked" errors under concurrent ingest + MCP search load. \`_set_busy_timeout\`'s default is now \`None\`, so the constant is pulled at CALL time (no stale literal that could drift again).
- **F38 (#39, low):** \`Memory.add("")\` / \`Memory.add("   \\t\\n  ")\` now emits a \`UserWarning\` and returns a skip-marker (\`{"id": None, "content": <input>, "user_id": ..., "created_at": None}\`). Pre-fix, empty/whitespace-only content silently inserted a useless row that inflated \`stats().message_count\` — painful for callers passing parsed-transcript or partial-JSON content. Per the finding's "What NOT to do": warn (don't raise) so batch callers can continue, and don't trim silently (content with real text + surrounding whitespace is stored as-passed).

## Test plan
- [x] pytest: **230 passed / 1 skipped** (baseline 212 after #56 merge + 18 new regression locks).
- [x] \`ruff check truememory/ tests/\` — clean.
- [x] \`tests/test_memory_api_safety.py\` (18 cases):
  - **F35 — shared-constant check**: verify \`DEFAULT_BUSY_TIMEOUT_MS == 10_000\`; \`create_db\` actually applies it (\`PRAGMA busy_timeout\` readback matches); pipeline helper signature has \`timeout_ms=None\` default (no literal); end-to-end call of \`_set_busy_timeout(memory)\` overwrites a seeded low value with the shared constant.
  - **F38 — empty content**: warn + skip-marker for \`""\`, whitespace-only, \`None\`; stats excludes skipped; real content still works; content with surrounding whitespace is STORED as-passed (not trimmed); skip-marker preserves user_id for batch-caller correlation; parameterized sweep over \`"", " ", "\\t", "\\n", "\\r\\n"\`, etc.

## What NOT to do — adherence
- F35: did NOT change just one literal and leave the other (would drift again); kept the pipeline helper's \`timeout_ms\` override capability for future callers.
- F38: did NOT raise on empty content; did NOT silently trim; did NOT suppress the warning (surface it so caller can decide).

Hunter findings: F35 (#12), F38 (#39). See \`_working/HUNTER_FINDINGS.md\`.