### PR TITLE
fix: tighten emoji regex to resolve CodeQL alerts

### DIFF
--- a/truememory/personality.py
+++ b/truememory/personality.py
@@ -208,15 +208,19 @@ def _extract_proper_nouns(content: str) -> list[str]:
 
 
 _EMOJI_RE = re.compile(
-    "[\U0001f600-\U0001f64f"  # emoticons
+    "["
+    "\U0001f600-\U0001f64f"   # emoticons
     "\U0001f300-\U0001f5ff"   # symbols & pictographs
     "\U0001f680-\U0001f6ff"   # transport & map
-    "\U0001f1e0-\U0001f1ff"   # flags
-    "\U00002702-\U000027b0"
-    "\U000024c2-\U0001f251"
-    "\U0001f900-\U0001f9ff"   # supplemental symbols
+    "\U0001f1e0-\U0001f1ff"   # flags (regional indicators)
+    "\U0001f900-\U0001f9ff"   # supplemental symbols & pictographs
     "\U0001fa00-\U0001fa6f"   # chess symbols
-    "\U0001fa70-\U0001faff"   # extended-A
+    "\U0001fa70-\U0001faff"   # symbols & pictographs extended-A
+    "\U00002702-\U000027b0"   # dingbats subset
+    "\U0000fe00-\U0000fe0f"   # variation selectors
+    "\U0000200d"              # zero-width joiner
+    "\U00002640\U00002642"    # gender symbols
+    "\U000023cf\U000023e9-\U000023f3\U000023f8-\U000023fa"  # misc symbols
     "]+",
     flags=re.UNICODE,
 )


### PR DESCRIPTION
## Summary

Fix 7 CodeQL `py/overly-large-range` alerts in `personality.py` by replacing the overly-broad Unicode range `U+24C2–U+1F251` (~77,000 code points) with specific emoji block ranges.

## What was wrong

The range `\U000024c2-\U0001f251` started at "Ⓒ" and ended 77,000 code points later, matching CJK characters, mathematical symbols, music notation, and thousands of other non-emoji characters.

## Fix

Replaced with specific, narrow Unicode emoji ranges from the standard emoji blocks. Removed the monster range entirely. Added variation selectors and zero-width joiner for compound emoji like 👨‍👩‍👧‍👦.

## Test plan

- [x] 10 emoji detection tests pass (emoticons, flags, dingbats, compound, negatives)
- [x] 437 full test suite pass
- [x] Ruff lint clean
- [ ] CI green + CodeQL alerts resolved