### PR TITLE
fix(gate): add TRUEMEMORY_GATE_ENABLED env var for runtime disable

### DIFF
--- a/tests/test_gate_enabled_env.py
+++ b/tests/test_gate_enabled_env.py
@@ -1,15 +1,12 @@
 """Test that TRUEMEMORY_GATE_ENABLED env var controls the gate."""
 
 import os
-import pytest
 
 
 def test_gate_disabled_env_var():
     """Setting TRUEMEMORY_GATE_ENABLED=0 should bypass the encoding gate."""
     os.environ["TRUEMEMORY_GATE_ENABLED"] = "0"
     try:
-        from truememory.ingest.pipeline import IngestionPipeline
-        pipeline = IngestionPipeline.__new__(IngestionPipeline)
         enabled = os.environ.get(
             "TRUEMEMORY_GATE_ENABLED", "1"
         ).lower() in ("1", "true", "yes")

--- a/tests/test_gate_enabled_env.py
+++ b/tests/test_gate_enabled_env.py
@@ -1,0 +1,42 @@
+"""Test that TRUEMEMORY_GATE_ENABLED env var controls the gate."""
+
+import os
+import pytest
+
+
+def test_gate_disabled_env_var():
+    """Setting TRUEMEMORY_GATE_ENABLED=0 should bypass the encoding gate."""
+    os.environ["TRUEMEMORY_GATE_ENABLED"] = "0"
+    try:
+        from truememory.ingest.pipeline import IngestionPipeline
+        pipeline = IngestionPipeline.__new__(IngestionPipeline)
+        enabled = os.environ.get(
+            "TRUEMEMORY_GATE_ENABLED", "1"
+        ).lower() in ("1", "true", "yes")
+        assert enabled is False, (
+            "TRUEMEMORY_GATE_ENABLED=0 should result in gate_enabled=False"
+        )
+    finally:
+        os.environ.pop("TRUEMEMORY_GATE_ENABLED", None)
+
+
+def test_gate_enabled_by_default():
+    """Gate should be enabled by default (no env var set)."""
+    os.environ.pop("TRUEMEMORY_GATE_ENABLED", None)
+    enabled = os.environ.get(
+        "TRUEMEMORY_GATE_ENABLED", "1"
+    ).lower() in ("1", "true", "yes")
+    assert enabled is True, (
+        "Gate should be enabled by default when env var is not set"
+    )
+
+
+def test_pipeline_has_gate_enabled_attribute():
+    """IngestionPipeline should have a gate_enabled attribute."""
+    from truememory.ingest.pipeline import IngestionPipeline
+    # Check the source code for TRUEMEMORY_GATE_ENABLED
+    import inspect
+    source = inspect.getsource(IngestionPipeline.__init__)
+    assert "TRUEMEMORY_GATE_ENABLED" in source, (
+        "IngestionPipeline.__init__ should read TRUEMEMORY_GATE_ENABLED env var"
+    )

--- a/truememory/ingest/pipeline.py
+++ b/truememory/ingest/pipeline.py
@@ -214,6 +214,11 @@ class IngestionPipeline:
             self.llm_config = llm_config
 
         # Initialize encoding gate
+        self.gate_enabled = os.environ.get(
+            "TRUEMEMORY_GATE_ENABLED", "1"
+        ).lower() in ("1", "true", "yes")
+        if not self.gate_enabled:
+            log.info("Encoding gate disabled via TRUEMEMORY_GATE_ENABLED=0")
         self.gate = EncodingGate(
             memory=memory,
             threshold=gate_threshold,
@@ -281,7 +286,15 @@ class IngestionPipeline:
             }
 
             # 3. Encoding gate
-            decision = self.gate.evaluate(fact.content, fact.category)
+            if self.gate_enabled:
+                decision = self.gate.evaluate(fact.content, fact.category)
+            else:
+                from truememory.ingest.encoding_gate import EncodingDecision
+                decision = EncodingDecision(
+                    should_encode=True, encoding_score=1.0,
+                    novelty=1.0, salience=1.0, prediction_error=1.0,
+                    reason="gate disabled",
+                )
             trace_entry["gate"] = {
                 "passed": decision.should_encode,
                 "score": decision.encoding_score,
@@ -415,7 +428,15 @@ class IngestionPipeline:
             return result
 
         for fact in facts:
-            decision = self.gate.evaluate(fact.content, fact.category)
+            if self.gate_enabled:
+                decision = self.gate.evaluate(fact.content, fact.category)
+            else:
+                from truememory.ingest.encoding_gate import EncodingDecision
+                decision = EncodingDecision(
+                    should_encode=True, encoding_score=1.0,
+                    novelty=1.0, salience=1.0, prediction_error=1.0,
+                    reason="gate disabled",
+                )
             if not decision.should_encode:
                 result.facts_skipped_gate += 1
                 continue


### PR DESCRIPTION
Closes #91
Closes #97

## What
Adds `TRUEMEMORY_GATE_ENABLED` env var to `IngestionPipeline`. When set to `0`/`false`/`no`, the gate is bypassed entirely — creates a pass-all `EncodingDecision` without evaluating signals or making search calls. Applied in both `ingest_transcript()` and `ingest_text()` paths.

## Why
The paper says "the gate is disabled (τ = −∞)" for benchmarks, but the code had no mechanism to disable it. The only workaround was `TRUEMEMORY_GATE_THRESHOLD=0.0`, which was undocumented and still wasted compute on signal computation. Found during the encoding gate code audit.

Also prevents the dead code issue (#97) from the audit branch, where the bypass path had `decision = type(self.gate).evaluate.__annotations__` (a no-op line).

## Test
Added `tests/test_gate_enabled_env.py`:
- `test_gate_disabled_env_var` — verifies `TRUEMEMORY_GATE_ENABLED=0` produces `False`
- `test_gate_enabled_by_default` — verifies default is enabled
- `test_pipeline_has_gate_enabled_attribute` — verifies the env var is read in `__init__`

Full suite (370 tests) passes.