### PR TITLE
medium: align __all__ with __init__.py re-exports (F37 — Phased PR)

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,187 @@
+"""Regression lock for Hunter F37 — `__all__` must enumerate the actual
+re-exports in `truememory/__init__.py`.
+
+Pre-fix, `__all__` declared 3 symbols while the package re-exported 79;
+IDE auto-import, Sphinx autodoc, and `from truememory import *` all saw
+a misleadingly small public API. This file locks the expanded list in
+place so future re-exports can't silently drift again.
+
+The contract:
+- Every non-underscore name exposed at the top of `truememory` is in
+  `__all__`.
+- `__all__` has no dead entries (every name resolves).
+- `from truememory import *` surfaces exactly the set declared by `__all__`.
+"""
+from __future__ import annotations
+
+
+def _public_names_of_truememory() -> set[str]:
+    """Names available on the top-level `truememory` module that are
+    treated as public (don't start with an underscore).
+
+    Python's `__version__` convention lives in `__all__` but is filtered
+    out by this helper because it starts with `_`. Tests handle it
+    explicitly.
+
+    Uses a fresh subprocess so other tests that imported `truememory.ingest`
+    or `truememory.mcp_server` don't pollute the `dir()` (Python registers
+    submodule imports on the parent package — a real "fresh install"
+    `import truememory` doesn't see them until they're explicitly accessed).
+    """
+    import subprocess
+    import sys
+    import json as _json
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, truememory\n"
+                "print(json.dumps([n for n in dir(truememory) "
+                "if not n.startswith('_')]))"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed: {result.stderr}"
+    )
+    return set(_json.loads(result.stdout.strip()))
+
+
+def test_all_is_declared_as_a_list_of_strings():
+    import truememory
+    assert hasattr(truememory, "__all__")
+    assert isinstance(truememory.__all__, list)
+    assert all(isinstance(n, str) for n in truememory.__all__)
+    # No duplicates (would mask drift during maintenance)
+    assert len(truememory.__all__) == len(set(truememory.__all__)), (
+        "F37 regression: duplicate entries in __all__"
+    )
+
+
+def test_all_entries_resolve_to_real_attributes():
+    """Every name in `__all__` must actually exist on the module —
+    dead entries would confuse autodoc and IDE tooling."""
+    import truememory
+    missing = [n for n in truememory.__all__ if not hasattr(truememory, n)]
+    assert missing == [], (
+        f"F37 regression: __all__ declares names that don't exist on the "
+        f"module: {missing}"
+    )
+
+
+def test_no_public_drift_between_dir_and_all():
+    """Every non-underscore name in `dir(truememory)` must be in `__all__`.
+
+    This is the primary F37 invariant. If a contributor adds
+    `from truememory.newmod import frob` to `__init__.py`, they must
+    also add `"frob"` to `__all__`, or this test fails loudly.
+    """
+    import truememory
+    public = _public_names_of_truememory()
+    declared = set(truememory.__all__)
+    # `__version__` is in __all__ but not in `public` because it starts
+    # with underscore. That's the ONE exception.
+    drift_in_public_not_declared = public - declared
+    assert drift_in_public_not_declared == set(), (
+        f"F37 regression: {len(drift_in_public_not_declared)} public name(s) "
+        f"exposed by truememory/__init__.py are NOT in __all__. Either add "
+        f"them to __all__ or move the import out of __init__.py. "
+        f"Missing: {sorted(drift_in_public_not_declared)}"
+    )
+
+
+def test_all_minus_version_equals_public_dir_set():
+    """The inverse check: `__all__` must not declare names that don't
+    actually appear in `dir()` (bar `__version__`). A declared-but-
+    not-exposed name means a typo or a stale entry."""
+    import truememory
+    public = _public_names_of_truememory()
+    declared = set(truememory.__all__)
+    declared_minus_version = declared - {"__version__"}
+    extra = declared_minus_version - public
+    assert extra == set(), (
+        f"F37 regression: __all__ declares non-underscore names that aren't "
+        f"actually exposed: {sorted(extra)}"
+    )
+
+
+def test_star_import_surfaces_exactly_all():
+    """`from truememory import *` must surface exactly the `__all__` set.
+
+    Runs in a subprocess so other tests' lazy submodule imports
+    (`truememory.ingest`, `truememory.mcp_server`) don't pollute the
+    result — `import *` would pick those up otherwise even though they're
+    intentionally not in `__all__`.
+    """
+    import subprocess
+    import sys
+    import json as _json
+    import truememory
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, truememory\n"
+                "ns = {}\n"
+                "exec('from truememory import *', ns)\n"
+                "print(json.dumps([k for k in ns if k != '__builtins__']))"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    star = set(_json.loads(result.stdout.strip()))
+    expected = set(truememory.__all__)
+    assert star == expected, (
+        f"F37 regression: `from truememory import *` surfaced {len(star)} "
+        f"names but __all__ has {len(expected)}. "
+        f"Surfaced-not-declared: {sorted(star - expected)}. "
+        f"Declared-not-surfaced: {sorted(expected - star)}."
+    )
+
+
+def test_core_symbols_present():
+    """Sanity: the three originally-declared names must still be in `__all__`."""
+    import truememory
+    for n in ("__version__", "Memory", "TrueMemoryEngine"):
+        assert n in truememory.__all__, f"F37 regression: {n!r} dropped from __all__"
+
+
+def test_submodules_accessible_via_star_import():
+    """Submodule names were listed in __all__ specifically so that
+    `from truememory import vector_search` works under `import *`
+    semantics. Verify those submodules resolve to the expected packages."""
+    import truememory
+    submodules = [
+        "client", "engine", "storage", "vector_search", "fts_search",
+        "hybrid", "temporal", "salience", "personality", "consolidation",
+        "predictive", "query_classifier", "reranker", "hyde", "clustering",
+    ]
+    for m in submodules:
+        assert m in truememory.__all__
+        assert hasattr(truememory, m)
+        mod = getattr(truememory, m)
+        assert mod.__name__ == f"truememory.{m}", (
+            f"F37 regression: truememory.{m} doesn't resolve to the package"
+        )
+
+
+def test_ingest_submodule_is_intentionally_lazy():
+    """`truememory.ingest` is NOT in `__all__` — it's a lazy import via
+    `__getattr__`. Confirm the public contract: attribute access works,
+    but `import *` does NOT pull it in."""
+    import truememory
+    # Access via attribute works (triggers __getattr__ lazy-load)
+    ingest = truememory.ingest
+    assert ingest.__name__ == "truememory.ingest"
+    # But it's NOT in __all__, so `import *` must NOT surface it
+    assert "ingest" not in truememory.__all__

--- a/truememory/__init__.py
+++ b/truememory/__init__.py
@@ -62,10 +62,59 @@ from truememory.hyde import (
 from truememory.clustering import cluster_messages, search_clustered, get_cluster_info
 from truememory.engine import TrueMemoryEngine
 
+# Hunter F37: `__all__` must enumerate every name __init__.py re-exports.
+# Pre-fix, only 3 of ~79 public names were declared — IDE auto-import,
+# Sphinx autodoc, and `from truememory import *` all saw a misleadingly
+# small public API surface. Entries here are grouped to match the
+# import block above; any new re-export must be added here at the same
+# time (enforced by `tests/test_public_api.py::test_no_public_drift`).
 __all__ = [
+    # Version + core
     "__version__",
     "Memory",
     "TrueMemoryEngine",
+    # Storage
+    "create_db",
+    "load_messages", "load_messages_from_file",
+    "insert_message", "delete_message", "update_message",
+    "get_message", "get_message_count",
+    # FTS
+    "search_fts", "search_fts_by_sender", "search_fts_in_range",
+    # Vector search
+    "init_vec_table", "build_vectors", "search_vector",
+    "build_separation_vectors", "search_vector_separation", "embed_single",
+    # Hybrid / RRF
+    "search_hybrid", "reciprocal_rank_fusion",
+    # Temporal
+    "detect_temporal_intent", "parse_date_reference", "search_temporal",
+    "get_timeline", "detect_episodes", "get_episode_messages",
+    "expand_to_episodes", "detect_landmark_events",
+    # Salience
+    "apply_salience_guard", "compute_message_salience", "detect_entities",
+    # Personality
+    "build_entity_profiles", "extract_preferences", "search_personality",
+    "get_entity_profile", "get_communication_pattern",
+    "resolve_entity", "build_dunbar_hierarchy",
+    # Consolidation
+    "build_entity_timelines", "detect_contradictions", "build_summaries",
+    "search_contradictions", "search_consolidated",
+    "build_entity_summary_sheets", "build_structured_facts",
+    # Predictive
+    "compute_surprise_score", "extract_facts", "build_surprise_index",
+    "get_high_surprise_messages",
+    # Query classifier
+    "classify_query", "get_search_mode", "QUERY_TYPES", "DEFAULT_WEIGHTS",
+    # Reranker
+    "rerank", "rerank_with_fusion", "get_reranker",
+    # HyDE
+    "hyde_search", "hyde_multi_search",
+    "generate_hypothetical_doc", "generate_multi_hypothetical_docs",
+    # Clustering
+    "cluster_messages", "search_clustered", "get_cluster_info",
+    # Submodules (explicit access: `from truememory import vector_search`)
+    "client", "engine", "storage", "vector_search", "fts_search",
+    "hybrid", "temporal", "salience", "personality", "consolidation",
+    "predictive", "query_classifier", "reranker", "hyde", "clustering",
 ]
 
 


### PR DESCRIPTION
Closes #37.

Hunter F37 — **Phased PR** per Josh's doctrine (public API surface). Shipping **Option 1** from the finding (expand \`__all__\`) rather than Option 2 (shrink re-exports), since Option 2 would be a breaking change needing a deprecation cycle and the finding's "What NOT to do" explicitly forbids it.

## Summary
Pre-fix state (runtime-verified with the finding's repro):
\`\`\`
__all__ size: 3
public attrs: 79
missing from __all__: 76
\`\`\`
\`from truememory import *\` only surfaced 3 names; autodoc, IDE auto-import, and type-checkers saw a misleadingly small public API. This PR expands \`__all__\` to enumerate every re-exported name: 80 total (3 core + 62 functions + 15 submodules), grouped by source module to mirror the import block.

Post-fix runtime check:
\`\`\`
__all__ size: 80
public attrs: 79
drift (public not declared): []
drift (declared not public): ['__version__']   # filtered by underscore
\`\`\`

## What this PR does NOT do
- Does not shrink the re-export set (Option 2 — breaking, deferred).
- Does not touch \`truememory.ingest\` (has its own \`__init__.py\` lazy-loader; the test explicitly verifies \`ingest\` stays out of \`__all__\` to preserve the lazy contract).
- Does not rearrange imports.

## Test plan
- [x] pytest: **238 passed / 1 skipped** (baseline 230 after #57 merge + 8 new).
- [x] \`ruff check truememory/ tests/\` — clean.
- [x] \`python -m build && twine check --strict\` — PASSED.
- [x] \`tests/test_public_api.py\` (8 cases):
  - \`__all__\` is a list of unique strings (no dupes).
  - Every \`__all__\` entry resolves to a real attribute (no dead entries).
  - \`test_no_public_drift_between_dir_and_all\` — runs in **subprocess** so earlier tests' lazy \`truememory.ingest\` / \`mcp_server\` loads don't pollute the check. Verifies a fresh \`import truememory\`'s \`dir()\` set matches \`__all__\` exactly.
  - \`test_all_minus_version_equals_public_dir_set\` — the inverse check (no stale/typo entries).
  - \`test_star_import_surfaces_exactly_all\` — also subprocess-isolated, runs \`exec("from truememory import *", ns)\` and asserts equality.
  - \`test_core_symbols_present\` — the three originally-declared names are still in \`__all__\`.
  - \`test_submodules_accessible_via_star_import\` — all 15 declared submodules resolve to \`truememory.<name>\`.
  - \`test_ingest_submodule_is_intentionally_lazy\` — \`truememory.ingest\` works via attribute access (\`__getattr__\`) but is NOT in \`__all__\`.

## Phase audit
Entry appended to \`_working/PHASE_AUDIT_LOG.md\` (gitignored). Rustle-the-feathers will verify before merge.

## Notes for rustle
- The test-ordering gotcha (Python registering imported submodules on the parent package) is why two of the three drift-detection tests run in a subprocess. The third (\`test_all_entries_resolve_to_real_attributes\`) runs in-process because it tests the opposite direction (\`hasattr\` lookup, not \`dir()\` enumeration).
- Why \`__version__\` is in \`__all__\` but filtered out of \`public\` in the helpers: it starts with an underscore. Python's convention since forever; tests handle it explicitly with \`declared - {"__version__"}\` subtraction.

Hunter audit finding: F37 (#37). See \`_working/HUNTER_FINDINGS.md\`.