### PR TITLE
fix(install): wire up hooks + CLAUDE.md via truememory-ingest install (closes #70)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,10 +11,13 @@
 #   3. Installs truememory as an isolated uv tool.
 #   4. Runs `truememory-mcp --setup` (code from PyPI) to auto-configure
 #      Claude Code and/or Claude Desktop. Set TRUEMEMORY_SKIP_SETUP=1 to skip.
+#   5. Runs `truememory-ingest install` to wire up lifecycle hooks
+#      (SessionStart, Stop, UserPromptSubmit, PreCompact) and merge
+#      CLAUDE.md instructions so Claude uses TrueMemory proactively.
 #
 # Environment overrides:
 #   TRUEMEMORY_PY=3.12         # pin a specific Python (default: 3.12)
-#   TRUEMEMORY_EXTRAS=mcp      # pip extras (default: mcp; use "gpu,mcp" for Pro)
+#   TRUEMEMORY_EXTRAS=          # pip extras (default: none; use "gpu" for Pro/GPU support)
 #   TRUEMEMORY_SOURCE=...      # install from a local path or git URL instead of PyPI
 #                            # (useful for testing: TRUEMEMORY_SOURCE=/path/to/truememory)
 #   TRUEMEMORY_SKIP_SETUP=1    # skip the Claude auto-config step
@@ -44,7 +47,7 @@ main() {
   set -eu
 
   TRUEMEMORY_PY="${TRUEMEMORY_PY:-3.12}"
-  TRUEMEMORY_EXTRAS="${TRUEMEMORY_EXTRAS:-mcp}"
+  TRUEMEMORY_EXTRAS="${TRUEMEMORY_EXTRAS:-}"
   TRUEMEMORY_SOURCE="${TRUEMEMORY_SOURCE:-}"
 
   # Defend against hostile env vars (e.g. a malicious "paste this" blog post).
@@ -58,10 +61,18 @@ main() {
   esac
 
   if [ -n "$TRUEMEMORY_SOURCE" ]; then
-    PKG_SPEC="${TRUEMEMORY_SOURCE}[${TRUEMEMORY_EXTRAS}]"
+    if [ -n "$TRUEMEMORY_EXTRAS" ]; then
+      PKG_SPEC="${TRUEMEMORY_SOURCE}[${TRUEMEMORY_EXTRAS}]"
+    else
+      PKG_SPEC="$TRUEMEMORY_SOURCE"
+    fi
     say "using custom source: $TRUEMEMORY_SOURCE"
   else
-    PKG_SPEC="truememory[${TRUEMEMORY_EXTRAS}]"
+    if [ -n "$TRUEMEMORY_EXTRAS" ]; then
+      PKG_SPEC="truememory[${TRUEMEMORY_EXTRAS}]"
+    else
+      PKG_SPEC="truememory"
+    fi
   fi
 
   # ---------- preflight ----------
@@ -116,6 +127,10 @@ main() {
     # resolves to the isolated tool venv, so Claude gets a stable absolute path.
     truememory-mcp --setup || \
       warn "auto-setup returned non-zero (you can re-run it with: truememory-mcp --setup)"
+
+    say "installing hooks and CLAUDE.md instructions..."
+    truememory-ingest install || \
+      warn "hook install returned non-zero (you can re-run it with: truememory-ingest install)"
   fi
 
   # ---------- done ----------


### PR DESCRIPTION
## Summary

Add `truememory-ingest install` to `install.sh` so hooks and CLAUDE.md instructions are installed alongside the MCP server.

## Why

`install.sh` only ran `truememory-mcp --setup`, giving users MCP-only TrueMemory. Without hooks, no automatic conversation capture. Without CLAUDE.md, Claude doesn't know to use TrueMemory proactively. Users had to discover and run `truememory-ingest install` separately — which most never did.

## Changes

1. **Added `truememory-ingest install`** after MCP setup (line 131-133). Non-fatal on failure — warns and continues so the user at least gets MCP.
2. **Fixed TRUEMEMORY_EXTRAS default** from `"mcp"` to empty. The `[mcp]` pip extra was removed (mcp is now a direct dependency). The old default caused `uv` to print a confusing warning on every install.
3. **Updated header comment** to document step 5 (hooks + CLAUDE.md).

## Dependency

Should merge after PR #126 (hook schema fix, #72) — otherwise `truememory-ingest install` writes hooks in the old broken format that Claude Code rejects.

## Test plan

- [x] `truememory-ingest install` is non-interactive (no stdin prompts)
- [x] Failure is non-fatal (warns, doesn't die)
- [x] TRUEMEMORY_SKIP_SETUP=1 skips both MCP and hooks
- [x] Empty TRUEMEMORY_EXTRAS passes validation and produces `truememory` (no brackets)
- [ ] CI green