### PR TITLE
fix(l0): normalize style_vec scores + wire score scale env var + blocklist fix

### DIFF
--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -1238,7 +1238,7 @@ class TrueMemoryEngine:
                     existing_ids = {r.get("id") for r in results if r.get("id")}
                     max_existing = max(
                         (r.get("score", 0) for r in results), default=0.05
-                    ) if results else 0.05
+                    )
                     _l0_scale_raw = os.environ.get("TRUEMEMORY_L0_SCORE_SCALE")
                     try:
                         _l0_scale = float(_l0_scale_raw) if _l0_scale_raw is not None else 0.9

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -1236,16 +1236,24 @@ class TrueMemoryEngine:
                 personality_results = search_personality(self.conn, query, limit=5)
                 if personality_results:
                     existing_ids = {r.get("id") for r in results if r.get("id")}
+                    max_existing = max(
+                        (r.get("score", 0) for r in results), default=0.05
+                    ) if results else 0.05
+                    _l0_scale_raw = os.environ.get("TRUEMEMORY_L0_SCORE_SCALE")
+                    try:
+                        _l0_scale = float(_l0_scale_raw) if _l0_scale_raw is not None else 0.9
+                    except (ValueError, TypeError):
+                        _l0_scale = 0.9
                     for pr in personality_results:
                         if "source" not in pr:
                             pr["source"] = "personality"
-                        # Scale profile-sourced scores to 0.8 so they rank high
-                        # but don't completely dominate hybrid results.
                         if pr.get("source") == "profile":
-                            pr["score"] = 0.8
+                            pr["score"] = max_existing * 0.8
+                        elif pr.get("source") == "style_vec":
+                            pr["score"] = max_existing * _l0_scale
                         pr_id = pr.get("id")
                         if pr_id and pr_id in existing_ids:
-                            continue  # Already in results
+                            continue
                         results.append(pr)
                         if pr_id:
                             existing_ids.add(pr_id)
@@ -1604,7 +1612,7 @@ class TrueMemoryEngine:
     # rationale and ``ISSUES.md`` for the follow-up validation plan.
 
     _SURPRISE_BOOST_SOURCE_BLOCKLIST = frozenset({
-        "personality", "profile", "summary", "contradiction",
+        "personality", "profile", "style_vec", "summary", "contradiction",
     })
     # IN-clause parameter chunk size. SQLite default is 999 variables —
     # keep a healthy margin for any other bound params in the query.

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -1244,13 +1244,12 @@ class TrueMemoryEngine:
                         _l0_scale = float(_l0_scale_raw) if _l0_scale_raw is not None else 0.9
                     except (ValueError, TypeError):
                         _l0_scale = 0.9
+                    _l0_scale = max(0.0, min(_l0_scale, 1.0))
                     for pr in personality_results:
                         if "source" not in pr:
                             pr["source"] = "personality"
-                        if pr.get("source") == "profile":
-                            pr["score"] = max_existing * 0.8
-                        elif pr.get("source") == "style_vec":
-                            pr["score"] = max_existing * _l0_scale
+                        if pr.get("source") in ("profile", "style_vec", "fts"):
+                            pr["score"] = max_existing * (0.8 if pr["source"] == "profile" else _l0_scale)
                         pr_id = pr.get("id")
                         if pr_id and pr_id in existing_ids:
                             continue


### PR DESCRIPTION
## Summary

Three bugs in the L0 personality integration that caused a -0.27% regression on LoCoMo:

1. **Score domain mismatch** — style_vec results scored 5.0-5.5 while hybrid/RRF results scored 0.016-0.033 (220x ratio). Personality results unconditionally dominated the top-k. Now normalized to `max_existing * scale` so they rank high but don't bulldoze factual answers.

2. **Missing blocklist entry** — `style_vec` source was not in `_SURPRISE_BOOST_SOURCE_BLOCKLIST`, so L5 surprise boost was further inflating already-dominant personality scores. Added.

3. **Score scale env var never wired** — `TRUEMEMORY_L0_SCORE_SCALE` was set by 12 benchmark scripts but never read by any truememory code. The entire score scale sweep was a no-op. Now wired: reads from env, defaults to 0.9.

## Root cause

The L0 implementation prompt (constraint #10) intentionally left scores uncapped. Post-implementation benchmarking revealed the 220x score ratio caused regression on factual queries that false-positive triggered `_has_personality_intent` (90/1540 LoCoMo questions, 5.8%).

## Test plan

- [x] All 55 tests pass (memory, L5, L0)
- [x] style_vec in blocklist verified
- [x] env var wiring verified
- [x] Score normalization verified