### PR TITLE
fix: 6 critical/high code health findings (closes #132, #139, #143, #144, #151, #152)

### DIFF
--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -637,6 +637,8 @@ class TrueMemoryEngine:
 
         self.conn = sqlite3.connect(str(self.db_path))
         self.conn.row_factory = None  # Use default tuple rows
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.execute("PRAGMA busy_timeout=5000")
 
         # Detect available tables
         tables = {
@@ -1034,7 +1036,17 @@ class TrueMemoryEngine:
         if _HAS_PERSONALITY:
             try:
                 t0 = time.time()
-                dunbar_result = build_dunbar_hierarchy(self.conn)
+                primary = None
+                try:
+                    row = self.conn.execute(
+                        "SELECT sender, COUNT(*) as cnt FROM messages "
+                        "GROUP BY sender ORDER BY cnt DESC LIMIT 1"
+                    ).fetchone()
+                    if row:
+                        primary = row[0]
+                except Exception:
+                    pass
+                dunbar_result = build_dunbar_hierarchy(self.conn, primary_entity=primary)
                 dunbar_count = len(dunbar_result) if isinstance(dunbar_result, dict) else dunbar_result
                 stats["dunbar_hierarchy"] = f"{dunbar_count} relationships in {time.time() - t0:.3f}s"
             except Exception as exc:

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -34,6 +34,7 @@ from pathlib import Path
 # Core modules (always available)
 # ───────────────────────────────────────────────────────────────────────────
 from truememory.storage import (
+    DEFAULT_BUSY_TIMEOUT_MS,
     create_db, load_messages_from_file, get_message_count,
     insert_message, delete_message, update_message, get_message,
 )
@@ -638,7 +639,6 @@ class TrueMemoryEngine:
         self.conn = sqlite3.connect(str(self.db_path))
         self.conn.row_factory = None  # Use default tuple rows
         self.conn.execute("PRAGMA journal_mode=WAL")
-        from truememory.storage import DEFAULT_BUSY_TIMEOUT_MS
         self.conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
 
         # Detect available tables
@@ -1046,8 +1046,8 @@ class TrueMemoryEngine:
                     ).fetchone()
                     if row and row[0] and row[0].strip():
                         primary = row[0]
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug("Failed to detect primary entity for Dunbar: %s", exc)
                 dunbar_result = build_dunbar_hierarchy(self.conn, primary_entity=primary)
                 dunbar_count = len(dunbar_result) if isinstance(dunbar_result, dict) else dunbar_result
                 stats["dunbar_hierarchy"] = f"{dunbar_count} relationships in {time.time() - t0:.3f}s"

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -638,7 +638,8 @@ class TrueMemoryEngine:
         self.conn = sqlite3.connect(str(self.db_path))
         self.conn.row_factory = None  # Use default tuple rows
         self.conn.execute("PRAGMA journal_mode=WAL")
-        self.conn.execute("PRAGMA busy_timeout=5000")
+        from truememory.storage import DEFAULT_BUSY_TIMEOUT_MS
+        self.conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
 
         # Detect available tables
         tables = {
@@ -1040,9 +1041,10 @@ class TrueMemoryEngine:
                 try:
                     row = self.conn.execute(
                         "SELECT sender, COUNT(*) as cnt FROM messages "
+                        "WHERE sender != '' AND sender IS NOT NULL "
                         "GROUP BY sender ORDER BY cnt DESC LIMIT 1"
                     ).fetchone()
-                    if row:
+                    if row and row[0] and row[0].strip():
                         primary = row[0]
                 except Exception:
                     pass

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -14,7 +14,8 @@ Usage::
     truememory-mcp
 
 Configuration via environment variables:
-    TRUEMEMORY_DB    Path to .db file (default: ~/.truememory/memories.db)
+    TRUEMEMORY_DB_PATH  Path to .db file (default: ~/.truememory/memories.db)
+                        (also accepts legacy TRUEMEMORY_DB)
     ANTHROPIC_API_KEY   For agentic search via Anthropic (optional)
     OPENROUTER_API_KEY  For agentic search via OpenRouter (optional, fallback)
 """
@@ -165,7 +166,9 @@ You should store and recall memories as naturally as a good assistant who rememb
 )
 
 _DB_PATH = os.path.expanduser(
-    os.environ.get("TRUEMEMORY_DB", str(Path.home() / ".truememory" / "memories.db"))
+    os.environ.get("TRUEMEMORY_DB_PATH",
+                   os.environ.get("TRUEMEMORY_DB",
+                                  str(Path.home() / ".truememory" / "memories.db")))
 )
 _memory: Memory | None = None
 _memory_lock = threading.Lock()
@@ -798,12 +801,15 @@ def truememory_configure(
         os.environ["TRANSFORMERS_OFFLINE"] = "1"
 
     # Build result with onboarding info
+    _tier_descriptions = {
+        "edge": "Edge: Model2Vec embeddings (8M params), MiniLM reranker (~30MB)",
+        "base": "Base: Qwen3 embeddings (256d), gte-reranker-modernbert (~1.5GB)",
+        "pro": "Pro: Qwen3 + HyDE query expansion (~1.5GB + API key)",
+    }
     result = {
         "status": "configured",
         "tier": tier,
-        "description": "Base: lightweight, works everywhere (~30MB)"
-        if tier == "base"
-        else "Pro: higher accuracy embeddings (~1.5GB)",
+        "description": _tier_descriptions.get(tier, f"Tier: {tier}"),
     }
     if rebuilt:
         result["note"] = "Existing memories have been re-embedded with the new model."

--- a/truememory/personality.py
+++ b/truememory/personality.py
@@ -23,9 +23,11 @@ All functions operate on a ``sqlite3.Connection`` produced by
 Python standard library.
 """
 
+import contextlib
 import json
 import re
 import sqlite3
+import warnings
 from collections import defaultdict
 from datetime import datetime, timezone
 
@@ -439,6 +441,13 @@ def _fts_search(conn: sqlite3.Connection, fts_query: str,
 # Public API
 # ---------------------------------------------------------------------------
 
+@contextlib.contextmanager
+def _warnings_ctx():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        yield
+
+
 def build_entity_profiles(conn: sqlite3.Connection) -> dict:
     """
     Analyze all messages and build personality profiles for key entities.
@@ -522,9 +531,7 @@ def build_entity_profiles(conn: sqlite3.Connection) -> dict:
                 "primary_topic": top_topic,
             }
 
-        import warnings
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
+        with _warnings_ctx():
             topics = _extract_topics(messages)
             traits = _extract_traits(messages)
 

--- a/truememory/personality.py
+++ b/truememory/personality.py
@@ -522,9 +522,11 @@ def build_entity_profiles(conn: sqlite3.Connection) -> dict:
                 "primary_topic": top_topic,
             }
 
-        # Topics and traits
-        topics = _extract_topics(messages)
-        traits = _extract_traits(messages)
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            topics = _extract_topics(messages)
+            traits = _extract_traits(messages)
 
         profile = {
             "message_count": len(messages),

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -25,8 +25,11 @@ Dependencies:
 
 from __future__ import annotations
 
+import logging
 import threading
 from typing import TYPE_CHECKING
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     pass
@@ -448,6 +451,6 @@ def rerank_with_llm(
         scored.sort(key=lambda r: (-r["llm_rerank_score"], -r.get("rrf_score", 0)))
         return scored[:top_k]
 
-    except Exception:
-        # Fallback: return original order
+    except Exception as e:
+        log.warning("LLM reranking failed: %s — returning original order", e)
         return results[:top_k]


### PR DESCRIPTION
## Summary

Fix the 6 critical/high findings from the code health audit (#132-#153).

## Fixes

| # | Severity | Fix |
|---|----------|-----|
| #152 | 🟠 High | **DB env var drift** — MCP used `TRUEMEMORY_DB`, hooks used `TRUEMEMORY_DB_PATH`. Now checks both, prefers `TRUEMEMORY_DB_PATH`. |
| #151 | 🟠 High | **Wrong tier descriptions** — Edge showed "Pro", Base showed "30MB". Fixed with correct per-tier dict. |
| #143 | 🟠 High | **Dunbar never ran** — `build_dunbar_hierarchy` called without `primary_entity`. Now auto-detects most frequent sender. |
| #132 | 🟠 High | **No WAL mode on open()** — concurrent access could lock. Added `PRAGMA journal_mode=WAL` and `busy_timeout=5000`. |
| #144 | 🟠 High | **Deprecated warnings on every ingest** — `_extract_topics`/`_extract_traits` emitted DeprecationWarning. Suppressed since calls are intentional. |
| #139 | 🟠 High | **rerank_with_llm swallowed errors** — bare `except` hid failures. Now logs warning before fallback. |

## Test plan

- [x] 437 tests pass, 0 failures
- [x] Ruff lint clean
- [ ] CI green