### PR TITLE
fix: 3 code health quick fixes (#141, #155, #156)

### DIFF
--- a/truememory/ingest/models.py
+++ b/truememory/ingest/models.py
@@ -311,22 +311,40 @@ def _complete_anthropic(config: LLMConfig, prompt: str, system: str) -> str:
     }
 
     req = urllib.request.Request(url, data=body, headers=headers, method="POST")
-    try:
-        with urllib.request.urlopen(req, timeout=60) as resp:
-            raw = resp.read()
-    except urllib.error.HTTPError as e:
-        detail = ""
+
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_RETRIES + 1):
         try:
-            detail = e.read().decode("utf-8", errors="replace")[:500]
-        except Exception:
-            pass
-        raise LLMError(f"Anthropic HTTP {e.code}: {detail or e.reason}") from e
-    except urllib.error.URLError as e:
-        raise LLMError(f"Anthropic network error: {e.reason}") from e
-    except (socket.timeout, TimeoutError) as e:
-        raise LLMError("Anthropic request timed out") from e
-    except OSError as e:
-        raise LLMError(f"Anthropic connection error: {e}") from e
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                raw = resp.read()
+            break
+        except urllib.error.HTTPError as e:
+            last_exc = e
+            if attempt < _MAX_RETRIES and _should_retry(e):
+                wait = _retry_backoff(attempt)
+                log.info("Anthropic HTTP %d (attempt %d/%d), retrying in %.1fs",
+                         e.code, attempt + 1, _MAX_RETRIES, wait)
+                time.sleep(wait)
+                continue
+            detail = ""
+            try:
+                detail = e.read().decode("utf-8", errors="replace")[:500]
+            except Exception:
+                pass
+            raise LLMError(f"Anthropic HTTP {e.code}: {detail or e.reason}") from e
+        except (urllib.error.URLError, socket.timeout, TimeoutError, OSError) as e:
+            last_exc = e
+            if attempt < _MAX_RETRIES:
+                wait = _retry_backoff(attempt)
+                log.info("Anthropic %s (attempt %d/%d), retrying in %.1fs",
+                         type(e).__name__, attempt + 1, _MAX_RETRIES, wait)
+                time.sleep(wait)
+                continue
+            if isinstance(e, urllib.error.URLError):
+                raise LLMError(f"Anthropic network error: {e.reason}") from e
+            raise LLMError(f"Anthropic connection error: {e}") from e
+    else:
+        raise LLMError("Anthropic: max retries exceeded") from last_exc
 
     try:
         data = json.loads(raw)

--- a/truememory/salience.py
+++ b/truememory/salience.py
@@ -314,19 +314,11 @@ def get_known_entities(conn: sqlite3.Connection) -> list[str]:
     return [r[0] for r in rows if r[0] and r[0] != "self"]
 
 
-_FALLBACK_ENTITIES = []
-
-
 def detect_entities(query: str, conn: sqlite3.Connection | None = None) -> list[str]:
     """
     Extract entity references (person names) from a query.
 
     Matches against known entities from the database for accurate detection.
-    The database entity list is augmented with a hardcoded fallback list
-    to catch entities that appear in message content but are never direct
-    senders/recipients (e.g. "marcus" is discussed but never sends messages).
-
-    If no database connection is provided, uses only the fallback list.
 
     Args:
         query: Natural language query string.
@@ -338,16 +330,9 @@ def detect_entities(query: str, conn: sqlite3.Connection | None = None) -> list[
         returns ``["jordan", "dev", "sam"]``.
     """
     if conn is not None:
-        db_entities = get_known_entities(conn)
-        # Merge DB entities with fallback list (dedup, preserve order)
-        seen = set(db_entities)
-        known = list(db_entities)
-        for e in _FALLBACK_ENTITIES:
-            if e not in seen:
-                known.append(e)
-                seen.add(e)
+        known = get_known_entities(conn)
     else:
-        known = list(_FALLBACK_ENTITIES)
+        known = []
 
     query_lower = query.lower()
     found = []

--- a/truememory/temporal.py
+++ b/truememory/temporal.py
@@ -166,22 +166,6 @@ def _end_of_month(year: int, month: int) -> str:
     return f"{year:04d}-{month:02d}-{last_day:02d}"
 
 
-def _add_months(iso_date: str, months: int) -> str:
-    """Add (or subtract) months from an ISO date string."""
-    dt = datetime.fromisoformat(iso_date)
-    new_month = dt.month + months
-    new_year = dt.year + (new_month - 1) // 12
-    new_month = ((new_month - 1) % 12) + 1
-    # Clamp day to valid range for the target month
-    max_day = (
-        datetime(new_year + (1 if new_month == 12 else 0),
-                 (new_month % 12) + 1 if new_month < 12 else 1, 1)
-        - timedelta(days=1)
-    ).day
-    new_day = min(dt.day, max_day)
-    return f"{new_year:04d}-{new_month:02d}-{new_day:02d}"
-
-
 # ---------------------------------------------------------------------------
 # Temporal intent detection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three quick code health fixes from the audit.

| # | Fix |
|---|-----|
| #155 | Remove dead `_add_months()` from temporal.py — zero callers |
| #141 | Remove empty `_FALLBACK_ENTITIES` and dead loop in salience.py |
| #156 | Add retry with exponential backoff to `_complete_anthropic` — was the only LLM provider path without retry logic |

## Test plan

- [x] 437 tests pass
- [x] Ruff lint clean
- [ ] CI green