### PR TITLE
fix(gate): remove PE floor bias that guaranteed PE >= 0.10

### DIFF
--- a/tests/test_encoding_gate_pe_floor.py
+++ b/tests/test_encoding_gate_pe_floor.py
@@ -1,7 +1,5 @@
 """Test that the PE signal can reach zero for pure noise (no +0.1 floor)."""
 
-import pytest
-
 
 class MockMemoryWithScore:
     """Returns results with a specific score."""

--- a/tests/test_encoding_gate_pe_floor.py
+++ b/tests/test_encoding_gate_pe_floor.py
@@ -1,0 +1,42 @@
+"""Test that the PE signal can reach zero for pure noise (no +0.1 floor)."""
+
+import pytest
+
+
+class MockMemoryWithScore:
+    """Returns results with a specific score."""
+    def __init__(self, score: float, content: str = "existing"):
+        self._score = score
+        self._content = content
+    def search(self, query, **kwargs):
+        if self._score > 0:
+            return [{"content": self._content, "score": self._score}]
+        return []
+
+
+def test_pe_no_floor_for_noise():
+    """PE should be able to reach values below 0.10 for low-surprise messages.
+
+    The old formula `surprise * 0.8 + 0.1` guaranteed PE >= 0.10 for all
+    messages, adding 0.025 to every noise message's final score. The fix
+    removes the +0.1 floor so pure noise can get PE closer to zero.
+    """
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    # Use a moderate novelty (0.1 < novelty < 0.9) to avoid the early returns.
+    # Search score 0.50 -> novelty ~0.50 (in the mid-range).
+    gate = EncodingGate(
+        memory=MockMemoryWithScore(score=0.50, content="existing fact"),
+        threshold=0.30,
+    )
+    decision = gate.evaluate("ok", "")
+
+    # With the old formula (surprise * 0.8 + 0.1), minimum PE = 0.10.
+    # With the new formula (surprise * 0.9), PE for noise ("ok") should be:
+    # compute_surprise_score("ok", set()) returns 0.05 (noise match).
+    # New PE: 0.05 * 0.9 = 0.045.
+    # The PE should be below 0.10 (the old floor).
+    assert decision.prediction_error < 0.10, (
+        f"PE for noise message should be below 0.10 (old floor), "
+        f"got {decision.prediction_error}"
+    )

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -336,7 +336,7 @@ class EncodingGate:
                 # Surprise score is 0-1; treat it as prediction error
                 # but weight by novelty to prevent totally new topics from
                 # dominating (we already captured that in the novelty signal)
-                return max(0.0, min(1.0, surprise * 0.8 + 0.1))
+                return max(0.0, min(1.0, surprise * 0.9))
             except Exception as e:
                 log.debug("truememory surprise failed, using fallback: %s", e)
 


### PR DESCRIPTION
Closes #90

## What
Changes the prediction error transform from `surprise * 0.8 + 0.1` to `surprise * 0.9`, removing the +0.1 floor that guaranteed PE >= 0.10 for all messages.

## Why
The floor added 0.10 × 0.25 = 0.025 to every message's final gate score, biasing noise messages toward encoding. Pure noise (surprise=0.05) got PE=0.14 instead of PE=0.045. Found during the encoding gate code audit.

## Test
Added `tests/test_encoding_gate_pe_floor.py`:
- `test_pe_no_floor_for_noise` — verifies PE for noise message "ok" at moderate novelty (0.50) falls below the old 0.10 floor

Test fails on main (PE=0.14), passes after fix (PE=0.045). Full suite (368 tests) passes.