### PR TITLE
fix: assert TrueMemory precedence over built-in auto-memory (closes #73)

### DIFF
--- a/truememory/ingest/CLAUDE_TEMPLATE.md
+++ b/truememory/ingest/CLAUDE_TEMPLATE.md
@@ -1,18 +1,25 @@
 # TrueMemory — Persistent Memory
 
+TrueMemory is the **primary long-horizon memory** for this user. It persists facts, preferences, decisions, and corrections across sessions, projects, and machines.
+
+Claude Code's built-in auto-memory (`MEMORY.md` files under `~/.claude/projects/*/memory/`) is for **session-specific working notes only** — task state, scratch plans, and conversation context that does not need to survive across projects. It does NOT replace TrueMemory for user facts.
+
+**On any question about the user** ("what does the user like", "do you remember…", "what's my favorite…"), search TrueMemory **first, always**, before answering "I don't know." The built-in auto-memory does not contain long-horizon user facts.
+
 When the `truememory` MCP server is connected, follow these rules:
 
 ## Auto-Recall (every session)
 - At the START of each conversation, call `truememory_search` with a broad query about the user (e.g. "user preferences and context") to load relevant memories before responding.
-- Before making recommendations, check memory for stored preferences.
-- When the user asks anything about past conversations or "do you remember", search memory.
+- Before making recommendations, check TrueMemory for stored preferences.
+- When the user asks anything about past conversations, "do you remember", or any personal fact question — search TrueMemory. Do NOT answer "I don't know" without searching first.
 
 ## Auto-Store (during conversation)
 - When the user shares a personal preference, store it immediately via `truememory_store`. Do not ask permission.
 - When an important decision is made, store it.
 - When the user corrects you, store the correction.
-- When the user shares a fact about themselves (location, job, projects, etc.), store it.
+- When the user shares a fact about themselves (location, job, projects, relationships, etc.), store it.
 - Write each memory as a clear, atomic statement: "Prefers bun over npm" not "The user mentioned they like bun."
+- Do NOT store to the built-in auto-memory (`MEMORY.md`) for user facts — those go to TrueMemory only.
 - Do NOT store full conversations, large code blocks, or transient debugging context.
 
 ## Background Processing

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -72,10 +72,12 @@ def recall_memories(input_data: dict, user_id: str = "", db_path: str = "") -> s
     db = db_path or None
     memory = Memory(path=db) if db else Memory()
 
-    # Broad search for user context
     queries = [
-        "user preferences and personal information",
-        "recent decisions and project context",
+        "user preferences favorites likes dislikes",
+        "personal facts name location job role",
+        "recent decisions and commitments",
+        "corrections and updates to prior information",
+        "relationships family friends coworkers",
     ]
 
     all_results = []
@@ -99,8 +101,13 @@ def recall_memories(input_data: dict, user_id: str = "", db_path: str = "") -> s
     if not all_results:
         return ""
 
-    # Format as XML-tagged context block
-    lines = ["<truememory-context>", "## Your Memory of This User"]
+    lines = [
+        "<truememory-context>",
+        "## TrueMemory — What You Know About This User",
+        "These are facts from TrueMemory (the primary long-horizon memory system).",
+        "Use these to answer user questions. Search TrueMemory for more if needed.",
+        "",
+    ]
     for r in all_results[:MEMORY_LIMIT]:
         content = r.get("content", "").strip()
         if content:

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -122,6 +122,10 @@ mcp = FastMCP(
     "truememory",
     instructions="""You have access to a persistent memory system (TrueMemory). Use it proactively.
 
+IMPORTANT — MEMORY PRECEDENCE:
+TrueMemory is the PRIMARY long-horizon memory for this user. It persists facts, preferences, decisions, and corrections across sessions, projects, and machines. Claude Code's built-in auto-memory (MEMORY.md files) is for session-specific working notes only — NOT for user facts.
+On ANY question about the user ("what does the user like", "do you remember…", "what's my favorite…"), search TrueMemory FIRST, ALWAYS, before answering "I don't know." Do NOT store user facts to the built-in auto-memory — those go to TrueMemory only.
+
 FIRST-TIME SETUP (do this FIRST, before anything else):
 1. Call truememory_stats at the start of your first session.
 2. If the response contains "setup_required": true, present the "welcome" message to the user EXACTLY as written — it contains the setup instructions.


### PR DESCRIPTION
## Summary

Update CLAUDE_TEMPLATE.md and MCP system_instructions to explicitly establish TrueMemory as the primary memory system, overriding Claude Code's built-in auto-memory for user facts.

## Why

Users had to say "look in TrueMemory" explicitly. Claude treated the built-in auto-memory (MEMORY.md) and TrueMemory as equal — it would search MEMORY.md first, find nothing, and answer "I don't know" even when TrueMemory had the answer. Next session, same cold-start problem.

## What changed

**CLAUDE_TEMPLATE.md** (merged into user's `~/.claude/CLAUDE.md` on install):
- Added explicit hierarchy: TrueMemory = primary long-horizon memory, built-in auto-memory = session scratch only
- Added "search TrueMemory FIRST, ALWAYS, before answering 'I don't know'" for any user-fact question
- Added store-side: "Do NOT store user facts to the built-in auto-memory — those go to TrueMemory only"

**MCP system_instructions:**
- Added MEMORY PRECEDENCE block at the top of instructions with the same hierarchy language

## Why this works

CLAUDE.md is loaded as `claudeMd` in the system prompt. The system says "These instructions OVERRIDE any default behavior." The built-in auto-memory instructions are default behavior. Our CLAUDE.md wording takes precedence.

## Rustle findings

- The precedence wording is scoped to "any question about the user" — won't trigger TrueMemory searches on math/code/general questions
- Store-side redirect is scoped to "user facts" — project notes and task state can still go to MEMORY.md
- Both CLAUDE.md and MCP instructions assert precedence (belt and suspenders — different load paths)
- If TrueMemory MCP is not connected, instructions don't apply — falls back to built-in auto-memory gracefully

## Test plan

- [x] Ruff lint clean
- [x] MCP safety tests pass
- [ ] CI green
- [ ] Manual: start fresh session, ask "what are my preferences?" — Claude should search TrueMemory before answering