### PR TITLE
fix(gate): use cosine similarity for novelty instead of RRF (closes #85)

### DIFF
--- a/tests/test_encoding_gate_pe_floor.py
+++ b/tests/test_encoding_gate_pe_floor.py
@@ -22,7 +22,7 @@ def test_pe_no_floor_for_noise():
     from truememory.ingest.encoding_gate import EncodingGate
 
     # Use a moderate novelty (0.1 < novelty < 0.9) to avoid the early returns.
-    # Search score 0.50 -> novelty ~0.33 (smooth function mid-range).
+    # Search score 0.50 -> novelty ~0.50 (linear: 1.0 - 0.50).
     gate = EncodingGate(
         memory=MockMemoryWithScore(score=0.50, content="existing fact"),
         threshold=0.30,

--- a/tests/test_encoding_gate_search_cache.py
+++ b/tests/test_encoding_gate_search_cache.py
@@ -27,7 +27,7 @@ def test_fallback_pe_reuses_novelty_search():
     gate = EncodingGate(memory=memory)
     gate.evaluate("Some fact about Portland", "")
 
-    # With score=0.5, novelty maps to ~0.33 (smooth function), which is in the mid-range
+    # With score=0.5, novelty maps to ~0.50 (linear: 1.0 - 0.50), which is in the mid-range
     # (not > 0.9 and not < 0.05), so PE will use the truememory path
     # or fallback. The similar_memory lookup also fires (0.1 < 0.5 < 0.7).
     #

--- a/tests/test_encoding_gate_threshold.py
+++ b/tests/test_encoding_gate_threshold.py
@@ -4,7 +4,11 @@ import pytest
 
 
 class MockMemoryFixedScore:
-    """Returns results with a controlled score to produce a known gate score."""
+    """Returns results with a controlled score to produce a known gate score.
+
+    Provides both search() (hybrid fallback) and search_vectors() (cosine
+    path) so the gate tests exercise the preferred cosine code path.
+    """
 
     def __init__(self, score: float, content: str = "existing"):
         self._score = score
@@ -14,6 +18,10 @@ class MockMemoryFixedScore:
         if self._score > 0:
             return [{"content": self._content, "score": self._score}]
         return []
+
+    def search_vectors(self, query, limit=5):
+        """Return same results as search — gate prefers this method."""
+        return self.search(query)
 
 
 def test_threshold_boundary_gte():

--- a/tests/test_encoding_gate_threshold.py
+++ b/tests/test_encoding_gate_threshold.py
@@ -49,15 +49,16 @@ def test_docstring_mentions_gte():
 
 
 @pytest.mark.parametrize("search_score,expected_novelty", [
-    (0.0, 1.0),
-    (0.05, 0.788),
-    (0.10, 0.700),
-    (0.25, 0.525),
-    (0.50, 0.328),
-    (1.0, 0.05),
+    (0.0, 1.0),     # no match → fully novel
+    (0.05, 0.95),   # 1.0 - 0.05
+    (0.10, 0.90),   # 1.0 - 0.10
+    (0.25, 0.75),   # 1.0 - 0.25
+    (0.50, 0.50),   # 1.0 - 0.50
+    (0.95, 0.05),   # 1.0 - 0.95 = 0.05 (floor)
+    (1.0, 0.05),    # floor at 0.05
 ])
-def test_smooth_novelty_mapping(search_score, expected_novelty):
-    """Verify the smooth novelty inversion at multiple points."""
+def test_linear_novelty_mapping(search_score, expected_novelty):
+    """Verify the novelty = 1 - similarity inversion (paper eq 1)."""
     from truememory.ingest.encoding_gate import EncodingGate
 
     gate = EncodingGate(

--- a/truememory/client.py
+++ b/truememory/client.py
@@ -138,18 +138,22 @@ class Memory:
     ) -> list[dict]:
         """Search by pure vector cosine similarity (no FTS, no RRF fusion).
 
-        Returns results with ``score`` in [0, 1] based on cosine distance:
-        ``score = 1 / (1 + distance)``. Used by the encoding gate for
-        novelty detection where raw cosine similarity is needed instead
-        of the hybrid RRF score.
+        Returns results with ``score`` as cosine similarity in [0, 1]
+        (1.0 = identical, 0.0 = orthogonal). Used by the encoding gate
+        for novelty detection where the paper equation (1) specifies
+        n_t = 1 - max cos(v_t, v_{e'}).
+
+        sqlite-vec returns cosine distance d. We convert to similarity:
+        cos_sim = max(0, 1 - d). This gives the gate a score that can
+        be directly subtracted from 1.0 to get novelty.
 
         Falls back to regular search() if vector search is unavailable.
         """
         if self._engine.conn is None or not self._engine._has_vectors:
             return self.search(query, limit=limit)
         try:
-            from truememory.vector_search import search_vector
-            return search_vector(self._engine.conn, query, limit=limit)
+            from truememory.vector_search import search_vector_raw
+            return search_vector_raw(self._engine.conn, query, limit=limit)
         except Exception:
             return self.search(query, limit=limit)
 

--- a/truememory/client.py
+++ b/truememory/client.py
@@ -131,6 +131,28 @@ class Memory:
 
         return results[:limit]
 
+    def search_vectors(
+        self,
+        query: str,
+        limit: int = 5,
+    ) -> list[dict]:
+        """Search by pure vector cosine similarity (no FTS, no RRF fusion).
+
+        Returns results with ``score`` in [0, 1] based on cosine distance:
+        ``score = 1 / (1 + distance)``. Used by the encoding gate for
+        novelty detection where raw cosine similarity is needed instead
+        of the hybrid RRF score.
+
+        Falls back to regular search() if vector search is unavailable.
+        """
+        if self._engine.conn is None or not self._engine._has_vectors:
+            return self.search(query, limit=limit)
+        try:
+            from truememory.vector_search import search_vector
+            return search_vector(self._engine.conn, query, limit=limit)
+        except Exception:
+            return self.search(query, limit=limit)
+
     def search_deep(
         self,
         query: str,

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -241,22 +241,32 @@ class EncodingGate:
         """
         Proxy for hippocampal novelty detection.
 
-        Uses truememory's hybrid search to find the most similar existing
-        memory. High similarity → low novelty. Low similarity → high novelty.
+        Uses cosine similarity against existing memories to determine how
+        novel this fact is. High similarity → low novelty. Low similarity
+        → high novelty.
 
-        This is NOT a CA1 comparator in any neuroscientific sense — it's
-        vector-similarity inversion. The name is aspirational; the
-        implementation is a pragmatic proxy.
+        Prefers pure vector search (cosine distance) when available via
+        memory.search_vectors(). Falls back to hybrid search (RRF scores)
+        if vector search is unavailable. Paper equation (1) specifies
+        cosine similarity inversion: n_t = 1 - max cos(v_t, v_{e'}).
         """
-        results = self._search(fact, limit=5)
+        # Prefer cosine-based vector search (matches paper equation 1)
+        results = None
+        if hasattr(self.memory, "search_vectors"):
+            try:
+                results = self.memory.search_vectors(fact, limit=5)
+            except Exception:
+                pass
+
+        # Fall back to hybrid search if vector search unavailable
+        if results is None:
+            results = self._search(fact, limit=5)
+
         self._last_search_results = results
 
         if not results:
             return 1.0  # Empty memory = maximum novelty
 
-        # truememory search returns results with a `score` field (engine.py:726)
-        # Scores from hybrid search are RRF-fused, so they're bounded roughly
-        # in [0, 1] but can be low even for decent matches
         top_score = results[0].get("score", 0.0)
         try:
             top_score = float(top_score)
@@ -265,10 +275,11 @@ class EncodingGate:
 
         top_score = max(0.0, min(1.0, top_score))
 
-        # Continuous inversion: high similarity → low novelty, low → high.
-        # Single smooth function replaces the piecewise with discontinuity at 0.8.
-        # Maps [0, 1] → [1.0, 0.05] with steeper falloff at high similarity.
-        return max(0.05, 1.0 - top_score ** 0.5 * 0.95)
+        # Simple inversion: novelty = 1 - similarity.
+        # With cosine-based scores from search_vectors(), this directly
+        # implements the paper's n_t = 1 - max cos(v_t, v_{e'}).
+        # Floor at 0.05 so near-duplicates still get a tiny novelty signal.
+        return max(0.05, 1.0 - top_score)
 
     # ------------------------------------------------------------------
     # Signal 2: Salience — delegates to truememory.salience when available

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -507,6 +507,59 @@ def search_vector(
     return results
 
 
+def search_vector_raw(
+    conn: sqlite3.Connection,
+    query: str,
+    limit: int = 5,
+) -> list[dict]:
+    """Search by vector similarity, returning cosine similarity scores.
+
+    Unlike :func:`search_vector` which returns ``1/(1+distance)``, this
+    function converts sqlite-vec's cosine distance to cosine similarity:
+    ``cos_sim = max(0, 1 - distance)``. This is used by the encoding
+    gate where the paper equation (1) requires ``n_t = 1 - cos_sim``.
+    """
+    model = get_model()
+    query_embedding = model.encode([query])[0]
+    query_blob = serialize_f32(query_embedding)
+
+    rows = conn.execute(
+        """
+        SELECT v.rowid, v.distance,
+               m.content, m.sender, m.recipient,
+               m.timestamp, m.category, m.modality
+        FROM (
+            SELECT rowid, distance
+            FROM vec_messages
+            WHERE embedding MATCH ? AND k = ?
+        ) v
+        JOIN messages m ON m.id = v.rowid
+        ORDER BY v.distance
+        """,
+        (query_blob, limit),
+    ).fetchall()
+
+    results: list[dict] = []
+    for row in rows:
+        distance = row[1]
+        cos_sim = max(0.0, min(1.0, 1.0 - distance))
+
+        results.append(
+            {
+                "id": row[0],
+                "content": row[2],
+                "sender": row[3],
+                "recipient": row[4],
+                "timestamp": row[5],
+                "category": row[6],
+                "modality": row[7],
+                "score": round(cos_sim, 6),
+            }
+        )
+
+    return results
+
+
 # ---------------------------------------------------------------------------
 # Separation embeddings (B2: dual embedding support)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The novelty signal was using hybrid search RRF scores (which cluster in [0.01, 0.10] for conversational text) instead of cosine similarity. This caused novelty to saturate at ~0.98 for all messages, making the signal useless for discrimination. The paper's equation (1) specifies `n_t = 1 - max cos(v_t, v_{e'})`.

## Changes

- **New**: `Memory.search_vectors(query, limit)` — pure vector cosine similarity search, bypassing FTS and RRF fusion. Returns scores based on `1/(1+distance)` from sqlite-vec.
- **Modified**: `EncodingGate._compute_novelty()` — prefers `search_vectors()` when available, falls back to hybrid search. Novelty inversion simplified to `max(0.05, 1.0 - similarity)` which directly implements the paper equation.
- **Updated**: 7 novelty mapping tests + 2 stale comment fixes.

## Impact

With cosine-based scores, novelty should now produce a real distribution across [0, 1] instead of being stuck at 0.98. This means the three-signal gate can actually use novelty for discrimination. The benchmark sweep will validate.

## Test plan

- [x] 35 gate tests pass
- [x] Novelty mapping verified at 7 points (0.0→1.0, 0.5→0.5, 1.0→0.05)
- [x] Monotonicity test passes
- [x] Graceful fallback when vector search unavailable