### PR TITLE
fix(gate): smooth novelty discontinuity + clean category handling (closes #92, #93)

### DIFF
--- a/tests/test_encoding_gate_pe_floor.py
+++ b/tests/test_encoding_gate_pe_floor.py
@@ -22,7 +22,7 @@ def test_pe_no_floor_for_noise():
     from truememory.ingest.encoding_gate import EncodingGate
 
     # Use a moderate novelty (0.1 < novelty < 0.9) to avoid the early returns.
-    # Search score 0.50 -> novelty ~0.50 (in the mid-range).
+    # Search score 0.50 -> novelty ~0.33 (smooth function mid-range).
     gate = EncodingGate(
         memory=MockMemoryWithScore(score=0.50, content="existing fact"),
         threshold=0.30,

--- a/tests/test_encoding_gate_search_cache.py
+++ b/tests/test_encoding_gate_search_cache.py
@@ -27,7 +27,7 @@ def test_fallback_pe_reuses_novelty_search():
     gate = EncodingGate(memory=memory)
     gate.evaluate("Some fact about Portland", "")
 
-    # With score=0.5, novelty maps to ~0.50, which is in the mid-range
+    # With score=0.5, novelty maps to ~0.33 (smooth function), which is in the mid-range
     # (not > 0.9 and not < 0.05), so PE will use the truememory path
     # or fallback. The similar_memory lookup also fires (0.1 < 0.5 < 0.7).
     #

--- a/tests/test_encoding_gate_threshold.py
+++ b/tests/test_encoding_gate_threshold.py
@@ -1,5 +1,7 @@
 """Test that the encoding gate threshold uses >= (paper equation 4)."""
 
+import pytest
+
 
 class MockMemoryFixedScore:
     """Returns results with a controlled score to produce a known gate score."""
@@ -45,8 +47,6 @@ def test_docstring_mentions_gte():
         "Module docstring should use >= (matching paper equation 4), not >"
     )
 
-
-import pytest
 
 @pytest.mark.parametrize("search_score,expected_novelty", [
     (0.0, 1.0),

--- a/tests/test_encoding_gate_threshold.py
+++ b/tests/test_encoding_gate_threshold.py
@@ -44,3 +44,49 @@ def test_docstring_mentions_gte():
     assert ">=" in docstring or "≥" in docstring or "> 0.30" not in docstring, (
         "Module docstring should use >= (matching paper equation 4), not >"
     )
+
+
+import pytest
+
+@pytest.mark.parametrize("search_score,expected_novelty", [
+    (0.0, 1.0),
+    (0.05, 0.788),
+    (0.10, 0.700),
+    (0.25, 0.525),
+    (0.50, 0.328),
+    (1.0, 0.05),
+])
+def test_smooth_novelty_mapping(search_score, expected_novelty):
+    """Verify the smooth novelty inversion at multiple points."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    gate = EncodingGate(
+        memory=MockMemoryFixedScore(score=search_score),
+        w_novelty=1.0,
+        w_salience=0.0,
+        w_prediction_error=0.0,
+    )
+    decision = gate.evaluate("test fact", "")
+    assert abs(decision.novelty - expected_novelty) < 0.01, (
+        f"At search_score={search_score}, expected novelty ~{expected_novelty}, "
+        f"got {decision.novelty:.4f}"
+    )
+
+
+def test_novelty_monotonically_decreasing():
+    """Higher search similarity should produce lower novelty."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    prev_novelty = 2.0
+    for score in [0.0, 0.1, 0.2, 0.3, 0.5, 0.7, 0.9, 1.0]:
+        gate = EncodingGate(
+            memory=MockMemoryFixedScore(score=score),
+            w_novelty=1.0, w_salience=0.0, w_prediction_error=0.0,
+        )
+        decision = gate.evaluate("test", "")
+        assert decision.novelty <= prev_novelty, (
+            f"Novelty should decrease as similarity increases: "
+            f"score={score} gave novelty={decision.novelty}, "
+            f"but previous (lower score) gave {prev_novelty}"
+        )
+        prev_novelty = decision.novelty

--- a/tests/test_encoding_gate_threshold.py
+++ b/tests/test_encoding_gate_threshold.py
@@ -18,21 +18,20 @@ def test_threshold_boundary_gte():
     """Score exactly at threshold should pass the gate (>= per paper eq 4)."""
     from truememory.ingest.encoding_gate import EncodingGate
 
-    threshold = 0.50
+    # Use novelty-only weighting with empty memory (novelty=1.0)
+    # and set threshold to match the expected score
     gate = EncodingGate(
-        memory=MockMemoryFixedScore(score=0.50),
-        threshold=0.50,
+        memory=MockMemoryFixedScore(score=0.0),  # empty results → novelty=1.0
+        threshold=1.0,  # set threshold exactly at novelty=1.0
         w_novelty=1.0,
         w_salience=0.0,
         w_prediction_error=0.0,
     )
     decision = gate.evaluate("test fact", "")
-    # novelty at search_score=0.50: 0.30 + 0.40*(1-(0.50-0.4)/0.2) = 0.30+0.40*0.5 = 0.50
-    assert abs(decision.novelty - 0.50) < 0.01, f"Expected novelty ~0.50, got {decision.novelty}"
-    assert abs(decision.encoding_score - 0.50) < 0.01, f"Expected score ~0.50, got {decision.encoding_score}"
-    # Paper equation (4): score >= threshold should encode
+    assert abs(decision.novelty - 1.0) < 0.01, f"Expected novelty ~1.0, got {decision.novelty}"
+    # Paper equation (4): score >= threshold should encode (score=1.0 >= threshold=1.0)
     assert decision.should_encode is True, (
-        f"Score {decision.encoding_score} at threshold {threshold} should encode "
+        f"Score {decision.encoding_score} at threshold {gate.threshold} should encode "
         f"(paper equation 4 uses >=, not >)"
     )
 

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -265,18 +265,10 @@ class EncodingGate:
 
         top_score = max(0.0, min(1.0, top_score))
 
-        # Non-linear inversion so that:
-        # - very high similarity (>0.8) maps to near-zero novelty
-        # - moderate similarity (0.4-0.8) maps to partial novelty (0.2-0.6)
-        # - low similarity (<0.4) maps to high novelty (>0.7)
-        if top_score > 0.8:
-            return 0.05
-        elif top_score > 0.6:
-            return 0.30 * (1.0 - (top_score - 0.6) / 0.2)
-        elif top_score > 0.4:
-            return 0.30 + 0.40 * (1.0 - (top_score - 0.4) / 0.2)
-        else:
-            return 0.70 + 0.30 * (1.0 - top_score / 0.4)
+        # Continuous inversion: high similarity → low novelty, low → high.
+        # Single smooth function replaces the piecewise with discontinuity at 0.8.
+        # Maps [0, 1] → [1.0, 0.05] with steeper falloff at high similarity.
+        return max(0.05, 1.0 - top_score ** 0.5 * 0.95)
 
     # ------------------------------------------------------------------
     # Signal 2: Salience — delegates to truememory.salience when available
@@ -309,7 +301,8 @@ class EncodingGate:
 
         # Category boost from the LLM extractor — corrections and decisions
         # are worth more than generic technical details
-        boost = _CATEGORY_SALIENCE_BOOST.get(category.lower(), 0.05) if category else 0.05
+        cat = (category or "").strip().lower()
+        boost = _CATEGORY_SALIENCE_BOOST.get(cat, 0.05)
 
         return max(0.0, min(1.0, base + boost))
 


### PR DESCRIPTION
## Summary

Two low-severity gate cleanup fixes:

**#92 — Novelty piecewise discontinuity at score=0.8:**
The old 5-segment piecewise function had a 0.05 upward jump at the boundary where score=0.8. Replaced with a continuous function `max(0.05, 1.0 - score^0.5 * 0.95)` — same endpoints, smooth everywhere.

**#93 — Category handling conflated None/""/unknown:**
The old code used `if category else 0.05` which treated None, "", and missing category identically via a truthy check. Now normalizes with `(category or "").strip().lower()` before the dict lookup, making the behavior explicit.

## Test plan
- [x] All 27 gate tests pass
- [x] Full suite: 379 passed, 1 skipped
- [x] Updated threshold boundary test to not depend on piecewise-specific values