### PR TITLE
fix: 7 medium code health findings (#133, #134, #138, #140, #142, #146, #141)

### DIFF
--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -183,6 +183,7 @@ _QUERY_STOP_WORDS = frozenset({
     "about", "their", "they", "them", "his", "her", "its",
 })
 
+
 def _has_personality_intent(query: str) -> bool:
     """
     Return True if the query is genuinely asking about personality, preferences,
@@ -1954,10 +1955,6 @@ Return ONLY the queries, one per line, no numbering or explanation:"""
                     logger.debug("Focused content search failed in entity search", exc_info=True)
 
         return results
-
-    # ──────────────────────────────────────────────────────────────────────
-    # Query paraphrasing helper
-    # ──────────────────────────────────────────────────────────────────────
 
     # ──────────────────────────────────────────────────────────────────────
     # Result cleaning helper

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -175,13 +175,13 @@ except (ImportError, ModuleNotFoundError):
 # Helper
 # ───────────────────────────────────────────────────────────────────────────
 
-def _timed(label: str, fn, *args, **kwargs):
-    """Run *fn* and return ``(result, timing_str)``."""
-    t0 = time.time()
-    result = fn(*args, **kwargs)
-    elapsed = time.time() - t0
-    return result, f"{elapsed:.3f}s"
-
+_QUERY_STOP_WORDS = frozenset({
+    "what", "did", "does", "do", "how", "where", "when", "who",
+    "which", "why", "is", "are", "was", "were", "has", "have",
+    "had", "would", "could", "should", "will", "can", "the",
+    "a", "an", "in", "on", "at", "to", "for", "of", "with",
+    "about", "their", "they", "them", "his", "her", "its",
+})
 
 def _has_personality_intent(query: str) -> bool:
     """
@@ -1898,13 +1898,7 @@ Return ONLY the queries, one per line, no numbering or explanation:"""
         # ── 2. Search within matched senders ──────────────────────────────
         if matched_senders:
             # Build a focused query by removing the sender name and stop words
-            stop_words = {
-                "what", "did", "does", "do", "how", "where", "when", "who",
-                "which", "why", "is", "are", "was", "were", "has", "have",
-                "had", "would", "could", "should", "will", "can", "the",
-                "a", "an", "in", "on", "at", "to", "for", "of", "with",
-                "about", "their", "they", "them", "his", "her", "its",
-            }
+            stop_words = _QUERY_STOP_WORDS
 
             content_words = []
             for word in query_words:
@@ -1943,13 +1937,7 @@ Return ONLY the queries, one per line, no numbering or explanation:"""
         # ── 3. Focused content-only search ────────────────────────────────
         # Search with just the key content terms, dropping question structure
         if not matched_senders:
-            stop_words = {
-                "what", "did", "does", "do", "how", "where", "when", "who",
-                "which", "why", "is", "are", "was", "were", "has", "have",
-                "had", "would", "could", "should", "will", "can", "the",
-                "a", "an", "in", "on", "at", "to", "for", "of", "with",
-                "about", "their", "they", "them", "his", "her", "its",
-            }
+            stop_words = _QUERY_STOP_WORDS
             content_words = [
                 w.strip("'\"?.,!") for w in query_words
                 if w.strip("'\"?.,!").lower() not in stop_words
@@ -1970,32 +1958,6 @@ Return ONLY the queries, one per line, no numbering or explanation:"""
     # ──────────────────────────────────────────────────────────────────────
     # Query paraphrasing helper
     # ──────────────────────────────────────────────────────────────────────
-
-    def _generate_query_paraphrases(
-        self, query: str, llm_fn, max_paraphrases: int = 2,
-    ) -> list[str]:
-        """
-        Generate semantic paraphrases of a query to catch vocabulary
-        variations. Unlike HyDE (hypothetical answers), this generates
-        alternative question phrasings with different vocabulary.
-        """
-        prompt = f"""Given this question: "{query}"
-
-Generate {max_paraphrases} alternative phrasings that ask the SAME question but use DIFFERENT vocabulary.
-Each paraphrase should be short and search-friendly (not a hypothetical answer).
-
-Return ONLY the paraphrases, one per line, no numbering:"""
-
-        try:
-            response = llm_fn(prompt)
-            lines = [
-                line.strip().strip('"').strip("'").strip("-").strip()
-                for line in response.strip().split("\n")
-                if line.strip() and len(line.strip()) > 5
-            ]
-            return lines[:max_paraphrases]
-        except Exception:
-            return []
 
     # ──────────────────────────────────────────────────────────────────────
     # Result cleaning helper

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -83,7 +83,10 @@ if not _HAS_TRUEMEMORY_SALIENCE:
 # copies of the same word list. Falls back to a minimal set if the
 # salience module isn't available.
 try:
-    from truememory.ingest.encoding_salience import _NOISE_EXACT_V23 as _PE_NOISE
+    from truememory.ingest.encoding_salience import (
+        _NOISE_EXACT_V23 as _PE_NOISE,
+        _CATEGORY_SALIENCE_BOOST,
+    )
 except ImportError:
     _PE_NOISE = frozenset({
         "ok", "okay", "k", "kk", "yes", "yeah", "yep", "yup",
@@ -92,6 +95,11 @@ except ImportError:
         "sounds good", "sure", "bet", "word", "same", "mood", "idk",
         "gn", "gm", "brb", "ttyl", "damn", "dude", "bro", "ugh", "wow",
     })
+    _CATEGORY_SALIENCE_BOOST = {
+        "correction": 0.40, "decision": 0.30, "personal": 0.25,
+        "preference": 0.25, "relationship": 0.20, "temporal": 0.15,
+        "technical": 0.10, "general": 0.05,
+    }
 
 
 @dataclass
@@ -105,20 +113,6 @@ class EncodingDecision:
     reason: str = ""         # Human-readable explanation
     similar_memory: str = "" # Most similar existing memory (if any)
 
-
-# Category-level weights derived from the LLM extractor's classification.
-# These are not "the amygdala" — they are a pragmatic boost for fact types
-# that matter more for future retrieval (corrections > decisions > technical).
-_CATEGORY_SALIENCE_BOOST = {
-    "correction": 0.40,
-    "decision": 0.30,
-    "personal": 0.25,
-    "preference": 0.25,
-    "relationship": 0.20,
-    "temporal": 0.15,
-    "technical": 0.10,
-    "general": 0.05,
-}
 
 # Per-category threshold overrides. High-value categories (corrections,
 # decisions, relationships) get a lower bar to pass the gate because

--- a/truememory/personality.py
+++ b/truememory/personality.py
@@ -207,22 +207,24 @@ def _extract_proper_nouns(content: str) -> list[str]:
     return [w for w in words if w not in common]
 
 
+_EMOJI_RE = re.compile(
+    "[\U0001f600-\U0001f64f"  # emoticons
+    "\U0001f300-\U0001f5ff"   # symbols & pictographs
+    "\U0001f680-\U0001f6ff"   # transport & map
+    "\U0001f1e0-\U0001f1ff"   # flags
+    "\U00002702-\U000027b0"
+    "\U000024c2-\U0001f251"
+    "\U0001f900-\U0001f9ff"   # supplemental symbols
+    "\U0001fa00-\U0001fa6f"   # chess symbols
+    "\U0001fa70-\U0001faff"   # extended-A
+    "]+",
+    flags=re.UNICODE,
+)
+
+
 def _detect_emoji(content: str) -> bool:
     """Return True if content contains emoji characters."""
-    emoji_pattern = re.compile(
-        "[\U0001f600-\U0001f64f"  # emoticons
-        "\U0001f300-\U0001f5ff"   # symbols & pictographs
-        "\U0001f680-\U0001f6ff"   # transport & map
-        "\U0001f1e0-\U0001f1ff"   # flags
-        "\U00002702-\U000027b0"
-        "\U000024c2-\U0001f251"
-        "\U0001f900-\U0001f9ff"   # supplemental symbols
-        "\U0001fa00-\U0001fa6f"   # chess symbols
-        "\U0001fa70-\U0001faff"   # extended-A
-        "]+",
-        flags=re.UNICODE,
-    )
-    return bool(emoji_pattern.search(content))
+    return bool(_EMOJI_RE.search(content))
 
 
 def _assess_formality(messages: list[dict]) -> str:

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -191,6 +191,8 @@ def _normalize_and_fuse(
     top_k: int,
 ) -> list[dict]:
     """Normalize rerank + original scores to [0,1] and fuse."""
+    if not reranked:
+        return []
     rerank_scores = [r["rerank_score"] for r in reranked]
     rr_min, rr_max = min(rerank_scores), max(rerank_scores)
     rr_range = rr_max - rr_min if rr_max > rr_min else 1.0

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -183,6 +183,32 @@ def get_reranker(model_name: str | None = None, device: str | None = None):
 # Reranking
 # ---------------------------------------------------------------------------
 
+
+def _normalize_and_fuse(
+    reranked: list[dict],
+    rerank_weight: float,
+    rrf_weight: float,
+    top_k: int,
+) -> list[dict]:
+    """Normalize rerank + original scores to [0,1] and fuse."""
+    rerank_scores = [r["rerank_score"] for r in reranked]
+    rr_min, rr_max = min(rerank_scores), max(rerank_scores)
+    rr_range = rr_max - rr_min if rr_max > rr_min else 1.0
+
+    orig_scores = [r.get("score", r.get("rrf_score", 0)) for r in reranked]
+    orig_min, orig_max = min(orig_scores), max(orig_scores)
+    orig_range = orig_max - orig_min if orig_max > orig_min else 1.0
+
+    for r in reranked:
+        norm_rerank = (r["rerank_score"] - rr_min) / rr_range
+        norm_orig = (r.get("score", r.get("rrf_score", 0)) - orig_min) / orig_range
+        r["fused_score"] = rerank_weight * norm_rerank + rrf_weight * norm_orig
+        r["score"] = r["fused_score"]
+
+    reranked.sort(key=lambda r: r["fused_score"], reverse=True)
+    return reranked[:top_k]
+
+
 def rerank(
     query: str,
     results: list[dict],
@@ -264,24 +290,7 @@ def rerank_with_fusion(
         return []
 
     reranked = rerank(query, results, top_k=len(results), **kwargs)
-
-    # Normalize scores to [0, 1] for fair fusion
-    rerank_scores = [r["rerank_score"] for r in reranked]
-    rr_min, rr_max = min(rerank_scores), max(rerank_scores)
-    rr_range = rr_max - rr_min if rr_max > rr_min else 1.0
-
-    orig_scores = [r.get("score", r.get("rrf_score", 0)) for r in reranked]
-    orig_min, orig_max = min(orig_scores), max(orig_scores)
-    orig_range = orig_max - orig_min if orig_max > orig_min else 1.0
-
-    for r in reranked:
-        norm_rerank = (r["rerank_score"] - rr_min) / rr_range
-        norm_orig = (r.get("score", r.get("rrf_score", 0)) - orig_min) / orig_range
-        r["fused_score"] = rerank_weight * norm_rerank + rrf_weight * norm_orig
-        r["score"] = r["fused_score"]
-
-    reranked.sort(key=lambda r: r["fused_score"], reverse=True)
-    return reranked[:top_k]
+    return _normalize_and_fuse(reranked, rerank_weight, rrf_weight, top_k)
 
 
 # ---------------------------------------------------------------------------
@@ -321,23 +330,7 @@ def rerank_with_modality_fusion(
             if modality in ("episode", "fact"):
                 r["rerank_score"] = r["rerank_score"] * 1.2
 
-    # Normalize and fuse
-    rerank_scores = [r["rerank_score"] for r in reranked]
-    rr_min, rr_max = min(rerank_scores), max(rerank_scores)
-    rr_range = rr_max - rr_min if rr_max > rr_min else 1.0
-
-    orig_scores = [r.get("score", r.get("rrf_score", 0)) for r in reranked]
-    orig_min, orig_max = min(orig_scores), max(orig_scores)
-    orig_range = orig_max - orig_min if orig_max > orig_min else 1.0
-
-    for r in reranked:
-        norm_rerank = (r["rerank_score"] - rr_min) / rr_range
-        norm_orig = (r.get("score", r.get("rrf_score", 0)) - orig_min) / orig_range
-        r["fused_score"] = rerank_weight * norm_rerank + rrf_weight * norm_orig
-        r["score"] = r["fused_score"]
-
-    reranked.sort(key=lambda r: r["fused_score"], reverse=True)
-    return reranked[:top_k]
+    return _normalize_and_fuse(reranked, rerank_weight, rrf_weight, top_k)
 
 
 def _classify_question_type(query: str) -> str:

--- a/truememory/salience.py
+++ b/truememory/salience.py
@@ -378,7 +378,7 @@ def filter_by_salience(
 
     Args:
         results:      List of message dicts from search.
-        min_salience: Minimum salience score to keep (default 0.3).
+        min_salience: Minimum salience score to keep (default 0.10).
 
     Returns:
         Filtered list with ``salience`` scores attached.
@@ -503,7 +503,7 @@ def apply_salience_guard(
         query:        The original natural language query.
         conn:         Optional database connection for dynamic entity lookup.
                       If not provided, uses hardcoded entity list.
-        min_salience: Minimum salience threshold for filtering (default 0.25).
+        min_salience: Minimum salience threshold for filtering (default 0.10).
                       Lower values (e.g. 0.15) allow more results through for
                       broad/diffuse queries.
 


### PR DESCRIPTION
## Summary

7 medium-severity fixes from the code health audit. Dead code removal, duplicate consolidation, docstring fix, and regex compilation.

## Fixes

| # | Category | Fix |
|---|----------|-----|
| #133 | Dead code | Removed `_timed()` and `_generate_query_paraphrases()` — zero callers |
| #134 | Duplicate | Extracted `_QUERY_STOP_WORDS` frozenset from two identical inline dicts |
| #138 | Duplicate | Extracted `_normalize_and_fuse()` from identical fusion logic in two reranker functions |
| #140 | Duplicate | `_CATEGORY_SALIENCE_BOOST` now imported from encoding_salience.py instead of duplicated in encoding_gate.py |
| #142 | Docstring | `min_salience` defaults said 0.3/0.25 but actual is 0.10 |
| #146 | Performance | `_detect_emoji` regex compiled once at module level instead of every call |
| #141 | Dead code (noted) | `_FALLBACK_ENTITIES` is empty but loop is correct — left as extension point |

## Deferred to follow-up

| # | Why deferred |
|---|-------------|
| #135 | Touches hot search path — high regression risk |
| #136 | Needs public API method added to engine — changes API surface |
| #137 | Engine.py 2,275-line split is a full refactor |
| #145 | Cross-module _fts_search dedup — moderate risk |
| #147 | Pipeline _process_facts extraction — moderate risk |
| #153 | Noise sets serve different contexts intentionally |

## Test plan

- [x] 437 tests pass, 0 failures
- [x] Ruff lint clean
- [ ] CI green