### PR TITLE
fix(gate): decouple prediction error from novelty (closes #110)

### DIFF
--- a/tests/test_encoding_gate_pe_decoupled.py
+++ b/tests/test_encoding_gate_pe_decoupled.py
@@ -1,0 +1,66 @@
+"""Test that prediction error is decoupled from novelty (issue #110)."""
+
+
+class MockMemoryWithScore:
+    """Returns results with a specific score."""
+    def __init__(self, score: float, content: str = "existing"):
+        self._score = score
+        self._content = content
+    def search(self, query, **kwargs):
+        if self._score > 0:
+            return [{"content": self._content, "score": self._score}]
+        return []
+    def search_vectors(self, query, limit=5):
+        return self.search(query)
+
+
+def test_pe_not_clamped_at_high_novelty():
+    """PE should NOT return a fixed 0.30 when novelty is high.
+
+    Before this fix, lines 353-356 clamped PE to 0.30 whenever
+    novelty > 0.9. Now PE computes its own value independently.
+    """
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    # Empty memory = novelty will be 1.0 (max)
+    gate = EncodingGate(memory=MockMemoryWithScore(score=0.0))
+
+    # Evaluate two very different messages — their PE should differ
+    decision_noise = gate.evaluate("ok", "")
+    decision_signal = gate.evaluate("I just got promoted to VP and my salary is now $350,000", "personal")
+
+    # Before the fix, both would get PE=0.30 (clamped).
+    # After the fix, they should differ because the surprise scorer
+    # sees different content.
+    # We don't assert exact values (they depend on the scorer),
+    # but PE should no longer be identical for all high-novelty messages.
+    assert decision_noise.prediction_error != 0.30 or decision_signal.prediction_error != 0.30, (
+        f"PE should not be clamped to 0.30 for high-novelty messages. "
+        f"noise PE={decision_noise.prediction_error}, signal PE={decision_signal.prediction_error}"
+    )
+
+
+def test_pe_not_forced_zero_at_low_novelty():
+    """PE should NOT be forced to 0.0 when novelty is very low.
+
+    Before this fix, lines 358-360 forced PE to 0.0 whenever
+    novelty < 0.05. A near-duplicate that CONTRADICTS existing
+    memory should still get high PE.
+    """
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    # High similarity = low novelty (~0.05)
+    gate = EncodingGate(memory=MockMemoryWithScore(score=0.95, content="I work at Stripe"))
+
+    # This message contradicts existing memory — should have nonzero PE
+    # even though novelty is very low (near-duplicate text similarity)
+    decision = gate.evaluate("I switched from Stripe to Anthropic", "personal")
+
+    # The _looks_like_update heuristic should catch "switched from...to"
+    # and return high PE. Before the fix, PE was forced to 0.0 for
+    # low-novelty messages, so this contradiction would be invisible.
+    # We just check PE is not forced to exactly 0.0
+    assert decision.prediction_error > 0.0, (
+        f"PE should not be forced to 0.0 for near-duplicates that contain updates. "
+        f"Got PE={decision.prediction_error}"
+    )

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -349,16 +349,12 @@ class EncodingGate:
 
         Real predictive coding is Bayesian error propagation up a
         hierarchical generative model. This is not that.
+
+        NOTE: Previously this function gated on the novelty score
+        (returning fixed values for novelty > 0.9 or < 0.05). That
+        coupling was removed (issue #110) so PE can be evaluated
+        independently. The linear combination handles signal interaction.
         """
-        if novelty > 0.9:
-            # Completely novel topic — can't really have a prediction error
-            # because there's nothing to predict against
-            return 0.3
-
-        if novelty < 0.05:
-            # Near-duplicate — zero prediction error
-            return 0.0
-
         # Use truememory's surprise score if available
         if _HAS_TRUEMEMORY_PREDICTIVE and _tm_surprise is not None:
             try:
@@ -373,9 +369,9 @@ class EncodingGate:
                 log.debug("truememory surprise failed, using fallback: %s", e)
 
         # Fallback: use the moderate-similarity heuristic
-        return self._fallback_prediction_error(fact, novelty)
+        return self._fallback_prediction_error(fact)
 
-    def _fallback_prediction_error(self, fact: str, novelty: float) -> float:
+    def _fallback_prediction_error(self, fact: str) -> float:
         """Fallback prediction error when truememory.predictive isn't available."""
         results = self._last_search_results[:3] if self._last_search_results else self._search(fact, limit=3)
         if not results:


### PR DESCRIPTION
## Summary

Removes the hardcoded novelty-to-PE coupling that made prediction error dependent on the novelty signal. Previously:
- `novelty > 0.9` → PE clamped to 0.30 (every novel message got the same PE)
- `novelty < 0.05` → PE forced to 0.0 (near-duplicates couldn't show contradictions)

Now PE computes its own value independently. The linear combination handles signal interaction.

## Why

This is the prerequisite for issues #107, #108, #109 (new encoding-specific signal scorers). The coupling made it impossible to evaluate or tune PE independently — changing novelty's calibration silently changed PE's output.

## Changes

- Removed lines 353-360 (novelty-gated early returns)
- Removed unused `novelty` parameter from `_fallback_prediction_error()`
- 2 new tests verifying decoupling

## Test plan

- [x] 37 gate tests pass (35 existing + 2 new)
- [x] PE no longer clamped to 0.30 at high novelty
- [x] PE no longer forced to 0.0 at low novelty
- [x] Contradictions still detected via `_looks_like_update`