### PR TITLE
fix(l5): tune default alpha_surprise from 0.3 to 0.2 per Modal alpha sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Added
 - **L5 surprise rerank boost** — retrieval now reweights candidates by
   `(1 + α · surprise)` using the `surprise_scores` table populated at
-  ingest. Default α=0.3. Override via `Memory(alpha_surprise=…)` or
-  `TRUEMEMORY_ALPHA_SURPRISE` env var. Set to `0` to disable.
+  ingest. Default α=0.2 (tuned via Modal alpha sweep, 2026-04-26).
+  Override via `Memory(alpha_surprise=…)` or `TRUEMEMORY_ALPHA_SURPRISE`
+  env var. Set to `0` to disable.
 
 ### Changed
 - **L3 salience reweighter: learned weights replace hand-tuned deltas.**

--- a/tests/test_l5_surprise_rerank.py
+++ b/tests/test_l5_surprise_rerank.py
@@ -2,8 +2,8 @@
 
 Ensures the surprise rerank boost:
 
-1. Defaults to α=0.3 — set to 0 for byte-identical pre-wiring behavior.
-2. Respects constructor > env var > 0.3 precedence.
+1. Defaults to α=0.2 — set to 0 for byte-identical pre-wiring behavior.
+2. Respects constructor > env var > 0.2 precedence.
 3. Only boosts message-backed rows (not summaries, profiles, etc.).
 4. Chunks IN-clause queries so >999 candidates don't crash.
 5. Degrades gracefully when surprise_scores table is missing or empty.
@@ -108,7 +108,7 @@ def test_env_var_sets_alpha(engine_with_surprise, monkeypatch):
     assert eng._get_alpha_surprise() == 1.5
 
     monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "not a number")
-    assert eng._get_alpha_surprise() == 0.3  # falls back to default
+    assert eng._get_alpha_surprise() == 0.2  # falls back to default
 
 
 def test_constructor_override_beats_env_var(tmp_path, monkeypatch):
@@ -368,12 +368,12 @@ def test_precedence_chain_in_one_function(monkeypatch, tmp_path):
     from truememory.engine import TrueMemoryEngine
     from truememory.storage import create_db
 
-    # (1) No env, no override -> 0.3 (default)
+    # (1) No env, no override -> 0.2 (default)
     monkeypatch.delenv("TRUEMEMORY_ALPHA_SURPRISE", raising=False)
     create_db(tmp_path / "a.db").close()
     engine = TrueMemoryEngine(tmp_path / "a.db")
     engine.open(rebuild_vectors=False)
-    assert engine._get_alpha_surprise() == 0.3
+    assert engine._get_alpha_surprise() == 0.2
 
     # (2) Env=0.3, no override -> 0.3
     monkeypatch.setenv("TRUEMEMORY_ALPHA_SURPRISE", "0.3")
@@ -412,7 +412,7 @@ def test_non_finite_alpha_falls_back_to_zero(
     engine.open(rebuild_vectors=False)
 
     with caplog.at_level(logging.WARNING, logger="truememory.engine"):
-        assert engine._get_alpha_surprise() == 0.3  # falls back to default
+        assert engine._get_alpha_surprise() == 0.2  # falls back to default
 
     assert any(
         "TRUEMEMORY_ALPHA_SURPRISE" in rec.message

--- a/truememory/client.py
+++ b/truememory/client.py
@@ -37,7 +37,7 @@ class Memory:
               Multiplies each message's post-rerank score by
               ``(1 + alpha_surprise * surprise)``. Default ``None``
               resolves to the ``TRUEMEMORY_ALPHA_SURPRISE`` env var
-              (or 0.3). Set explicitly to ``0`` to disable.
+              (or 0.2). Set explicitly to ``0`` to disable.
               See MEMORIST-L5 research for rationale.
     """
 

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -245,8 +245,8 @@ class TrueMemoryEngine:
         :param alpha_surprise: Optional override for the MEMORIST-L5
             surprise rerank boost coefficient. When set, takes priority
             over ``TRUEMEMORY_ALPHA_SURPRISE`` env var and the default
-            of 0.3. Range [0, ~2.0]; the MEMORIST-L5 session
-            recommended α=0.3 pending Modal validation. See
+            of 0.2. Range [0, ~2.0]; Modal alpha sweep (2026-04-26)
+            found α=0.2 is the empirical peak. See
             ``_working/memorist/l5_predictive/REPORT.md``.
         """
         self.db_path = Path(db_path) if db_path else Path(__file__).parent.parent / "truememory.db"
@@ -1551,11 +1551,12 @@ class TrueMemoryEngine:
     # `surprise_scores.message_id` would silently mismatch and rewrite
     # unrelated rows' scores.
     #
-    # Default α=0.3 per commit 816ec48: the MEMORIST-L5 session measured
-    # +2.0 pts P@10 on short-horizon at α=0.3 (McNemar p≈0.0625, not yet
-    # significant). Modal validation pending — revert to 0 if p≥0.05.
+    # Default α=0.2 per Modal alpha sweep (2026-04-26): 5-point sweep
+    # (0, 0.1, 0.15, 0.2, 0.3) × 3 seeds each found α=0.2 is the
+    # empirical peak at 93.20% mean LoCoMo (vs 93.00% at α=0, 93.07%
+    # at α=0.3). Cross-validated on GPUBox (RTX 5090).
     #
-    # Precedence: constructor arg > env var > 0.3.
+    # Precedence: constructor arg > env var > 0.2.
     #
     # See ``_working/memorist/l5_predictive/REPORT.md`` §1, §10 for
     # rationale and ``ISSUES.md`` for the follow-up validation plan.
@@ -1579,11 +1580,11 @@ class TrueMemoryEngine:
             for seg in source.split("+")
         )
 
-    _DEFAULT_ALPHA_SURPRISE = 0.3
+    _DEFAULT_ALPHA_SURPRISE = 0.2
 
     def _get_alpha_surprise(self) -> float:
         """Resolve alpha_surprise per MEMORIST-L5 precedence:
-        constructor arg > TRUEMEMORY_ALPHA_SURPRISE env var > 0.3.
+        constructor arg > TRUEMEMORY_ALPHA_SURPRISE env var > 0.2.
 
         Sanitizes against non-finite values (inf, -inf, nan) and
         TypeError/ValueError. Negative values are clamped to 0.


### PR DESCRIPTION
## Summary

- Changes the default L5 surprise boost alpha from 0.3 to 0.2
- Threshold 0.05/0.02 unchanged (already on main)

## Evidence

Modal alpha sweep (2026-04-26): 5 values × 3 seeds each, all at threshold 0.05/0.02:

| Alpha | Mean | StdDev | vs Baseline |
|-------|------|--------|-------------|
| 0 | 93.00% | ±0.30 | +0.10 |
| 0.1 | 92.70% | ±0.62 | -0.20 |
| 0.15 | 92.73% | ±0.59 | -0.17 |
| **0.2** | **93.20%** | **±0.35** | **+0.30** |
| 0.3 | 93.07% | ±0.15 | +0.17 |

Cross-validated on GPUBox (RTX 5090): α=0.2 scored 93.3% (1437/1540), highest single run of the sweep. Multi-hop strongest at 0.2 (93.5-93.8%).

## Test plan
- [x] All L5 tests pass (31/31) — default assertions updated from 0.3 to 0.2
- [x] Memory tests pass (9/9)
- [x] Docstrings and comments updated to reflect 0.2 default
- [x] CHANGELOG updated