### PR TITLE
fix(ingest): write hooks in correct {matcher, hooks} schema (closes #72)

### DIFF
--- a/tests/ingest/test_hook_schema.py
+++ b/tests/ingest/test_hook_schema.py
@@ -1,0 +1,140 @@
+"""Tests for Claude Code hook schema format (issue #72)."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_install_writes_correct_hook_schema():
+    """Hooks must use the {matcher, hooks: [{type, command}]} schema.
+
+    Claude Code rejects the entire settings.json if any hook entry
+    uses the old flat {type, command} format.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        settings_path = Path(tmpdir) / "settings.json"
+        settings_path.write_text("{}")
+
+        # Simulate the install by importing and calling the builder
+        from truememory.ingest.cli import _run_install
+
+        class FakeArgs:
+            user = ""
+            db = ""
+            dry_run = True  # don't actually write
+
+        # Capture the dry-run output
+        import io
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            _run_install(FakeArgs())
+
+        output = captured.getvalue()
+
+        # Parse the JSON from the dry-run output
+        json_start = output.index("{")
+        json_str = output[json_start:]
+        settings = json.loads(json_str)
+
+        hooks = settings.get("hooks", {})
+        assert hooks, "No hooks in output"
+
+        for event, entries in hooks.items():
+            assert isinstance(entries, list), f"{event}: entries should be a list"
+            for i, entry in enumerate(entries):
+                assert isinstance(entry, dict), f"{event}[{i}]: should be a dict"
+                assert "matcher" in entry, (
+                    f"{event}[{i}]: missing 'matcher' key. "
+                    f"Got keys: {list(entry.keys())}. "
+                    f"Claude Code requires {{matcher, hooks}} format."
+                )
+                assert "hooks" in entry, (
+                    f"{event}[{i}]: missing 'hooks' key. "
+                    f"Got keys: {list(entry.keys())}. "
+                    f"Claude Code requires {{matcher, hooks}} format."
+                )
+                assert isinstance(entry["hooks"], list), (
+                    f"{event}[{i}]: 'hooks' should be a list"
+                )
+                for j, inner in enumerate(entry["hooks"]):
+                    assert "type" in inner, f"{event}[{i}].hooks[{j}]: missing 'type'"
+                    assert "command" in inner, f"{event}[{i}].hooks[{j}]: missing 'command'"
+                    assert inner["type"] == "command", f"{event}[{i}].hooks[{j}]: type should be 'command'"
+
+                # Must NOT have flat format keys at the top level
+                assert "type" not in entry, (
+                    f"{event}[{i}]: has 'type' at top level — this is the OLD format. "
+                    f"Claude Code will reject the entire settings.json."
+                )
+                assert "command" not in entry, (
+                    f"{event}[{i}]: has 'command' at top level — this is the OLD format."
+                )
+
+
+def test_migration_upgrades_old_format():
+    """The installer should upgrade old-format hooks in existing settings.json."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        settings_path = Path(tmpdir) / "settings.json"
+
+        # Write old-format hooks
+        old_settings = {
+            "hooks": {
+                "SessionStart": [{
+                    "type": "command",
+                    "command": "/usr/bin/python3 /some/path/session_start.py",
+                }],
+                "Stop": [{
+                    "type": "command",
+                    "command": "/usr/bin/python3 /some/path/stop.py",
+                }],
+            }
+        }
+        settings_path.write_text(json.dumps(old_settings))
+
+        # Read back and simulate migration
+        existing = json.loads(settings_path.read_text())
+
+        # Apply migration logic (same as in cli.py)
+        for event in list(existing["hooks"].keys()):
+            entries = existing["hooks"][event]
+            if not isinstance(entries, list):
+                continue
+            migrated = []
+            for h in entries:
+                if not isinstance(h, dict):
+                    migrated.append(h)
+                    continue
+                if "type" in h and "command" in h and "hooks" not in h:
+                    migrated.append({"matcher": "", "hooks": [h]})
+                else:
+                    migrated.append(h)
+            existing["hooks"][event] = migrated
+
+        # Verify migrated format
+        for event, entries in existing["hooks"].items():
+            for entry in entries:
+                assert "matcher" in entry, f"{event}: missing matcher after migration"
+                assert "hooks" in entry, f"{event}: missing hooks after migration"
+                assert "type" not in entry, f"{event}: still has flat 'type' after migration"
+
+
+def test_new_format_not_double_wrapped():
+    """Hooks already in correct format should NOT be re-wrapped."""
+    correct_entry = {
+        "matcher": "",
+        "hooks": [{
+            "type": "command",
+            "command": "/usr/bin/python3 /some/path/stop.py",
+        }],
+    }
+
+    # Migration should leave this unchanged
+    h = correct_entry
+    if "type" in h and "command" in h and "hooks" not in h:
+        result = {"matcher": "", "hooks": [h]}
+    else:
+        result = h
+
+    assert result == correct_entry, "Correct-format entry was incorrectly modified"
+    assert len(result["hooks"]) == 1, "Should still have exactly one inner hook"

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -555,8 +555,11 @@ def _run_install(args):
     settings = {
         "hooks": {
             event: [{
-                "type": "command",
-                "command": _build_command(path),
+                "matcher": "",
+                "hooks": [{
+                    "type": "command",
+                    "command": _build_command(path),
+                }],
             }]
             for event, path in hook_files.items()
         }
@@ -614,6 +617,32 @@ def _run_install(args):
                 "(earlier versions registered the wrong event name)."
             )
 
+    # Migration: earlier versions wrote hooks in the flat format
+    # {type, command} instead of the required {matcher, hooks: [{type, command}]}.
+    # Claude Code rejects the entire settings.json when any hook uses the
+    # old format. Upgrade in-place before merging new entries.
+    for event in list(existing["hooks"].keys()):
+        entries = existing["hooks"][event]
+        if not isinstance(entries, list):
+            continue
+        migrated = []
+        did_migrate = False
+        for h in entries:
+            if not isinstance(h, dict):
+                migrated.append(h)
+                continue
+            if "type" in h and "command" in h and "hooks" not in h:
+                migrated.append({
+                    "matcher": "",
+                    "hooks": [h],
+                })
+                did_migrate = True
+            else:
+                migrated.append(h)
+        if did_migrate:
+            existing["hooks"][event] = migrated
+            print(f"Migrated '{event}' hook entries from old format to new {{matcher, hooks}} schema.")
+
     for event, hooks in settings["hooks"].items():
         existing["hooks"].setdefault(event, [])
         if not isinstance(existing["hooks"][event], list):
@@ -621,11 +650,22 @@ def _run_install(args):
         # Don't add duplicates (match on stop.py / session_start.py etc.)
         for hook in hooks:
             hook_file = str(hook_files[event])
-            already_present = any(
-                hook_file in h.get("command", "")
-                for h in existing["hooks"][event]
-                if isinstance(h, dict)
-            )
+            already_present = False
+            for h in existing["hooks"][event]:
+                if not isinstance(h, dict):
+                    continue
+                # Check new schema: {matcher, hooks: [{type, command}]}
+                inner_hooks = h.get("hooks", [])
+                if isinstance(inner_hooks, list):
+                    for ih in inner_hooks:
+                        if isinstance(ih, dict) and hook_file in ih.get("command", ""):
+                            already_present = True
+                            break
+                # Check old schema: {type, command} (for migration)
+                if hook_file in h.get("command", ""):
+                    already_present = True
+                if already_present:
+                    break
             if not already_present:
                 existing["hooks"][event].append(hook)
 


### PR DESCRIPTION
## Summary

Fix the hook installer to write Claude Code hooks in the correct `{matcher, hooks}` schema instead of the rejected flat `{type, command}` format.

## Why

Claude Code validates hook entries on launch. The old flat format causes the **entire settings.json to be skipped** — users lose all their settings (permissions, statusLine, env vars, MCP servers) until they manually fix the hook entries. This is the most destructive bug in the installer chain.

## What changed

**Before (wrong — Claude Code rejects this):**
```json
"SessionStart": [{"type": "command", "command": "python session_start.py"}]
```

**After (correct):**
```json
"SessionStart": [{"matcher": "", "hooks": [{"type": "command", "command": "python session_start.py"}]}]
```

## Migration

Users who already ran the old installer have broken entries in their `settings.json`. The fix includes automatic migration: when `truememory-ingest install` runs again, it detects old-format entries and upgrades them in-place before adding new hooks. Existing non-TrueMemory settings (permissions, env, etc.) are preserved.

## Verified

- Dry-run output produces correct schema for all 4 hooks
- Migration upgrades old-format entries without data loss
- Duplicate detection works with both old and new formats
- Existing settings (permissions, statusLine) survive the migration
- Already-correct entries are not double-wrapped

## Test plan

- [x] 3 dedicated schema tests (correct format, migration, no double-wrap)
- [x] Ruff lint clean
- [x] Manual verification of JSON output against Claude Code docs
- [ ] CI green