### PR TITLE
nit: rename load_messages → bulk_replace_messages with deprecation shim (F34 — last finding)

### DIFF
--- a/tests/test_load_messages_rename.py
+++ b/tests/test_load_messages_rename.py
@@ -1,0 +1,173 @@
+"""Regression lock for Hunter F34 — `load_messages` → `bulk_replace_messages`
+rename with a deprecated alias.
+
+Pre-fix, `load_messages` (destructive: DELETE then INSERT) shared the
+naming convention with `insert_message` (appending). A caller writing
+`load_messages(conn, [new_msg])` believing it appended destroyed their
+DB. The destructive semantics now live under `bulk_replace_messages`;
+`load_messages` is preserved for one release as a deprecated alias.
+"""
+from __future__ import annotations
+
+import warnings
+
+
+def _make_db(tmp_path):
+    from truememory.storage import create_db
+    return create_db(tmp_path / "t.db")
+
+
+def _sample_messages(n=3):
+    return [
+        {"content": f"msg {i}", "sender": "alice", "recipient": "bob"}
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# bulk_replace_messages — the non-deprecated API
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_replace_messages_is_public():
+    """The new name must be importable from `truememory` AND
+    `truememory.storage`, and be in `truememory.__all__`."""
+    import truememory
+    from truememory.storage import bulk_replace_messages as from_storage
+    from truememory import bulk_replace_messages as from_top
+    assert from_top is from_storage
+    assert "bulk_replace_messages" in truememory.__all__
+
+
+def test_bulk_replace_messages_inserts_without_warning(tmp_path):
+    conn = _make_db(tmp_path)
+    from truememory.storage import bulk_replace_messages, get_message_count
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            n = bulk_replace_messages(conn, _sample_messages(3))
+        # No DeprecationWarning on the new name
+        dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert dep_warnings == []
+        assert n == 3
+        assert get_message_count(conn) == 3
+    finally:
+        conn.close()
+
+
+def test_bulk_replace_messages_is_destructive(tmp_path):
+    """The core invariant: bulk_replace WIPES existing rows before insert."""
+    conn = _make_db(tmp_path)
+    from truememory.storage import bulk_replace_messages, get_message_count
+    try:
+        bulk_replace_messages(conn, _sample_messages(5))
+        assert get_message_count(conn) == 5
+        # Second call wipes the first batch
+        bulk_replace_messages(conn, _sample_messages(2))
+        assert get_message_count(conn) == 2
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# load_messages — deprecated alias
+# ---------------------------------------------------------------------------
+
+
+def test_load_messages_emits_deprecation_warning(tmp_path):
+    """The old name must still work but emit DeprecationWarning. Callers
+    migrating in the deprecation window should see the hint in their
+    CI / test logs."""
+    conn = _make_db(tmp_path)
+    from truememory.storage import load_messages
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            load_messages(conn, _sample_messages(2))
+        dep_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert len(dep_warnings) == 1
+        msg = str(dep_warnings[0].message)
+        # Must name the replacement function
+        assert "bulk_replace_messages" in msg
+        # Must also hint at insert_message for the append case
+        assert "insert_message" in msg
+    finally:
+        conn.close()
+
+
+def test_load_messages_same_behavior_as_bulk_replace(tmp_path):
+    """The deprecated alias must produce identical final state."""
+    from truememory.storage import bulk_replace_messages, load_messages, get_message_count
+
+    # Run via the new name
+    (tmp_path / "a").mkdir()
+    conn_a = _make_db(tmp_path / "a")
+    try:
+        bulk_replace_messages(conn_a, _sample_messages(4))
+        count_new = get_message_count(conn_a)
+    finally:
+        conn_a.close()
+
+    # Run via the deprecated alias (suppress the warning for this assertion)
+    (tmp_path / "b").mkdir()
+    conn_b = _make_db(tmp_path / "b")
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            load_messages(conn_b, _sample_messages(4))
+        count_old = get_message_count(conn_b)
+    finally:
+        conn_b.close()
+
+    assert count_old == count_new == 4
+
+
+def test_load_messages_from_file_does_not_emit_deprecation(tmp_path):
+    """`load_messages_from_file` is NOT deprecated — its internal impl
+    was rewired to call `bulk_replace_messages` directly so users who
+    never called the bare `load_messages` don't see our own
+    DeprecationWarning bleeding into their logs."""
+    import json as _json
+    conn = _make_db(tmp_path)
+    data_path = tmp_path / "msgs.json"
+    data_path.write_text(_json.dumps(_sample_messages(3)))
+
+    from truememory.storage import load_messages_from_file
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            n = load_messages_from_file(conn, data_path)
+        dep_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert dep_warnings == [], (
+            "F34 regression: load_messages_from_file is emitting a "
+            "DeprecationWarning because it's still calling the deprecated "
+            "load_messages internally. Rewire it to call bulk_replace_messages."
+        )
+        assert n == 3
+    finally:
+        conn.close()
+
+
+def test_load_messages_stacklevel_attributes_to_caller(tmp_path):
+    """`stacklevel=2` in the deprecation warning means the warning's
+    filename points at the CALLER, not at storage.py. This makes the
+    migration hint actionable — users see their own code in the
+    warning line, not a library internal."""
+    conn = _make_db(tmp_path)
+    from truememory.storage import load_messages
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            load_messages(conn, _sample_messages(1))
+        dep_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert len(dep_warnings) == 1
+        # Filename should be the test file (caller), not storage.py
+        assert "test_load_messages_rename.py" in dep_warnings[0].filename
+    finally:
+        conn.close()

--- a/truememory/__init__.py
+++ b/truememory/__init__.py
@@ -30,7 +30,7 @@ __version__ = "0.4.0"
 
 from truememory.client import Memory
 from truememory.storage import (
-    create_db, load_messages, load_messages_from_file,
+    create_db, bulk_replace_messages, load_messages, load_messages_from_file,
     insert_message, delete_message, update_message,
     get_message, get_message_count,
 )
@@ -75,7 +75,8 @@ __all__ = [
     "TrueMemoryEngine",
     # Storage
     "create_db",
-    "load_messages", "load_messages_from_file",
+    "bulk_replace_messages",  # F34: non-deprecated name for load_messages
+    "load_messages", "load_messages_from_file",  # load_messages: DEPRECATED alias
     "insert_message", "delete_message", "update_message",
     "get_message", "get_message_count",
     # FTS

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -191,12 +191,14 @@ def create_db(db_path: str | Path) -> sqlite3.Connection:
 # Message loading
 # ---------------------------------------------------------------------------
 
-def load_messages(conn: sqlite3.Connection, messages: list[dict]) -> int:
+def bulk_replace_messages(conn: sqlite3.Connection, messages: list[dict]) -> int:
     """
-    Bulk-load messages into the database.
+    Replace every row in ``messages`` with the provided list (destructive).
 
-    Clears all existing message data (messages + FTS index) before inserting,
-    so the database reflects exactly the provided list afterwards.
+    **DESTRUCTIVE:** Clears all existing message data (messages + FTS index)
+    before inserting, so the database reflects exactly the provided list
+    afterwards. If you want to append without wiping, use
+    :func:`insert_message` per-row.
 
     Each dict in *messages* should have at minimum a ``content`` key.
     Optional keys: ``sender``, ``recipient``, ``timestamp``, ``category``,
@@ -237,12 +239,35 @@ def load_messages(conn: sqlite3.Connection, messages: list[dict]) -> int:
     return len(messages)
 
 
+def load_messages(conn: sqlite3.Connection, messages: list[dict]) -> int:
+    """Deprecated alias for :func:`bulk_replace_messages`.
+
+    Hunter F34: the original name ``load_messages`` paralleled
+    ``insert_message`` (non-destructive) but actually WIPES the table
+    before inserting. Callers writing ``load_messages(conn, [new_msg])``
+    believing it appended silently destroyed their DB. The destructive
+    semantics now live under ``bulk_replace_messages``; this alias is
+    preserved for one release with a ``DeprecationWarning``.
+    """
+    import warnings
+    warnings.warn(
+        "`load_messages` is a deprecated alias for "
+        "`bulk_replace_messages` (which makes the destructive semantics "
+        "explicit). This alias will be removed in a future release — "
+        "migrate to `bulk_replace_messages` for the same behaviour, or "
+        "use `insert_message` per-row if you actually want to append.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return bulk_replace_messages(conn, messages)
+
+
 def load_messages_from_file(conn: sqlite3.Connection, json_path: str | Path) -> int:
     """
-    Load messages from a JSON file into the database.
+    Load messages from a JSON file into the database (destructive — wipes first).
 
     The file must contain a JSON array of message objects (same format as
-    :func:`load_messages`).
+    :func:`bulk_replace_messages`).
 
     Args:
         conn:      Open database connection.
@@ -255,7 +280,9 @@ def load_messages_from_file(conn: sqlite3.Connection, json_path: str | Path) -> 
     with open(path, "r", encoding="utf-8") as f:
         messages = json.load(f)
 
-    return load_messages(conn, messages)
+    # Use the non-deprecated name internally so we don't emit our own
+    # DeprecationWarning to users who never called `load_messages`.
+    return bulk_replace_messages(conn, messages)
 
 
 # ---------------------------------------------------------------------------
@@ -379,8 +406,8 @@ def insert_message(conn: sqlite3.Connection, msg: dict) -> int:
     """
     Insert a single message without clearing existing data.
 
-    Unlike :func:`load_messages`, this appends to the database — it does NOT
-    wipe existing messages.  The FTS5 INSERT trigger keeps the full-text
+    Unlike :func:`bulk_replace_messages`, this appends to the database —
+    it does NOT wipe existing messages.  The FTS5 INSERT trigger keeps the full-text
     index in sync automatically.
 
     Args:


### PR DESCRIPTION
Closes #38.

**Hunter F34 — the final finding in the v1 backlog.** This PR closes the 40th of 40 issues.

## Summary
Pre-fix, \`storage.load_messages(conn, messages)\` was destructive (DELETE → INSERT) but its name paralleled the non-destructive \`insert_message\`. A caller writing \`load_messages(conn, [new_msg])\` believing it appended silently destroyed their DB. The destructive semantics now live under \`bulk_replace_messages\` — the verb makes the wipe explicit.

- **\`bulk_replace_messages(conn, messages)\`** — new name, identical behaviour to the old \`load_messages\`. Added to \`__all__\`.
- **\`load_messages\`** — preserved for one release as a deprecated alias that calls \`bulk_replace_messages\` and emits \`DeprecationWarning\`. \`stacklevel=2\` so the warning filename points at the caller, not at storage.py. The warning text cites both the new name AND \`insert_message\` (the actual trap the old name set — "if you wanted append, use insert_message").
- **\`load_messages_from_file\`** — docstring marks it "destructive — wipes first"; internal call rewired to \`bulk_replace_messages\` so users who never typed bare \`load_messages\` don't see our DeprecationWarning bleeding into their logs.
- **\`insert_message\`** docstring now cross-references \`bulk_replace_messages\` instead of the deprecated name.
- **\`truememory.__init__.py\`** re-exports both; the \`__all__\` entry for \`load_messages\` has a comment marking it DEPRECATED so the F37-locked public-API list flags it.

## What NOT to do — adherence
- Did NOT rename without a deprecation alias (finding's explicit "don't break callers in benchmark scripts + tests").
- Did NOT repurpose \`load_messages\` for an appending variant (finding: "it's the function-naming inverse").

## Test plan
- [x] pytest: **245 passed / 1 skipped** (baseline 238 after #58 merge + 7 new F34 regression locks).
- [x] \`ruff check truememory/ tests/\` — clean.
- [x] F37 public-API test still passes (new \`bulk_replace_messages\` added to \`__all__\`; old \`load_messages\` kept in \`__all__\` with comment marker).
- [x] \`tests/test_load_messages_rename.py\` (7 cases):
  - New name is importable from \`truememory\` top-level + \`truememory.storage\`; present in \`__all__\`.
  - New name produces no DeprecationWarning.
  - New name is destructive (wipes on second call).
  - Old name emits exactly one DeprecationWarning citing both \`bulk_replace_messages\` and \`insert_message\`.
  - Both names produce identical final state (row count parity).
  - **Critical regression**: \`load_messages_from_file\` does NOT emit DeprecationWarning (proves the internal rewire to bulk_replace_messages held).
  - \`stacklevel=2\` attributes the warning filename to the caller, not storage.py (makes migration hint actionable).

## Milestone — Hunter v1 backlog complete

After this merges, all 40 Hunter findings from the v0.4.0-release audit are closed. \`_working/FIXER_JOURNAL.md\` documents every PR with SHA + classification + rustle result. Repo is ready for a v0.4.1 or v0.5.0 release (your call).

Hunter audit finding: F34 (#38). See \`_working/HUNTER_FINDINGS.md\`.