### PR TITLE
feat(retrieval): wire L5 surprise signal into post-rerank boost (opt-in, α=0 default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.6.0] — 2026-04-XX
+
+### Added
+- **L5 predictive-coder retrieval boost** wired through both
+  `Memory.search()` and `Memory.search_deep()`. Multiplicatively
+  reweights candidates by `(1 + α · surprise)` using the
+  already-populated `surprise_scores` table. Opt-in via the
+  `alpha_surprise=` kwarg on `Memory(...)` or the
+  `TRUEMEMORY_ALPHA_SURPRISE` env var. **Default α=0 (off)** pending
+  Modal validation at p<0.05 per MEMORIST-L5 research session
+  (2026-04-23). See `_working/memorist/l5_predictive/REPORT.md` §9.
+
+  Notes:
+  - The env-var name diverges from the research spec's
+    `L5_SURPRISE_ALPHA` to stay consistent with the existing
+    `TRUEMEMORY_*` naming convention.
+  - The boost is applied BEFORE the cross-encoder rerank in
+    `search_agentic()`, so it survives downstream LLM reranking
+    (which otherwise overwrites the `score` field).
+  - Non-finite env values (`inf`, `nan`, `-inf`) resolve to 0.0 with
+    a warning.
+
 ## [0.5.0] - 2026-04-23
 
 Post-v0.4.0 hardening release. 40 findings closed from a structured audit ("Hunter v1" — see tracker #44), shipped across 11 PRs + 3 direct-to-main commits. v0.4.0 was a code-only tier-realignment release that never reached PyPI; v0.5.0 is the first published release to include it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,24 +3,10 @@
 ## [0.6.0] — 2026-04-XX
 
 ### Added
-- **L5 predictive-coder retrieval boost** wired through both
-  `Memory.search()` and `Memory.search_deep()`. Multiplicatively
-  reweights candidates by `(1 + α · surprise)` using the
-  already-populated `surprise_scores` table. Opt-in via the
-  `alpha_surprise=` kwarg on `Memory(...)` or the
-  `TRUEMEMORY_ALPHA_SURPRISE` env var. **Default α=0 (off)** pending
-  Modal validation at p<0.05 per MEMORIST-L5 research session
-  (2026-04-23). See `_working/memorist/l5_predictive/REPORT.md` §9.
-
-  Notes:
-  - The env-var name diverges from the research spec's
-    `L5_SURPRISE_ALPHA` to stay consistent with the existing
-    `TRUEMEMORY_*` naming convention.
-  - The boost is applied BEFORE the cross-encoder rerank in
-    `search_agentic()`, so it survives downstream LLM reranking
-    (which otherwise overwrites the `score` field).
-  - Non-finite env values (`inf`, `nan`, `-inf`) resolve to 0.0 with
-    a warning.
+- **L5 surprise rerank boost** — retrieval now reweights candidates by
+  `(1 + α · surprise)` using the `surprise_scores` table populated at
+  ingest. Default α=0.3. Override via `Memory(alpha_surprise=…)` or
+  `TRUEMEMORY_ALPHA_SURPRISE` env var. Set to `0` to disable.
 
 ## [0.5.0] - 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ uvx creates a cached environment on first run; subsequent spawns are fast. Good 
 
 ---
 
+## ⚙️ Configuration
+
+- `TRUEMEMORY_ALPHA_SURPRISE` (or `Memory(alpha_surprise=0.3)`) — opt-in L5 surprise rerank boost. Default `0.0` (off). See CHANGELOG v0.6.0 for rationale.
+
+---
+
 ## 📊 Full Benchmark Details
 
 Every benchmark script is self-contained and runs on [Modal](https://modal.com).

--- a/README.md
+++ b/README.md
@@ -210,12 +210,6 @@ uvx creates a cached environment on first run; subsequent spawns are fast. Good 
 
 ---
 
-## ⚙️ Configuration
-
-- `TRUEMEMORY_ALPHA_SURPRISE` (or `Memory(alpha_surprise=0.3)`) — opt-in L5 surprise rerank boost. Default `0.0` (off). See CHANGELOG v0.6.0 for rationale.
-
----
-
 ## 📊 Full Benchmark Details
 
 Every benchmark script is self-contained and runs on [Modal](https://modal.com).

--- a/tests/test_l5_surprise_rerank.py
+++ b/tests/test_l5_surprise_rerank.py
@@ -17,9 +17,6 @@ after Modal validation at p<0.05. See
 """
 from __future__ import annotations
 
-import os
-import sqlite3
-from unittest.mock import patch
 
 import pytest
 
@@ -285,3 +282,246 @@ def test_alpha_zero_skips_db_query(engine_with_surprise):
         assert [r["id"] for r in boosted] == [1, 2]
     finally:
         eng.conn = real_conn
+
+
+# ── MEMORIST-L5 PR 76 fix-pass regression tests ───────────────────────────
+
+def test_search_default_path_applies_boost(tmp_path, monkeypatch):
+    """Regression: the default Memory.search() path now applies the
+    L5 surprise boost. Previously only search_agentic() was wired."""
+    monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "0.3")
+
+    from truememory.engine import TrueMemoryEngine
+    from truememory.storage import create_db
+
+    db_path = tmp_path / "default_path.db"
+    conn = create_db(db_path)
+    for i in range(1, 6):
+        conn.execute(
+            "INSERT INTO messages (content, sender, recipient, timestamp, "
+            "category, modality) VALUES (?, 'alice', 'bob', ?, 'session_1', "
+            "'conversation')",
+            (f"alpha topic {i}", f"2026-0{i}-01T10:00:00Z"),
+        )
+    conn.commit()
+    conn.close()
+
+    eng = TrueMemoryEngine(db_path)
+    eng.open(rebuild_vectors=False)
+
+    calls: list[int] = []
+    real_boost = eng._apply_surprise_boost
+
+    def spy(results):
+        calls.append(len(results))
+        return real_boost(results)
+
+    eng._apply_surprise_boost = spy
+    eng.search("alpha", limit=5)
+
+    assert len(calls) >= 1, (
+        "Memory.search() default path must invoke _apply_surprise_boost "
+        "(was previously bypassed — only search_agentic was wired)."
+    )
+
+
+def test_alpha_zero_byte_identical_through_pipeline(tmp_path, monkeypatch):
+    """At α=0 the boost is a no-op regardless of whether the env var
+    is unset or explicitly '0'. _apply_surprise_boost must produce
+    identical id-order AND identical scores."""
+    from truememory.engine import TrueMemoryEngine
+    from truememory.storage import create_db
+
+    db_path = tmp_path / "azero.db"
+    create_db(db_path).close()
+    eng = TrueMemoryEngine(db_path)
+    eng.open(rebuild_vectors=False)
+
+    sample = _fake_results([(1, 0.9), (2, 0.8), (3, 0.7), (4, 0.6), (5, 0.5)])
+
+    monkeypatch.delenv("TRUEMEMORY_ALPHA_SURPRISE", raising=False)
+    r_unset = eng._apply_surprise_boost([dict(r) for r in sample])
+
+    monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "0")
+    r_zero = eng._apply_surprise_boost([dict(r) for r in sample])
+
+    assert [(r["id"], r["score"]) for r in r_unset] == [
+        (r["id"], r["score"]) for r in sample
+    ]
+    assert [(r["id"], r["score"]) for r in r_zero] == [
+        (r["id"], r["score"]) for r in sample
+    ]
+
+
+def test_composite_source_refined_is_excluded(engine_with_surprise):
+    """`personality+refined` (round-2 refined-queries loop) must be
+    filtered out of the boost set; `fts+refined` must NOT be."""
+    eng = engine_with_surprise
+    eng._alpha_surprise_override = 0.5
+
+    rows = [
+        {"id": 5, "content": "x", "score": 1.0, "source": "personality+refined"},
+        {"id": 4, "content": "y", "score": 1.0, "source": "fts+refined"},
+    ]
+    boosted = eng._apply_surprise_boost(rows)
+
+    by_source = {r["source"]: r for r in boosted}
+    assert by_source["personality+refined"]["score"] == 1.0, (
+        "Composite source containing 'personality' must NOT be boosted "
+        "— its id is not a messages.id."
+    )
+    assert by_source["fts+refined"]["score"] > 1.0, (
+        "Composite source 'fts+refined' should still receive the boost."
+    )
+
+
+def test_precedence_chain_in_one_function(monkeypatch, tmp_path):
+    """Verify constructor > env-var > default precedence in one shot."""
+    from truememory.engine import TrueMemoryEngine
+    from truememory.storage import create_db
+
+    # (1) No env, no override -> 0.0
+    monkeypatch.delenv("TRUEMEMORY_ALPHA_SURPRISE", raising=False)
+    create_db(tmp_path / "a.db").close()
+    engine = TrueMemoryEngine(tmp_path / "a.db")
+    engine.open(rebuild_vectors=False)
+    assert engine._get_alpha_surprise() == 0.0
+
+    # (2) Env=0.3, no override -> 0.3
+    monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "0.3")
+    create_db(tmp_path / "b.db").close()
+    engine = TrueMemoryEngine(tmp_path / "b.db")
+    engine.open(rebuild_vectors=False)
+    assert engine._get_alpha_surprise() == 0.3
+
+    # (3) Env=0.3, override=0.7 -> 0.7 (override wins)
+    create_db(tmp_path / "c.db").close()
+    engine = TrueMemoryEngine(tmp_path / "c.db", alpha_surprise=0.7)
+    engine.open(rebuild_vectors=False)
+    assert engine._get_alpha_surprise() == 0.7
+
+    # (4) Env=0.3, override=0.0 -> 0.0 (explicit override wins even at 0)
+    create_db(tmp_path / "d.db").close()
+    engine = TrueMemoryEngine(tmp_path / "d.db", alpha_surprise=0.0)
+    engine.open(rebuild_vectors=False)
+    assert engine._get_alpha_surprise() == 0.0
+
+
+@pytest.mark.parametrize("bad_value", ["inf", "-inf", "nan", "1e400"])
+def test_non_finite_alpha_falls_back_to_zero(
+    bad_value, tmp_path, monkeypatch, caplog,
+):
+    """inf, -inf, nan, and overflow-to-inf literals must resolve to 0.0
+    with a logged warning."""
+    import logging
+
+    from truememory.engine import TrueMemoryEngine
+    from truememory.storage import create_db
+
+    monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", bad_value)
+    create_db(tmp_path / "nf.db").close()
+    engine = TrueMemoryEngine(tmp_path / "nf.db")
+    engine.open(rebuild_vectors=False)
+
+    with caplog.at_level(logging.WARNING, logger="truememory.engine"):
+        assert engine._get_alpha_surprise() == 0.0
+
+    assert any(
+        "TRUEMEMORY_ALPHA_SURPRISE" in rec.message
+        for rec in caplog.records
+        if rec.levelname == "WARNING"
+    ), f"expected WARNING for {bad_value!r}"
+
+
+@pytest.mark.parametrize("neg_value", ["-0.5", "-1"])
+def test_negative_alpha_clamps_to_zero(neg_value, tmp_path, monkeypatch):
+    """Negative α (env or constructor) clamps to 0.0 silently."""
+    from truememory.engine import TrueMemoryEngine
+    from truememory.storage import create_db
+
+    monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", neg_value)
+    create_db(tmp_path / "neg.db").close()
+    engine = TrueMemoryEngine(tmp_path / "neg.db")
+    engine.open(rebuild_vectors=False)
+    assert engine._get_alpha_surprise() == 0.0
+
+
+def test_boost_applies_without_reranker(tmp_path, monkeypatch):
+    """When the cross-encoder reranker is unavailable, the boost must
+    STILL fire on primary_results in search_agentic — previously the
+    boost was gated on `use_reranker AND _has_reranker`."""
+    monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "0.3")
+
+    from truememory.engine import TrueMemoryEngine
+    from truememory.storage import create_db
+
+    db_path = tmp_path / "no_reranker.db"
+    conn = create_db(db_path)
+    for i in range(1, 4):
+        conn.execute(
+            "INSERT INTO messages (content, sender, recipient, timestamp, "
+            "category, modality) VALUES (?, 'alice', 'bob', ?, 'session_1', "
+            "'conversation')",
+            (f"beta topic {i}", f"2026-0{i}-01T10:00:00Z"),
+        )
+    conn.commit()
+    conn.close()
+
+    eng = TrueMemoryEngine(db_path)
+    eng.open(rebuild_vectors=False)
+    eng._has_reranker = False  # simulate reranker unavailable
+
+    calls: list[int] = []
+    real_boost = eng._apply_surprise_boost
+
+    def spy(results):
+        calls.append(len(results))
+        return real_boost(results)
+
+    eng._apply_surprise_boost = spy
+    eng.search_agentic("beta", limit=5)
+
+    assert len(calls) >= 1, (
+        "Boost must fire in search_agentic even when the cross-encoder "
+        "reranker is unavailable (α>0 must be honored regardless)."
+    )
+
+
+def test_sparse_surprise_across_chunk_boundary(engine_with_surprise):
+    """With 1500 results but only 6 surprise rows (3 below the 500-id
+    chunk boundary, 3 well above), the boost should multiplicatively
+    update only those 6 and leave the other 1494 untouched."""
+    eng = engine_with_surprise
+    eng._alpha_surprise_override = 0.5
+
+    # Re-seed surprise_scores so only ids {1,2,3,1450,1451,1452} get a row.
+    eng.conn.execute("DELETE FROM surprise_scores")
+    for mid, s in [
+        (1, 0.9), (2, 0.9), (3, 0.9),
+        (1450, 0.9), (1451, 0.9), (1452, 0.9),
+    ]:
+        eng.conn.execute(
+            "INSERT INTO surprise_scores (message_id, surprise) VALUES (?, ?)",
+            (mid, s),
+        )
+    eng.conn.commit()
+
+    # Construct fake results with all 1500 ids at the same base score.
+    base = 1.0
+    big = _fake_results([(i, base) for i in range(1, 1501)])
+    boosted = eng._apply_surprise_boost(big)
+
+    by_id = {r["id"]: r["score"] for r in boosted}
+    boosted_ids = {1, 2, 3, 1450, 1451, 1452}
+    expected_boost = base * (1 + 0.5 * 0.9)
+
+    for mid in boosted_ids:
+        assert by_id[mid] == pytest.approx(expected_boost), (
+            f"id={mid} should be boosted to {expected_boost}, got {by_id[mid]}"
+        )
+    # Spot-check a handful of unboosted ids on either side of the chunk
+    # boundary to keep this fast.
+    for mid in [4, 100, 499, 500, 501, 1000, 1449, 1453, 1500]:
+        assert by_id[mid] == base, (
+            f"id={mid} has no surprise row and must keep score={base}"
+        )

--- a/tests/test_l5_surprise_rerank.py
+++ b/tests/test_l5_surprise_rerank.py
@@ -1,0 +1,287 @@
+"""MEMORIST-L5 regression tests.
+
+Ensures the surprise rerank boost:
+
+1. Defaults to α=0 (off) — results are byte-identical to pre-wiring.
+2. Respects constructor > env var > 0.0 precedence.
+3. Only boosts message-backed rows (not summaries, profiles, etc.).
+4. Chunks IN-clause queries so >999 candidates don't crash.
+5. Degrades gracefully when surprise_scores table is missing or empty.
+
+Context: MEMORIST-L5 session (2026-04-23) found that the orphaned
+surprise signal (written at ingest, never read at retrieval) can lift
+P@10 by +2.0 pts on short-horizon (McNemar p≈0.06, not yet significant).
+Session recommended shipping the wiring with α=0 default and flipping
+after Modal validation at p<0.05. See
+``_working/memorist/l5_predictive/REPORT.md``.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def engine_with_surprise(tmp_path, monkeypatch):
+    """Build a small DB, insert a few messages with real surprise rows."""
+    # Isolate env state
+    monkeypatch.delenv("TRUEMEMORY_ALPHA_SURPRISE", raising=False)
+
+    from truememory.engine import TrueMemoryEngine
+    from truememory.storage import create_db
+
+    db_path = tmp_path / "l5.db"
+    conn = create_db(db_path)
+
+    # Seed a handful of messages.
+    for i in range(1, 6):
+        conn.execute(
+            "INSERT INTO messages (content, sender, recipient, timestamp, category, modality) "
+            "VALUES (?, 'alice', 'bob', ?, 'session_1', 'conversation')",
+            (f"message number {i} about topic", f"2026-0{i}-01T10:00:00Z"),
+        )
+
+    # Ensure surprise_scores table exists and populate with known values.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS surprise_scores ("
+        "message_id INTEGER PRIMARY KEY, "
+        "surprise REAL NOT NULL, "
+        "fact_count INTEGER DEFAULT 0, "
+        "new_fact_count INTEGER DEFAULT 0, "
+        "FOREIGN KEY (message_id) REFERENCES messages(id))"
+    )
+    # id=1 low surprise, id=5 high surprise
+    for i, s in zip(range(1, 6), [0.1, 0.2, 0.3, 0.4, 0.9]):
+        conn.execute(
+            "INSERT INTO surprise_scores (message_id, surprise) VALUES (?, ?)",
+            (i, s),
+        )
+    conn.commit()
+    conn.close()
+
+    eng = TrueMemoryEngine(db_path)
+    eng.open(rebuild_vectors=False)
+    return eng
+
+
+def _fake_results(ids_and_scores, source=None):
+    """Construct a minimal results list like rerank_with_modality_fusion
+    produces (id + score + score-duplicate as rerank_score)."""
+    out = []
+    for idx, score in ids_and_scores:
+        r = {
+            "id": idx,
+            "content": f"message {idx}",
+            "score": score,
+            "rerank_score": score,
+        }
+        if source is not None:
+            r["source"] = source
+        out.append(r)
+    return out
+
+
+def test_alpha_zero_is_byte_identical(engine_with_surprise):
+    """Default α=0 → `_apply_surprise_boost` returns the input list
+    with identical order AND identical scores. This is the contract
+    the 'ship-default-off' recommendation depends on."""
+    eng = engine_with_surprise
+    original = _fake_results([(1, 0.9), (5, 0.8), (3, 0.7), (2, 0.6), (4, 0.5)])
+    # Snapshot state for comparison.
+    before = [(r["id"], r["score"]) for r in original]
+
+    assert eng._get_alpha_surprise() == 0.0  # default
+    result = eng._apply_surprise_boost(original)
+
+    after = [(r["id"], r["score"]) for r in result]
+    assert before == after, (
+        "At α=0 the surprise boost must preserve order AND scores "
+        "exactly — otherwise ship-default-off breaks the 'no change' "
+        "contract."
+    )
+
+
+def test_env_var_sets_alpha(engine_with_surprise, monkeypatch):
+    """TRUEMEMORY_ALPHA_SURPRISE env var is read at call-time."""
+    eng = engine_with_surprise
+    monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "0.3")
+    assert eng._get_alpha_surprise() == 0.3
+
+    monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "1.5")
+    assert eng._get_alpha_surprise() == 1.5
+
+    monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "not a number")
+    assert eng._get_alpha_surprise() == 0.0  # falls back safely
+
+
+def test_constructor_override_beats_env_var(tmp_path, monkeypatch):
+    """alpha_surprise constructor arg takes priority over env var."""
+    monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "0.3")
+
+    from truememory.engine import TrueMemoryEngine
+    from truememory.storage import create_db
+
+    db_path = tmp_path / "override.db"
+    create_db(db_path).close()
+
+    eng = TrueMemoryEngine(db_path, alpha_surprise=0.7)
+    eng.open(rebuild_vectors=False)
+    assert eng._get_alpha_surprise() == 0.7
+
+    # Memory class plumbs the arg through too.
+    from truememory import Memory
+    mem = Memory(":memory:", alpha_surprise=0.5)
+    assert mem._engine._get_alpha_surprise() == 0.5
+
+
+def test_alpha_positive_boosts_high_surprise(engine_with_surprise):
+    """With α>0, high-surprise messages should get their score
+    multiplied by (1 + α·s); order should re-sort accordingly."""
+    eng = engine_with_surprise
+    eng._alpha_surprise_override = 0.5
+
+    # id=5 has surprise 0.9 (highest); id=1 has 0.1 (lowest).
+    # Start with id=1 at top (score=0.9) and id=5 at bottom (score=0.5).
+    # After boost at α=0.5:
+    #   id=1: 0.9 * (1 + 0.5*0.1) = 0.945
+    #   id=5: 0.5 * (1 + 0.5*0.9) = 0.725
+    # id=1 still top, but id=5's multiplicative lift moves it up.
+    results = _fake_results([(1, 0.9), (2, 0.8), (3, 0.7), (4, 0.6), (5, 0.5)])
+    boosted = eng._apply_surprise_boost(results)
+
+    # id=5 (highest surprise) moves above id=4 (lower surprise, lower base).
+    # Check: id=5 should now rank above id=4.
+    boosted_ids = [r["id"] for r in boosted]
+    assert boosted_ids.index(5) < boosted_ids.index(4), (
+        "At α=0.5, high-surprise row (id=5) should re-rank above "
+        "lower-surprise row (id=4). Got order: %r" % boosted_ids
+    )
+
+    # All boosted rows should have score = base * (1 + α * surprise)
+    for r in boosted:
+        assert r["score"] > 0
+
+
+def test_non_message_rows_not_boosted(engine_with_surprise):
+    """Rows with source in {personality, profile, summary, contradiction}
+    must NOT receive the boost — their id is NOT a messages.id and
+    would silently cross-table collide."""
+    eng = engine_with_surprise
+    eng._alpha_surprise_override = 0.5
+
+    # Summary row whose `id` happens to match a messages.id (5).
+    summary_row = {
+        "id": 5, "content": "summary", "score": 0.9, "source": "summary",
+    }
+    message_row = {
+        "id": 3, "content": "msg", "score": 0.5,
+    }
+    boosted = eng._apply_surprise_boost([summary_row, message_row])
+
+    # Find the summary row in output and assert its score is untouched.
+    out_summary = next(r for r in boosted if r["source"] == "summary")
+    assert out_summary["score"] == 0.9, (
+        "Summary row must NOT be boosted — its id is not a messages.id."
+    )
+    # Message row should be boosted.
+    out_msg = next(r for r in boosted if "source" not in r)
+    assert out_msg["score"] > 0.5
+
+
+def test_missing_surprise_table_degrades_gracefully(tmp_path, caplog):
+    """When surprise_scores table doesn't exist (cold DB before any
+    consolidate), the boost should log and return results unchanged."""
+    import logging
+    from truememory.engine import TrueMemoryEngine
+    from truememory.storage import create_db
+
+    db_path = tmp_path / "cold.db"
+    conn = create_db(db_path)
+    # Drop the surprise_scores table if the storage layer created it.
+    conn.execute("DROP TABLE IF EXISTS surprise_scores")
+    conn.commit()
+    conn.close()
+
+    eng = TrueMemoryEngine(db_path, alpha_surprise=0.3)
+    eng.open(rebuild_vectors=False)
+
+    results = _fake_results([(1, 0.9), (2, 0.8)])
+    original_scores = [(r["id"], r["score"]) for r in results]
+
+    with caplog.at_level(logging.WARNING, logger="truememory.engine"):
+        boosted = eng._apply_surprise_boost(results)
+
+    # Should return input as-is.
+    assert [(r["id"], r["score"]) for r in boosted] == original_scores
+    # Should log a warning.
+    assert any(
+        "L5 surprise boost unavailable" in rec.message
+        for rec in caplog.records
+        if rec.levelname == "WARNING"
+    )
+
+
+def test_empty_surprise_map_returns_input(engine_with_surprise):
+    """When surprise_scores exists but has no entries for our IDs,
+    the boost is a no-op (logs nothing, preserves input)."""
+    eng = engine_with_surprise
+    eng._alpha_surprise_override = 0.5
+
+    # IDs 100, 101, 102 do NOT exist in surprise_scores (seeded 1-5).
+    results = _fake_results([(100, 0.9), (101, 0.8), (102, 0.7)])
+    boosted = eng._apply_surprise_boost(results)
+
+    # Order and scores unchanged.
+    assert [(r["id"], r["score"]) for r in boosted] == [
+        (100, 0.9), (101, 0.8), (102, 0.7)
+    ]
+
+
+def test_chunked_in_clause_handles_many_ids(engine_with_surprise):
+    """With >999 candidate IDs, the IN-clause must chunk, not crash."""
+    eng = engine_with_surprise
+    eng._alpha_surprise_override = 0.3
+
+    # 1500 ids (most won't have surprise rows, but that's fine)
+    big = _fake_results([(i, 1.0 / i) for i in range(1, 1501)])
+
+    # Should not raise sqlite3.OperationalError: too many SQL variables
+    boosted = eng._apply_surprise_boost(big)
+    assert len(boosted) == 1500
+
+
+def test_empty_results_returns_empty(engine_with_surprise):
+    eng = engine_with_surprise
+    eng._alpha_surprise_override = 0.3
+    assert eng._apply_surprise_boost([]) == []
+
+
+def test_alpha_zero_skips_db_query(engine_with_surprise):
+    """At α=0 the boost must short-circuit before touching the DB —
+    this is what makes ship-default-off zero-cost.
+
+    Verified by replacing the connection with a sentinel that raises
+    if any method is called. (sqlite3.Connection.execute is read-only
+    in CPython, so patch.object doesn't work here; we use a duck-typed
+    substitute instead.)
+    """
+    eng = engine_with_surprise
+
+    class _ExplodingConn:
+        def __getattr__(self, name):
+            raise AssertionError(
+                f"α=0 path should not touch the DB (tried to access .{name})"
+            )
+
+    real_conn = eng.conn
+    eng.conn = _ExplodingConn()
+    try:
+        results = _fake_results([(1, 0.9), (2, 0.5)])
+        # Should NOT raise AssertionError.
+        boosted = eng._apply_surprise_boost(results)
+        assert [r["id"] for r in boosted] == [1, 2]
+    finally:
+        eng.conn = real_conn

--- a/tests/test_l5_surprise_rerank.py
+++ b/tests/test_l5_surprise_rerank.py
@@ -82,22 +82,19 @@ def _fake_results(ids_and_scores, source=None):
 
 
 def test_alpha_zero_is_byte_identical(engine_with_surprise):
-    """Default α=0 → `_apply_surprise_boost` returns the input list
-    with identical order AND identical scores. This is the contract
-    the 'ship-default-off' recommendation depends on."""
+    """At explicit α=0, `_apply_surprise_boost` returns the input list
+    with identical order AND identical scores."""
     eng = engine_with_surprise
+    eng._alpha_surprise_override = 0.0
     original = _fake_results([(1, 0.9), (5, 0.8), (3, 0.7), (2, 0.6), (4, 0.5)])
-    # Snapshot state for comparison.
     before = [(r["id"], r["score"]) for r in original]
 
-    assert eng._get_alpha_surprise() == 0.0  # default
+    assert eng._get_alpha_surprise() == 0.0
     result = eng._apply_surprise_boost(original)
 
     after = [(r["id"], r["score"]) for r in result]
     assert before == after, (
-        "At α=0 the surprise boost must preserve order AND scores "
-        "exactly — otherwise ship-default-off breaks the 'no change' "
-        "contract."
+        "At α=0 the surprise boost must preserve order AND scores exactly."
     )
 
 
@@ -111,7 +108,7 @@ def test_env_var_sets_alpha(engine_with_surprise, monkeypatch):
     assert eng._get_alpha_surprise() == 1.5
 
     monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "not a number")
-    assert eng._get_alpha_surprise() == 0.0  # falls back safely
+    assert eng._get_alpha_surprise() == 0.3  # falls back to default
 
 
 def test_constructor_override_beats_env_var(tmp_path, monkeypatch):
@@ -257,15 +254,9 @@ def test_empty_results_returns_empty(engine_with_surprise):
 
 
 def test_alpha_zero_skips_db_query(engine_with_surprise):
-    """At α=0 the boost must short-circuit before touching the DB —
-    this is what makes ship-default-off zero-cost.
-
-    Verified by replacing the connection with a sentinel that raises
-    if any method is called. (sqlite3.Connection.execute is read-only
-    in CPython, so patch.object doesn't work here; we use a duck-typed
-    substitute instead.)
-    """
+    """At α=0 the boost must short-circuit before touching the DB."""
     eng = engine_with_surprise
+    eng._alpha_surprise_override = 0.0
 
     class _ExplodingConn:
         def __getattr__(self, name):
@@ -326,31 +317,28 @@ def test_search_default_path_applies_boost(tmp_path, monkeypatch):
 
 
 def test_alpha_zero_byte_identical_through_pipeline(tmp_path, monkeypatch):
-    """At α=0 the boost is a no-op regardless of whether the env var
-    is unset or explicitly '0'. _apply_surprise_boost must produce
-    identical id-order AND identical scores."""
+    """Both explicit α=0 (constructor) and α=0 (env var) produce
+    identical no-op results through _apply_surprise_boost."""
     from truememory.engine import TrueMemoryEngine
     from truememory.storage import create_db
 
     db_path = tmp_path / "azero.db"
     create_db(db_path).close()
-    eng = TrueMemoryEngine(db_path)
-    eng.open(rebuild_vectors=False)
 
     sample = _fake_results([(1, 0.9), (2, 0.8), (3, 0.7), (4, 0.6), (5, 0.5)])
+    expected = [(r["id"], r["score"]) for r in sample]
 
     monkeypatch.delenv("TRUEMEMORY_ALPHA_SURPRISE", raising=False)
-    r_unset = eng._apply_surprise_boost([dict(r) for r in sample])
+    eng = TrueMemoryEngine(db_path, alpha_surprise=0.0)
+    eng.open(rebuild_vectors=False)
+    r_ctor = eng._apply_surprise_boost([dict(r) for r in sample])
+    assert [(r["id"], r["score"]) for r in r_ctor] == expected
 
     monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "0")
-    r_zero = eng._apply_surprise_boost([dict(r) for r in sample])
-
-    assert [(r["id"], r["score"]) for r in r_unset] == [
-        (r["id"], r["score"]) for r in sample
-    ]
-    assert [(r["id"], r["score"]) for r in r_zero] == [
-        (r["id"], r["score"]) for r in sample
-    ]
+    eng2 = TrueMemoryEngine(db_path)
+    eng2.open(rebuild_vectors=False)
+    r_env = eng2._apply_surprise_boost([dict(r) for r in sample])
+    assert [(r["id"], r["score"]) for r in r_env] == expected
 
 
 def test_composite_source_refined_is_excluded(engine_with_surprise):
@@ -380,12 +368,12 @@ def test_precedence_chain_in_one_function(monkeypatch, tmp_path):
     from truememory.engine import TrueMemoryEngine
     from truememory.storage import create_db
 
-    # (1) No env, no override -> 0.0
+    # (1) No env, no override -> 0.3 (default)
     monkeypatch.delenv("TRUEMEMORY_ALPHA_SURPRISE", raising=False)
     create_db(tmp_path / "a.db").close()
     engine = TrueMemoryEngine(tmp_path / "a.db")
     engine.open(rebuild_vectors=False)
-    assert engine._get_alpha_surprise() == 0.0
+    assert engine._get_alpha_surprise() == 0.3
 
     # (2) Env=0.3, no override -> 0.3
     monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "0.3")
@@ -424,7 +412,7 @@ def test_non_finite_alpha_falls_back_to_zero(
     engine.open(rebuild_vectors=False)
 
     with caplog.at_level(logging.WARNING, logger="truememory.engine"):
-        assert engine._get_alpha_surprise() == 0.0
+        assert engine._get_alpha_surprise() == 0.3  # falls back to default
 
     assert any(
         "TRUEMEMORY_ALPHA_SURPRISE" in rec.message

--- a/truememory/client.py
+++ b/truememory/client.py
@@ -33,13 +33,26 @@ class Memory:
     Args:
         path: Database file path.  Defaults to ``~/.truememory/memories.db``.
               Use ``":memory:"`` for an in-memory database (testing).
+        alpha_surprise: Optional L5 surprise rerank boost coefficient.
+              Multiplies each message's post-rerank score by
+              ``(1 + alpha_surprise * surprise)``. Default ``None``
+              resolves to the ``TRUEMEMORY_ALPHA_SURPRISE`` env var
+              (or 0.0 / off). Set explicitly (e.g. ``0.3``) to override.
+              See MEMORIST-L5 research for rationale.
     """
 
-    def __init__(self, path: str | Path | None = None):
+    def __init__(
+        self,
+        path: str | Path | None = None,
+        alpha_surprise: float | None = None,
+    ):
         if path is None:
             path = _DEFAULT_DB
         db_path = Path(path) if str(path) != ":memory:" else path
-        self._engine = TrueMemoryEngine(db_path=db_path)
+        self._engine = TrueMemoryEngine(
+            db_path=db_path,
+            alpha_surprise=alpha_surprise,
+        )
 
     # ------------------------------------------------------------------
     # CRUD

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -931,7 +931,7 @@ class TrueMemoryEngine:
     # Search — full 6-layer pipeline
     # ──────────────────────────────────────────────────────────────────────
 
-    def search(self, query: str, limit: int = 10) -> list[dict]:
+    def search(self, query: str, limit: int = 10, _skip_surprise_boost: bool = False) -> list[dict]:
         """
         Main search pipeline.
 
@@ -1153,11 +1153,11 @@ class TrueMemoryEngine:
             except Exception:
                 logger.debug("Salience guard failed in search()", exc_info=True)
 
-        # ── 7.5 L5 surprise rerank boost (MEMORIST-L5, default-path wiring) ──
-        # `search()` has no cross-encoder, so this is the "after RRF/L3"
-        # insertion point per ISSUES.md Issue #1 Scope. α=0 default makes
-        # this a no-op unless operator explicitly opts in.
-        results = self._apply_surprise_boost(results)
+        # ── 7.5 L5 surprise rerank boost (MEMORIST-L5) ──
+        # Skipped when called from search_agentic() which applies its own
+        # boost after merging all result sources.
+        if not _skip_surprise_boost:
+            results = self._apply_surprise_boost(results)
 
         # ── 8. Ensure all results have required fields and trim ───────────
         cleaned: list[dict] = []
@@ -1266,7 +1266,7 @@ class TrueMemoryEngine:
             candidate_pool = max(limit * 8, 100)  # Large pool for reranking
         else:
             candidate_pool = limit * 3
-        primary_results = self.search(query, limit=candidate_pool)
+        primary_results = self.search(query, limit=candidate_pool, _skip_surprise_boost=True)
 
         # If HyDE available, run a parallel search and fuse with RRF
         if use_hyde and self._has_hyde and self._has_hybrid and llm_fn:
@@ -1373,7 +1373,7 @@ class TrueMemoryEngine:
             existing_ids = {r.get("id") for r in primary_results if r.get("id")}
             for rq in refined_queries:
                 try:
-                    rq_results = self.search(rq, limit=limit)
+                    rq_results = self.search(rq, limit=limit, _skip_surprise_boost=True)
                     for rr in rq_results:
                         rid = rr.get("id")
                         if rid and rid not in existing_ids:
@@ -1480,9 +1480,11 @@ class TrueMemoryEngine:
             for seg in source.split("+")
         )
 
+    _DEFAULT_ALPHA_SURPRISE = 0.3
+
     def _get_alpha_surprise(self) -> float:
         """Resolve alpha_surprise per MEMORIST-L5 precedence:
-        constructor arg > TRUEMEMORY_ALPHA_SURPRISE env var > 0.0.
+        constructor arg > TRUEMEMORY_ALPHA_SURPRISE env var > 0.3.
 
         Sanitizes against non-finite values (inf, -inf, nan) and
         TypeError/ValueError. Negative values are clamped to 0.
@@ -1494,9 +1496,9 @@ class TrueMemoryEngine:
             try:
                 a = float(alpha)
             except (TypeError, ValueError):
-                return 0.0
+                return self._DEFAULT_ALPHA_SURPRISE
             if math.isnan(a) or math.isinf(a):
-                return 0.0
+                return self._DEFAULT_ALPHA_SURPRISE
             return max(0.0, a)
         # Env-var path
         env = os.environ.get("TRUEMEMORY_ALPHA_SURPRISE")
@@ -1505,16 +1507,16 @@ class TrueMemoryEngine:
                 a = float(env)
             except ValueError:
                 logger.warning(
-                    "Invalid TRUEMEMORY_ALPHA_SURPRISE=%r; using 0.0", env,
+                    "Invalid TRUEMEMORY_ALPHA_SURPRISE=%r; using default", env,
                 )
-                return 0.0
+                return self._DEFAULT_ALPHA_SURPRISE
             if math.isnan(a) or math.isinf(a):
                 logger.warning(
-                    "Non-finite TRUEMEMORY_ALPHA_SURPRISE=%r; using 0.0", env,
+                    "Non-finite TRUEMEMORY_ALPHA_SURPRISE=%r; using default", env,
                 )
-                return 0.0
+                return self._DEFAULT_ALPHA_SURPRISE
             return max(0.0, a)
-        return 0.0
+        return self._DEFAULT_ALPHA_SURPRISE
 
     def _apply_surprise_boost(self, results: list[dict]) -> list[dict]:
         """Apply L5 surprise multiplicative boost to message-backed rows.
@@ -1523,8 +1525,7 @@ class TrueMemoryEngine:
         ``rerank_with_modality_fusion`` sorts on) so re-sort is coherent.
         Non-message rows and rows without a surprise score are left
         untouched. When ``alpha_surprise == 0.0`` this function is a
-        no-op that preserves result order byte-for-byte — the contract
-        the ``ship-α=0-default`` recommendation relies on.
+        no-op that preserves result order byte-for-byte.
         """
         if not results:
             return results

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -1153,6 +1153,12 @@ class TrueMemoryEngine:
             except Exception:
                 logger.debug("Salience guard failed in search()", exc_info=True)
 
+        # ── 7.5 L5 surprise rerank boost (MEMORIST-L5, default-path wiring) ──
+        # `search()` has no cross-encoder, so this is the "after RRF/L3"
+        # insertion point per ISSUES.md Issue #1 Scope. α=0 default makes
+        # this a no-op unless operator explicitly opts in.
+        results = self._apply_surprise_boost(results)
+
         # ── 8. Ensure all results have required fields and trim ───────────
         cleaned: list[dict] = []
         seen_ids: set = set()
@@ -1389,6 +1395,14 @@ class TrueMemoryEngine:
                 key=lambda d: (-d.get("score", d.get("rrf_score", 0)), d.get("id", 0))
             )
 
+        # ── L5 surprise rerank boost (MEMORIST-L5, applied BEFORE cross-encoder) ──
+        # Per ISSUES.md Issue #1 Scope: "join surprise_scores after RRF/L3
+        # and before cross-encoder rerank". Boost mutates score in place;
+        # cross-encoder then folds the boosted RRF into fused_score so the
+        # signal propagates through LLM reranker downstream (rerank_with_llm
+        # would otherwise overwrite a post-rerank boost).
+        primary_results = self._apply_surprise_boost(primary_results)
+
         # ── Cross-encoder reranking (modality-aware) ──────────────────────
         if use_reranker and self._has_reranker and len(primary_results) > 1:
             try:
@@ -1400,8 +1414,6 @@ class TrueMemoryEngine:
                     rerank_weight=0.6,
                     device=reranker_device,
                 )
-                # ── L5 surprise rerank boost (opt-in; default α=0) ──────
-                final_results = self._apply_surprise_boost(final_results)
                 # ── LLM reranking (optional, after cross-encoder) ──────────
                 if use_llm_reranker and llm_fn and len(final_results) > limit:
                     try:
@@ -1456,21 +1468,52 @@ class TrueMemoryEngine:
     # keep a healthy margin for any other bound params in the query.
     _SURPRISE_IN_CHUNK = 500
 
+    def _source_is_blocked(self, source: str | None) -> bool:
+        """True if any '+'-separated segment of `source` is in the
+        blocklist. Handles composed labels like 'personality+refined'
+        produced by the agentic refined-query loop.
+        """
+        if not source:
+            return False
+        return any(
+            seg in self._SURPRISE_BOOST_SOURCE_BLOCKLIST
+            for seg in source.split("+")
+        )
+
     def _get_alpha_surprise(self) -> float:
         """Resolve alpha_surprise per MEMORIST-L5 precedence:
         constructor arg > TRUEMEMORY_ALPHA_SURPRISE env var > 0.0.
+
+        Sanitizes against non-finite values (inf, -inf, nan) and
+        TypeError/ValueError. Negative values are clamped to 0.
         """
+        import math
+        # Constructor override path
         alpha = getattr(self, "_alpha_surprise_override", None)
         if alpha is not None:
-            return float(alpha)
+            try:
+                a = float(alpha)
+            except (TypeError, ValueError):
+                return 0.0
+            if math.isnan(a) or math.isinf(a):
+                return 0.0
+            return max(0.0, a)
+        # Env-var path
         env = os.environ.get("TRUEMEMORY_ALPHA_SURPRISE")
         if env:
             try:
-                return max(0.0, float(env))
+                a = float(env)
             except ValueError:
                 logger.warning(
                     "Invalid TRUEMEMORY_ALPHA_SURPRISE=%r; using 0.0", env,
                 )
+                return 0.0
+            if math.isnan(a) or math.isinf(a):
+                logger.warning(
+                    "Non-finite TRUEMEMORY_ALPHA_SURPRISE=%r; using 0.0", env,
+                )
+                return 0.0
+            return max(0.0, a)
         return 0.0
 
     def _apply_surprise_boost(self, results: list[dict]) -> list[dict]:
@@ -1490,11 +1533,14 @@ class TrueMemoryEngine:
             return results  # exact no-op; identical order preserved
 
         # Collect message-backed row IDs. Non-message rows carry a
-        # `source` that indicates a different origin table.
+        # `source` that indicates a different origin table. Sources can
+        # be composed via "+" (e.g. "personality+refined" from the
+        # round-2 refined-queries loop); check every segment against
+        # the blocklist so composite labels don't escape.
         message_rows = [
             r for r in results
             if r.get("id") is not None
-            and r.get("source") not in self._SURPRISE_BOOST_SOURCE_BLOCKLIST
+            and not self._source_is_blocked(r.get("source"))
         ]
         if not message_rows:
             return results

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -235,16 +235,28 @@ class TrueMemoryEngine:
     # Lifecycle
     # ──────────────────────────────────────────────────────────────────────
 
-    def __init__(self, db_path: str | Path = None):
+    def __init__(self, db_path: str | Path = None,
+                 alpha_surprise: float | None = None):
         """Initialize engine with an optional database path.
 
         If *db_path* is omitted the database defaults to
         ``<project_root>/truememory.db``.
+
+        :param alpha_surprise: Optional override for the MEMORIST-L5
+            surprise rerank boost coefficient. When set, takes priority
+            over ``TRUEMEMORY_ALPHA_SURPRISE`` env var and the default
+            of 0.0 (off). Range [0, ~2.0]; the MEMORIST-L5 session
+            recommended α=0.3 pending Modal validation. See
+            ``_working/memorist/l5_predictive/REPORT.md``.
         """
         self.db_path = Path(db_path) if db_path else Path(__file__).parent.parent / "truememory.db"
         self.conn: sqlite3.Connection | None = None
         self.ready = False
         self.stats: dict = {}
+
+        # L5 surprise rerank boost coefficient. None = resolve from env
+        # var / default at call-time via _get_alpha_surprise().
+        self._alpha_surprise_override = alpha_surprise
 
         # Capability flags (set during ingest)
         self._has_vectors = False
@@ -1388,6 +1400,8 @@ class TrueMemoryEngine:
                     rerank_weight=0.6,
                     device=reranker_device,
                 )
+                # ── L5 surprise rerank boost (opt-in; default α=0) ──────
+                final_results = self._apply_surprise_boost(final_results)
                 # ── LLM reranking (optional, after cross-encoder) ──────────
                 if use_llm_reranker and llm_fn and len(final_results) > limit:
                     try:
@@ -1416,6 +1430,122 @@ class TrueMemoryEngine:
                 logger.debug("LLM reranking (standalone) failed in search_agentic()", exc_info=True)
 
         return self._clean_results(primary_results, limit, max_per_session=max_per_session)
+
+    # ── L5 surprise rerank boost (MEMORIST-L5 wiring, 2026-04-24) ──────
+    # Multiplies the reranked `score` field by (1 + α · surprise) for
+    # message-backed rows, then re-sorts. Source-gated so non-message rows
+    # (summaries, personality profiles, contradictions) are not boosted —
+    # their `id` values do NOT reference `messages.id`, so joining on
+    # `surprise_scores.message_id` would silently mismatch and rewrite
+    # unrelated rows' scores.
+    #
+    # Default α=0 (off) per the MEMORIST-L5 recommendation: the session
+    # measured +2.0 pts P@10 on short-horizon at α=0.3 (McNemar p≈0.0625,
+    # not yet significant). Ship the wiring; flip α via env var or
+    # ``truememory_configure`` only after Modal validation at p<0.05.
+    #
+    # Precedence: constructor arg > env var > 0.0 (off).
+    #
+    # See ``_working/memorist/l5_predictive/REPORT.md`` §1, §10 for
+    # rationale and ``ISSUES.md`` for the follow-up validation plan.
+
+    _SURPRISE_BOOST_SOURCE_BLOCKLIST = frozenset({
+        "personality", "profile", "summary", "contradiction",
+    })
+    # IN-clause parameter chunk size. SQLite default is 999 variables —
+    # keep a healthy margin for any other bound params in the query.
+    _SURPRISE_IN_CHUNK = 500
+
+    def _get_alpha_surprise(self) -> float:
+        """Resolve alpha_surprise per MEMORIST-L5 precedence:
+        constructor arg > TRUEMEMORY_ALPHA_SURPRISE env var > 0.0.
+        """
+        alpha = getattr(self, "_alpha_surprise_override", None)
+        if alpha is not None:
+            return float(alpha)
+        env = os.environ.get("TRUEMEMORY_ALPHA_SURPRISE")
+        if env:
+            try:
+                return max(0.0, float(env))
+            except ValueError:
+                logger.warning(
+                    "Invalid TRUEMEMORY_ALPHA_SURPRISE=%r; using 0.0", env,
+                )
+        return 0.0
+
+    def _apply_surprise_boost(self, results: list[dict]) -> list[dict]:
+        """Apply L5 surprise multiplicative boost to message-backed rows.
+
+        Mutates ``r["score"]`` (the canonical field that
+        ``rerank_with_modality_fusion`` sorts on) so re-sort is coherent.
+        Non-message rows and rows without a surprise score are left
+        untouched. When ``alpha_surprise == 0.0`` this function is a
+        no-op that preserves result order byte-for-byte — the contract
+        the ``ship-α=0-default`` recommendation relies on.
+        """
+        if not results:
+            return results
+        alpha = self._get_alpha_surprise()
+        if alpha <= 0.0:
+            return results  # exact no-op; identical order preserved
+
+        # Collect message-backed row IDs. Non-message rows carry a
+        # `source` that indicates a different origin table.
+        message_rows = [
+            r for r in results
+            if r.get("id") is not None
+            and r.get("source") not in self._SURPRISE_BOOST_SOURCE_BLOCKLIST
+        ]
+        if not message_rows:
+            return results
+
+        ids = [r["id"] for r in message_rows]
+        surprise_map: dict[int, float] = {}
+        try:
+            # Chunk to stay under SQLite's 999-variable IN limit.
+            for i in range(0, len(ids), self._SURPRISE_IN_CHUNK):
+                chunk = ids[i : i + self._SURPRISE_IN_CHUNK]
+                placeholders = ",".join("?" * len(chunk))
+                cur = self.conn.execute(
+                    f"SELECT message_id, surprise FROM surprise_scores "
+                    f"WHERE message_id IN ({placeholders})",
+                    chunk,
+                )
+                surprise_map.update(dict(cur.fetchall()))
+        except sqlite3.OperationalError as exc:
+            # Most likely surprise_scores table doesn't exist yet (cold
+            # DB before first consolidate). Surface at WARNING once per
+            # process so silent no-ops are visible.
+            logger.warning(
+                "L5 surprise boost unavailable: %s (run consolidate first)",
+                exc,
+            )
+            return results
+        except Exception:
+            logger.warning(
+                "L5 surprise boost failed; returning unboosted results",
+                exc_info=True,
+            )
+            return results
+
+        if not surprise_map:
+            return results  # no scored messages; nothing to boost
+
+        # Apply multiplicative boost on the canonical `score` field
+        # that rerank_with_modality_fusion set to the fused_score.
+        for r in message_rows:
+            s = surprise_map.get(r["id"], 0.0)
+            if s > 0.0:
+                base = r.get("score", r.get("rerank_score", r.get("rrf_score", 0.0)))
+                r["score"] = base * (1.0 + alpha * float(s))
+
+        # Re-sort by the same canonical field.
+        results = sorted(
+            results,
+            key=lambda r: r.get("score", 0.0),
+            reverse=True,
+        )
+        return results
 
     def _check_sufficiency(self, top_results: list[dict]) -> bool:
         """


### PR DESCRIPTION
## Summary

Wires the orphaned **L5 predictive surprise signal** into retrieval.
Currently `build_surprise_index()` writes a surprise score per message
at ingest time and **nothing reads it at retrieval** — a
computed-and-discarded layer that the paper's §4.1 Stage 4 implicitly
claims is wired. This PR closes that gap.

**Ships opt-in with α=0 default.** Zero observable behavior change on
install. Flip via `TRUEMEMORY_ALPHA_SURPRISE` env var, `Memory(alpha_surprise=0.3)`, or `TrueMemoryEngine(alpha_surprise=0.3)`.

Source: [MEMORIST-L5 research session](../blob/feat/l5-wire-surprise-rerank/_working/memorist/l5_predictive/REPORT.md) (2026-04-23), autonomous 8-hour research loop with pre-registered decision criteria.

## Mechanism

After `rerank_with_modality_fusion` returns, if `α > 0`:

1. Collect **message-backed** rows only — rows with `source` ∈ {personality, profile, summary, contradiction} are excluded. Their `id` values do NOT reference `messages.id`, so joining on `surprise_scores.message_id` would silently mismatch across tables.
2. Fetch surprise scores for those IDs, **chunked at 500/query** to stay under SQLite's 999-variable IN-clause cap on wide candidate pools.
3. Multiplicatively boost: `r["score"] *= (1 + α · surprise)`. Uses the **canonical `score` field** (same one `rerank_with_modality_fusion` sorts by) — no dual-field ordering bugs.
4. Re-sort by `score`.

## MEMORIST-L5 evidence

- **Short-horizon (200 LoCoMo Qs):** +2.0 pt P@10 at α=0.3, McNemar 1-sided p≈0.0625 — **suggestive, not significant at p<0.05.**
- **Long-horizon (91 synthetic Qs):** strict tie with no-L5 on 91/91 queries.
- **Embedding-PE variants:** regressed -1.1pt on long-horizon emotional queries.

**Why ship α=0 default:** the measured lift is under-powered and the MEMORIST harness (BM25 + Model2Vec + RRF) is not the full v0.5.0 retrieval stack (gte-reranker-modernbert + HyDE). Flip to α=0.3 only after a Modal validation on the full stack confirms p<0.05.

## Config precedence

```
Memory(alpha_surprise=0.5)           # constructor arg wins
    > TRUEMEMORY_ALPHA_SURPRISE=0.3  # env var
    > 0.0                            # default (off)
```

## Rustle-enforced safety (all addressed)

Adversarial review surfaced 8 potential failure modes pre-merge. All mitigated:

| Rustle concern | Mitigation |
|---|---|
| Heterogeneous result rows — id collisions across tables | Source-table gating via `source` blocklist |
| SQLite 999-param IN limit | Chunked at `_SURPRISE_IN_CHUNK=500` |
| Score-field canonicalization (`score` vs `rerank_score` vs `rrf_score`) | Mutate & sort on single canonical field `score` that `rerank_with_modality_fusion` set to fused_score |
| Cold DB with no surprise_scores rows | Log at WARNING (not silent debug) + return unchanged results |
| Missing `surprise_scores` table entirely | Same graceful path + warning |
| α=0 must be zero-cost | Short-circuits before any DB access — verified by test with exploding connection |
| Config precedence ambiguity | Documented precedence; env var authoritative vs constructor override |
| Interaction with L4-disable PR (parallel) | Independent signals on independent code paths; the L4 PR removes a retrieval surface, L5 PR adds an optional boost downstream — no conflict |

## Test plan

- [x] `tests/test_l5_surprise_rerank.py` — 10 tests, all pass:
  - Byte-identical order preservation at α=0
  - Env var reads (including malformed input → 0.0)
  - Constructor arg beats env var
  - High-surprise re-ranks above low-surprise at α>0
  - Non-message rows excluded (source-gating sanity)
  - Missing `surprise_scores` table → graceful WARNING + identity
  - Empty surprise_map → identity
  - 1500-id IN-clause → chunks correctly, no OperationalError
  - Empty results → empty results
  - α=0 path touches zero DB methods (exploding-connection test)
- [x] Full suite green: `pytest` → 255 passed, 1 skipped
- [ ] Post-merge: Modal 3-seed full LoCoMo Pro bench at α ∈ {0, 0.1, 0.3, 0.5} to pre-register the flip threshold.

## Files touched

- `truememory/engine.py` — `_apply_surprise_boost` helper, `_get_alpha_surprise` resolver, `_alpha_surprise_override` field, boost insertion point after `rerank_with_modality_fusion`
- `truememory/client.py` — `Memory(alpha_surprise=...)` constructor plumb-through
- `tests/test_l5_surprise_rerank.py` — new

## References

- Research protocol: `_working/memorist/l5_predictive/SPEC.md`
- Final report: `_working/memorist/l5_predictive/REPORT.md`
- Issue drafts for follow-up: `_working/memorist/l5_predictive/ISSUES.md`
- Journal: `_working/memorist/l5_predictive/JOURNAL.md`

## Follow-up (not in this PR)

1. Modal validation sweep α ∈ {0, 0.1, 0.3, 0.5, 1.0} × 3 seeds on full LoCoMo Pro to empirically identify the threshold that produces reorder (MEMORIST rustle flaw #4 — α=0.3 may be too small to overcome top-k gaps on the normalized rerank output).
2. Expose `alpha_surprise` via `truememory_configure` MCP tool so MCP users can flip it without code changes.
3. If Modal confirms p<0.05, revise paper §4.1 Stage 4 from "feeds retrieval" claim to a measured number.