### PR TITLE
fix: onboarding bugs — stale scores, wrong upgrade command, uv cache (#167-#171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,20 +48,15 @@ One command. Works on any Mac or Linux box, even if your system Python is old or
 curl -LsSf https://raw.githubusercontent.com/buildingjoshbetter/TrueMemory/main/install.sh | sh
 ```
 
-**Step 3.** Wait ~1-2 minutes while it downloads and installs. You'll see progress messages scroll by.
+**Step 3.** Wait ~3-5 minutes while it downloads and installs. The installer pre-downloads models for all three tiers (Edge, Base, Pro) so you can switch between them instantly later.
 
-**Step 4.** If Claude Desktop was already open, **quit it with `Cmd+Q` and reopen it** (a new chat window is not enough; the config is only read at launch). Then start a new Claude session and TrueMemory walks you through choosing **Edge**, **Base**, or **Pro** on first run.
+**Step 4.** If Claude Desktop was already open, **quit it with `Cmd+Q` and reopen it** (a new chat window is not enough; the config is only read at launch). Then start a new Claude session and type **"Set up TrueMemory"**. TrueMemory walks you through choosing **Edge**, **Base**, or **Pro**.
 
-> **What this actually does:** installs [uv](https://docs.astral.sh/uv/) (Astral's Python tool manager) if needed, fetches a managed Python 3.12 into `~/.local/share/uv/`, installs TrueMemory into an isolated tool environment, registers the MCP server, wires up lifecycle hooks, and merges instructions into your `~/.claude/CLAUDE.md`. **Your system Python is never touched.** No sudo, no venvs, no pip struggle. Uninstall cleanly with `uv tool uninstall truememory`.
+> **Switching tiers later?** Just tell Claude "switch to Base" or "switch to Pro" in any session. All models are pre-installed, so switching is instant. Pro requires an LLM API key for HyDE query expansion.
 
-> **Want to audit the script first?** It's ~170 lines of shell, no sudo, stays entirely under `$HOME`. Read the source at [`install.sh`](install.sh), or download and inspect locally: `curl -LsSf https://raw.githubusercontent.com/buildingjoshbetter/TrueMemory/main/install.sh -o install.sh && less install.sh && sh install.sh`.
+> **What this actually does:** installs [uv](https://docs.astral.sh/uv/) (Astral's Python tool manager) if needed, fetches a managed Python 3.12 into `~/.local/share/uv/`, installs TrueMemory with all tier models into an isolated tool environment, registers the MCP server, wires up lifecycle hooks, and merges instructions into your `~/.claude/CLAUDE.md`. **Your system Python is never touched.** No sudo, no venvs, no pip struggle. Uninstall cleanly with `uv tool uninstall truememory`.
 
-> **Want Base or Pro** (adds Qwen3 embeddings + gte-reranker + sentence-transformers, ~1.5-2.5GB depending on OS)?
-> ```bash
-> curl -LsSf https://raw.githubusercontent.com/buildingjoshbetter/TrueMemory/main/install.sh | TRUEMEMORY_EXTRAS="gpu" sh
-> ```
-> The default install is **Edge** (~30MB, the CPU-only tier). If you pick Base or Pro during first-run setup, TrueMemory will prompt you to install the extra models. Pro additionally requires an LLM API key at runtime for HyDE.
-> *(Linux CPU-only boxes will pull PyTorch's default CUDA wheel, which is larger, ~2.5GB total. Mac installs are closer to ~1.5GB.)*
+> **Want to audit the script first?** It's ~200 lines of shell, no sudo, stays entirely under `$HOME`. Read the source at [`install.sh`](install.sh), or download and inspect locally: `curl -LsSf https://raw.githubusercontent.com/buildingjoshbetter/TrueMemory/main/install.sh -o install.sh && less install.sh && sh install.sh`.
 
 ### Python library (for developers)
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ One command. Works on any Mac or Linux box, even if your system Python is old or
 curl -LsSf https://raw.githubusercontent.com/buildingjoshbetter/TrueMemory/main/install.sh | sh
 ```
 
-**Step 3.** Wait ~3-5 minutes while it downloads and installs. The installer pre-downloads models for all three tiers (Edge, Base, Pro) so you can switch between them instantly later.
+**Step 3.** Wait ~3-5 minutes while it downloads and installs (up to 15-30 minutes on slower connections). The installer pre-downloads models for all three tiers (Edge, Base, Pro) so you can switch between them instantly later.
 
 **Step 4.** If Claude Desktop was already open, **quit it with `Cmd+Q` and reopen it** (a new chat window is not enough; the config is only read at launch). Then start a new Claude session and type **"Set up TrueMemory"**. TrueMemory walks you through choosing **Edge**, **Base**, or **Pro**.
 
-> **Switching tiers later?** Just tell Claude "switch to Base" or "switch to Pro" in any session. All models are pre-installed, so switching is instant. Pro requires an LLM API key for HyDE query expansion.
+> **Switching tiers later?** Just tell Claude "switch to Base" or "switch to Pro" in any session. All models are pre-installed, so switching is instant (if you have existing memories, they will be re-embedded with the new model, which may take a moment). Pro requires an LLM API key for HyDE query expansion.
+
+> **Updating to the latest version?** Run `uv tool upgrade truememory` in your terminal. Then restart Claude.
 
 > **What this actually does:** installs [uv](https://docs.astral.sh/uv/) (Astral's Python tool manager) if needed, fetches a managed Python 3.12 into `~/.local/share/uv/`, installs TrueMemory with all tier models into an isolated tool environment, registers the MCP server, wires up lifecycle hooks, and merges instructions into your `~/.claude/CLAUDE.md`. **Your system Python is never touched.** No sudo, no venvs, no pip struggle. Uninstall cleanly with `uv tool uninstall truememory`.
 

--- a/install.sh
+++ b/install.sh
@@ -149,8 +149,11 @@ BANNER
   printf '\n'
   ok "TrueMemory installed successfully."
   printf '\n'
-  printf '  %bFirst time?%b Start a new Claude session — TrueMemory will\n' "$GREEN" "$RESET"
-  printf '  walk you through tier selection automatically.\n'
+  printf '  %bFirst time?%b Start a new Claude session and type:\n' "$GREEN" "$RESET"
+  printf '\n'
+  printf '    %b%bSet up TrueMemory%b\n' "$BOLD" "$GREEN" "$RESET"
+  printf '\n'
+  printf '  TrueMemory will walk you through choosing Edge, Base, or Pro.\n'
   printf '\n'
   printf '  %b%bIMPORTANT — if Claude Desktop was already open:%b\n' "$YELLOW" "$BOLD" "$RESET"
   printf '    Quit it completely with %bCmd+Q%b and reopen it.\n' "$BOLD" "$RESET"

--- a/install.sh
+++ b/install.sh
@@ -128,27 +128,57 @@ main() {
   # ---------- step 5: pre-download models for all tiers ----------
   say "pre-downloading models for all tiers (Edge + Base + Pro)..."
   say "  this takes 2-5 min but means tier switching just works afterward."
-  # Use the tool's Python to run the download inside the uv venv
+  # Use the tool's Python to run the download inside the uv venv.
+  # stderr is filtered to show only download progress (lines with %)
+  # while suppressing noisy import warnings from torch/transformers.
   TOOL_PYTHON="$(uv tool dir)/truememory/bin/python"
   if [ -x "$TOOL_PYTHON" ]; then
     # Edge: Model2Vec embedder (usually bundled) + MiniLM reranker
+    say "  [1/3] Edge reranker (MiniLM-L-6-v2, ~22MB)..."
     "$TOOL_PYTHON" -c "
 from sentence_transformers import CrossEncoder
-print('  downloading Edge reranker (MiniLM-L-6-v2)...')
 CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')
-print('  ✓ Edge reranker cached')
-" 2>/dev/null && ok "Edge models ready" || warn "Edge reranker download failed (search still works without it)"
+print('done')
+" 2>&1 | grep -E '%|done|Downloading' | while IFS= read -r line; do
+      case "$line" in
+        *done*) ;;
+        *) printf '\r  %b%s%b' "$DIM" "$line" "$RESET" ;;
+      esac
+    done
+    printf '\r%80s\r' ""
+    ok "  [1/3] Edge reranker ready"
 
-    # Base/Pro: Qwen3 embedder + gte-reranker
+    # Base/Pro: Qwen3 embedder
+    say "  [2/3] Base/Pro embedder (Qwen3-Embedding-0.6B, ~1.2GB)..."
     "$TOOL_PYTHON" -c "
-from sentence_transformers import SentenceTransformer, CrossEncoder
-print('  downloading Base/Pro embedder (Qwen3-Embedding-0.6B, ~1.2GB)...')
+from sentence_transformers import SentenceTransformer
 SentenceTransformer('Qwen/Qwen3-Embedding-0.6B', truncate_dim=256)
-print('  ✓ embedder cached')
-print('  downloading Base/Pro reranker (gte-reranker-modernbert-base, ~600MB)...')
+print('done')
+" 2>&1 | grep -E '%|done|Downloading' | while IFS= read -r line; do
+      case "$line" in
+        *done*) ;;
+        *) printf '\r  %b%s%b' "$DIM" "$line" "$RESET" ;;
+      esac
+    done
+    printf '\r%80s\r' ""
+    ok "  [2/3] Base/Pro embedder ready"
+
+    # Base/Pro: gte-reranker
+    say "  [3/3] Base/Pro reranker (gte-modernbert, ~600MB)..."
+    "$TOOL_PYTHON" -c "
+from sentence_transformers import CrossEncoder
 CrossEncoder('Alibaba-NLP/gte-reranker-modernbert-base')
-print('  ✓ reranker cached')
-" 2>/dev/null && ok "Base/Pro models ready" || warn "Base/Pro model download failed (you can retry later or use Edge tier)"
+print('done')
+" 2>&1 | grep -E '%|done|Downloading' | while IFS= read -r line; do
+      case "$line" in
+        *done*) ;;
+        *) printf '\r  %b%s%b' "$DIM" "$line" "$RESET" ;;
+      esac
+    done
+    printf '\r%80s\r' ""
+    ok "  [3/3] Base/Pro reranker ready"
+
+    ok "all models pre-downloaded — tier switching is instant."
   else
     warn "could not locate tool Python at $TOOL_PYTHON — skipping model pre-download"
     warn "models will download on first use instead"

--- a/install.sh
+++ b/install.sh
@@ -111,7 +111,7 @@ main() {
   say "installing $PKG_SPEC (~1-2 min on first run)..."
   # --force makes re-runs idempotent. --python pins the interpreter to avoid
   # astral-sh/uv#14110. stderr stays visible so you see real progress and errors.
-  uv tool install --python "$TRUEMEMORY_PY" --force "$PKG_SPEC" >/dev/null || \
+  uv tool install --python "$TRUEMEMORY_PY" --force --refresh "$PKG_SPEC" >/dev/null || \
     die "truememory install failed (see error above)"
 
   # Future shells should see ~/.local/bin. Reversible via 'uv tool update-shell --uninstall'.

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@
 #
 # Environment overrides:
 #   TRUEMEMORY_PY=3.12         # pin a specific Python (default: 3.12)
-#   TRUEMEMORY_EXTRAS=          # pip extras (default: none; use "gpu" for Pro/GPU support)
+#   TRUEMEMORY_EXTRAS=          # (deprecated — gpu extras are now installed by default)
 #   TRUEMEMORY_SOURCE=...      # install from a local path or git URL instead of PyPI
 #                            # (useful for testing: TRUEMEMORY_SOURCE=/path/to/truememory)
 #   TRUEMEMORY_SKIP_SETUP=1    # skip the Claude auto-config step
@@ -61,18 +61,10 @@ main() {
   esac
 
   if [ -n "$TRUEMEMORY_SOURCE" ]; then
-    if [ -n "$TRUEMEMORY_EXTRAS" ]; then
-      PKG_SPEC="${TRUEMEMORY_SOURCE}[${TRUEMEMORY_EXTRAS}]"
-    else
-      PKG_SPEC="$TRUEMEMORY_SOURCE"
-    fi
+    PKG_SPEC="${TRUEMEMORY_SOURCE}[gpu]"
     say "using custom source: $TRUEMEMORY_SOURCE"
   else
-    if [ -n "$TRUEMEMORY_EXTRAS" ]; then
-      PKG_SPEC="truememory[${TRUEMEMORY_EXTRAS}]"
-    else
-      PKG_SPEC="truememory"
-    fi
+    PKG_SPEC="truememory[gpu]"
   fi
 
   # ---------- preflight ----------
@@ -108,7 +100,7 @@ main() {
     die "failed to install managed Python $TRUEMEMORY_PY (see error above)"
 
   # ---------- step 3: install truememory as a uv tool ----------
-  say "installing $PKG_SPEC (~1-2 min on first run)..."
+  say "installing $PKG_SPEC (~3-5 min on first run, downloads all tier models)..."
   # --force makes re-runs idempotent. --python pins the interpreter to avoid
   # astral-sh/uv#14110. stderr stays visible so you see real progress and errors.
   uv tool install --python "$TRUEMEMORY_PY" --force --refresh "$PKG_SPEC" >/dev/null || \
@@ -131,6 +123,35 @@ main() {
     say "installing hooks and CLAUDE.md instructions..."
     truememory-ingest install || \
       warn "hook install returned non-zero (you can re-run it with: truememory-ingest install)"
+  fi
+
+  # ---------- step 5: pre-download models for all tiers ----------
+  say "pre-downloading models for all tiers (Edge + Base + Pro)..."
+  say "  this takes 2-5 min but means tier switching just works afterward."
+  # Use the tool's Python to run the download inside the uv venv
+  TOOL_PYTHON="$(uv tool dir)/truememory/bin/python"
+  if [ -x "$TOOL_PYTHON" ]; then
+    # Edge: Model2Vec embedder (usually bundled) + MiniLM reranker
+    "$TOOL_PYTHON" -c "
+from sentence_transformers import CrossEncoder
+print('  downloading Edge reranker (MiniLM-L-6-v2)...')
+CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')
+print('  ✓ Edge reranker cached')
+" 2>/dev/null && ok "Edge models ready" || warn "Edge reranker download failed (search still works without it)"
+
+    # Base/Pro: Qwen3 embedder + gte-reranker
+    "$TOOL_PYTHON" -c "
+from sentence_transformers import SentenceTransformer, CrossEncoder
+print('  downloading Base/Pro embedder (Qwen3-Embedding-0.6B, ~1.2GB)...')
+SentenceTransformer('Qwen/Qwen3-Embedding-0.6B', truncate_dim=256)
+print('  ✓ embedder cached')
+print('  downloading Base/Pro reranker (gte-reranker-modernbert-base, ~600MB)...')
+CrossEncoder('Alibaba-NLP/gte-reranker-modernbert-base')
+print('  ✓ reranker cached')
+" 2>/dev/null && ok "Base/Pro models ready" || warn "Base/Pro model download failed (you can retry later or use Edge tier)"
+  else
+    warn "could not locate tool Python at $TOOL_PYTHON — skipping model pre-download"
+    warn "models will download on first use instead"
   fi
 
   # ---------- done ----------

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -325,9 +325,9 @@ def _run_setup(args):
     existing_tier = config.get("tier", "")
     print("  \033[1mEmbedding Tier\033[0m")
     print("  ─────────────")
-    print("  [1] Edge — 90.1% LoCoMo, CPU-only, ~30MB install. Works anywhere.")
-    print("  [2] Base — 91.5% LoCoMo, GPU recommended, ~1.5GB install. No API key needed.")
-    print("  [3] Pro  — 91.8% LoCoMo, GPU recommended, ~1.5GB install. Requires LLM API key (HyDE).")
+    print("  [1] Edge — 89.6% LoCoMo, CPU-only, ~30MB install. Works anywhere.")
+    print("  [2] Base — 92.0% LoCoMo, GPU recommended, ~1.5GB install. No API key needed.")
+    print("  [3] Pro  — 93.0% LoCoMo, GPU recommended, ~1.5GB install. Requires LLM API key (HyDE).")
     print()
 
     _TIER_NUM = {"edge": "1", "base": "2", "pro": "3"}
@@ -343,7 +343,9 @@ def _run_setup(args):
             import sentence_transformers  # noqa: F401
             print(f"  \033[32m✓ {tier.capitalize()} dependencies already installed\033[0m")
         except ImportError:
-            print(f"  \033[33m⚠ {tier.capitalize()} tier requires: pip install truememory[gpu]\033[0m")
+            print(f'  \033[33m⚠ {tier.capitalize()} tier requires GPU extras.\033[0m')
+            print(f'  \033[33m  curl installer: uv tool install "truememory[gpu]"\033[0m')
+            print(f'  \033[33m  pip:            pip install "truememory[gpu]"\033[0m')
             if not args.non_interactive:
                 do_install = input("  Install now? [y/N]: ").strip().lower()
                 if do_install == "y":
@@ -359,10 +361,11 @@ def _run_setup(args):
                         )
                     except subprocess.TimeoutExpired:
                         print(
-                            "  \033[33m⚠ pip install timed out after "
-                            "10 minutes. Try `pip install "
-                            "truememory[gpu]` directly, then re-run "
-                            "`truememory-ingest setup`.\033[0m",
+                            '  \033[33m⚠ Install timed out after '
+                            '10 minutes. Try running directly:\n'
+                            '    uv tool install "truememory[gpu]"   (curl installer)\n'
+                            '    pip install "truememory[gpu]"       (pip)\n'
+                            '  then re-run `truememory-ingest setup`.\033[0m',
                             file=sys.stderr,
                         )
                         print("  Falling back to Edge tier.")

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -344,8 +344,8 @@ def _run_setup(args):
             print(f"  \033[32m✓ {tier.capitalize()} dependencies already installed\033[0m")
         except ImportError:
             print(f'  \033[33m⚠ {tier.capitalize()} tier requires GPU extras.\033[0m')
-            print(f'  \033[33m  curl installer: uv tool install "truememory[gpu]"\033[0m')
-            print(f'  \033[33m  pip:            pip install "truememory[gpu]"\033[0m')
+            print('  \033[33m  curl installer: uv tool install "truememory[gpu]"\033[0m')
+            print('  \033[33m  pip:            pip install "truememory[gpu]"\033[0m')
             if not args.non_interactive:
                 do_install = input("  Install now? [y/N]: ").strip().lower()
                 if do_install == "y":

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -648,14 +648,14 @@ def truememory_stats() -> str:
             "\n"
             "Choose your tier:\n"
             "\n"
-            "  Edge — 90.1% accuracy on LoCoMo. CPU-only, works anywhere.\n"
+            "  Edge — 89.6% accuracy on LoCoMo. CPU-only, works anywhere.\n"
             "          Lightweight (~30MB install). No API key needed.\n"
             "\n"
-            "  Base — 91.5% accuracy on LoCoMo. GPU recommended.\n"
+            "  Base — 92.0% accuracy on LoCoMo. GPU recommended.\n"
             "          Paper-aligned Qwen3 @ 256d + gte-reranker (~1.5GB install).\n"
             "          No API key needed — fully offline.\n"
             "\n"
-            "  Pro  — 91.8% accuracy on LoCoMo. GPU recommended.\n"
+            "  Pro  — 93.0% accuracy on LoCoMo. GPU recommended.\n"
             "          Same models as Base plus HyDE query expansion.\n"
             "          Requires an API key (Anthropic / OpenRouter / OpenAI) for the HyDE LLM call.\n"
             "\n"
@@ -713,7 +713,10 @@ def truememory_configure(
             import sentence_transformers  # noqa: F401
         except ImportError:
             return json.dumps({
-                "error": f"{tier.capitalize()} tier requires an extra install. Run: pip install truememory[gpu]",
+                "error": f"{tier.capitalize()} tier requires GPU extras. "
+                         f"If you installed via the curl installer, run:  uv tool install \"truememory[gpu]\"  "
+                         f"If you used pip, run:  pip install \"truememory[gpu]\"  "
+                         f"Then restart Claude and try again.",
                 "current_tier": _load_config().get("tier", "edge"),
             })
 

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -49,7 +49,7 @@ _inference_lock = threading.Lock()  # Protects concurrent model.predict() calls
 #
 # Edge uses the lightweight MiniLM cross-encoder (22M params, CPU-friendly).
 # Base and Pro use gte-reranker-modernbert-base (149M, GPU recommended) —
-# required to reach the 91.5% / 91.8% LoCoMo targets for those tiers.
+# required to reach the 92.0% / 93.0% LoCoMo targets for those tiers.
 #
 # The active tier is cached in _active_tier. It's seeded lazily on first
 # get_current_reranker_name() call (from TRUEMEMORY_EMBED_MODEL env var or


### PR DESCRIPTION
## Summary

Five bugs found from real user testing on a fresh MacBook install. All relate to the Edge→Base/Pro upgrade path.

## Changes

| Issue | File | Fix |
|-------|------|-----|
| **#167** | `mcp_server.py`, `cli.py`, `reranker.py` | Tier scores 90.1/91.5/91.8 → 89.6/92.0/93.0 (7 locations) |
| **#168** | `mcp_server.py`, `cli.py` | Error message now shows both `uv tool install "truememory[gpu]"` and `pip install "truememory[gpu]"` with quotes |
| **#169** | `install.sh` | Added `--refresh` to `uv tool install` to bypass cached package resolution |
| **#170** | `mcp_server.py`, `cli.py` | Improved error messages guide users toward correct upgrade path |
| **#171** | `mcp_server.py` | Error message says "restart Claude and try again" |

## Root cause

A user installed TrueMemory via `curl | sh`, got Edge working, then tried to switch to Base. The system correctly detected missing GPU extras but told them to run `pip install truememory[gpu]` — wrong command for uv tool users. zsh also fails on unquoted brackets. User hit a dead end.

## Test plan
- [x] Zero stale scores (90.1/91.5/91.8) remaining in codebase
- [x] All `truememory[gpu]` references properly quoted in user-facing messages
- [x] install.sh uses `--refresh` flag
- [ ] CI green