### PR TITLE
fix(bench): call set_active_tier before get_reranker (closes #75)

### DIFF
--- a/benchmarks/locomo/scripts/bench_truememory_base.py
+++ b/benchmarks/locomo/scripts/bench_truememory_base.py
@@ -208,8 +208,9 @@ def retrieve_truememory_base(conv_data, conv_idx):
     from truememory.vector_search import set_embedding_model
     set_embedding_model("base")
     from truememory.engine import TrueMemoryEngine
-    from truememory.reranker import get_reranker
+    from truememory.reranker import get_reranker, set_active_tier
     import tempfile
+    set_active_tier("base")
     get_reranker(model_name="Alibaba-NLP/gte-reranker-modernbert-base")
     msgs = parse_conv(conv_data)
     _tmp_db_file = tempfile.NamedTemporaryFile(suffix=".db", prefix=f"base_{conv_idx}_", delete=False)

--- a/benchmarks/locomo/scripts/bench_truememory_edge.py
+++ b/benchmarks/locomo/scripts/bench_truememory_edge.py
@@ -207,8 +207,9 @@ def retrieve_truememory_edge(conv_data, conv_idx):
     from truememory.vector_search import set_embedding_model
     set_embedding_model("edge")
     from truememory.engine import TrueMemoryEngine
-    from truememory.reranker import get_reranker
+    from truememory.reranker import get_reranker, set_active_tier
     import tempfile
+    set_active_tier("edge")
     get_reranker(model_name="cross-encoder/ms-marco-MiniLM-L-6-v2")
     msgs = parse_conv(conv_data)
     _tmp_db_file = tempfile.NamedTemporaryFile(suffix=".db", prefix=f"edge_{conv_idx}_", delete=False)

--- a/benchmarks/locomo/scripts/bench_truememory_pro.py
+++ b/benchmarks/locomo/scripts/bench_truememory_pro.py
@@ -218,8 +218,9 @@ def retrieve_truememory_pro(conv_data, conv_idx):
     from truememory.vector_search import set_embedding_model
     set_embedding_model("pro")
     from truememory.engine import TrueMemoryEngine
-    from truememory.reranker import get_reranker
+    from truememory.reranker import get_reranker, set_active_tier
     import tempfile
+    set_active_tier("pro")
     get_reranker(model_name="Alibaba-NLP/gte-reranker-modernbert-base")
     llm_fn = _tm_make_hyde_fn()
     msgs = parse_conv(conv_data)


### PR DESCRIPTION
## Summary

Add `set_active_tier()` call before `get_reranker()` in all three LoCoMo bench scripts (base, pro, edge).

## Why

After commit 683a401, `get_reranker(None)` resolves via `get_current_reranker_name()` which checks `_active_tier`. On bench workers (Modal), `_active_tier` is None → resolves to "edge" → MiniLM. The bench's explicit `get_reranker(model_name="gte...")` preload gets silently replaced by MiniLM when `engine.search_agentic()` later calls `get_reranker()` without a model name.

Result: Base bench silently reranks with MiniLM instead of gte-reranker-modernbert. -1.8pt regression on LoCoMo.

## Fix

One line per script: `set_active_tier("base")` / `set_active_tier("pro")` / `set_active_tier("edge")` before the `get_reranker()` preload. This pins the tier for the entire bench run.

## Verification

Traced the code path directly:
- With fix: `get_current_reranker_name()` → "Alibaba-NLP/gte-reranker-modernbert-base" for base/pro
- Without fix: `get_current_reranker_name()` → "cross-encoder/ms-marco-MiniLM-L-6-v2" (bug)

## Test plan

- [x] Ruff lint clean
- [x] Code path traced and verified programmatically
- [ ] CI green