### PR TITLE
fix(gate): add TRUEMEMORY_GATE_W_* env vars for signal weight tuning

### DIFF
--- a/tests/test_encoding_gate_weight_env.py
+++ b/tests/test_encoding_gate_weight_env.py
@@ -1,7 +1,6 @@
 """Test that signal weights can be configured via env vars."""
 
 import os
-import pytest
 
 
 class MockMemoryEmpty:

--- a/tests/test_encoding_gate_weight_env.py
+++ b/tests/test_encoding_gate_weight_env.py
@@ -1,0 +1,39 @@
+"""Test that signal weights can be configured via env vars."""
+
+import os
+import pytest
+
+
+class MockMemoryEmpty:
+    def search(self, *a, **kw):
+        return []
+
+
+def test_env_var_weights_applied():
+    """TRUEMEMORY_GATE_W_* env vars should override default weights."""
+    os.environ["TRUEMEMORY_GATE_W_NOVELTY"] = "0.10"
+    os.environ["TRUEMEMORY_GATE_W_SALIENCE"] = "0.60"
+    os.environ["TRUEMEMORY_GATE_W_PE"] = "0.30"
+    try:
+        from truememory.ingest.encoding_gate import EncodingGate
+        gate = EncodingGate(memory=MockMemoryEmpty())
+        assert abs(gate.w_novelty - 0.10) < 1e-9, f"Expected w_novelty=0.10, got {gate.w_novelty}"
+        assert abs(gate.w_salience - 0.60) < 1e-9, f"Expected w_salience=0.60, got {gate.w_salience}"
+        assert abs(gate.w_prediction_error - 0.30) < 1e-9, f"Expected w_pe=0.30, got {gate.w_prediction_error}"
+    finally:
+        os.environ.pop("TRUEMEMORY_GATE_W_NOVELTY", None)
+        os.environ.pop("TRUEMEMORY_GATE_W_SALIENCE", None)
+        os.environ.pop("TRUEMEMORY_GATE_W_PE", None)
+
+
+def test_explicit_args_override_env():
+    """Explicit constructor args should take precedence over env vars."""
+    os.environ["TRUEMEMORY_GATE_W_NOVELTY"] = "0.99"
+    try:
+        from truememory.ingest.encoding_gate import EncodingGate
+        gate = EncodingGate(memory=MockMemoryEmpty(), w_novelty=0.10)
+        assert abs(gate.w_novelty - 0.10) < 1e-9, (
+            f"Explicit arg should override env var: expected 0.10, got {gate.w_novelty}"
+        )
+    finally:
+        os.environ.pop("TRUEMEMORY_GATE_W_NOVELTY", None)

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -51,6 +51,7 @@ References (for inspiration, not literal modeling):
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 
 log = logging.getLogger(__name__)
@@ -141,13 +142,19 @@ class EncodingGate:
         self,
         memory,
         threshold: float = 0.30,
-        w_novelty: float = 0.40,
-        w_salience: float = 0.35,
-        w_prediction_error: float = 0.25,
+        w_novelty: float | None = None,
+        w_salience: float | None = None,
+        w_prediction_error: float | None = None,
         user_id: str = "",
     ):
         self.memory = memory
         self.threshold = threshold
+        if w_novelty is None:
+            w_novelty = float(os.environ.get("TRUEMEMORY_GATE_W_NOVELTY", "0.40"))
+        if w_salience is None:
+            w_salience = float(os.environ.get("TRUEMEMORY_GATE_W_SALIENCE", "0.35"))
+        if w_prediction_error is None:
+            w_prediction_error = float(os.environ.get("TRUEMEMORY_GATE_W_PE", "0.25"))
         self.w_novelty = w_novelty
         self.w_salience = w_salience
         self.w_prediction_error = w_prediction_error


### PR DESCRIPTION
Closes #87

## What
Changes constructor defaults from `w_novelty: float = 0.40` to `w_novelty: float | None = None`, with env var fallback when None. Three new env vars:
- `TRUEMEMORY_GATE_W_NOVELTY` (default 0.40)
- `TRUEMEMORY_GATE_W_SALIENCE` (default 0.35)
- `TRUEMEMORY_GATE_W_PE` (default 0.25)

Explicit constructor args still override env vars.

## Why
Operators couldn't tune gate weights without modifying source code. This blocks the benchmark sweep from testing different weight configurations. Found during the encoding gate code audit.

## Test
Added `tests/test_encoding_gate_weight_env.py`:
- `test_env_var_weights_applied` — sets env vars, verifies they're read
- `test_explicit_args_override_env` — verifies constructor args take precedence

Full suite (369 tests) passes.