### PR TITLE
docs: space out Quick Start steps and clarify advanced dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,27 @@
 
 **Step 1.** Open Terminal (Mac: `Cmd + Space`, type `Terminal`. Linux: `Ctrl + Alt + T`).
 
+&nbsp;
+
 **Step 2.** Paste this and press Enter:
 
 ```bash
 curl -LsSf https://raw.githubusercontent.com/buildingjoshbetter/TrueMemory/main/install.sh | sh
 ```
 
+&nbsp;
+
 **Step 3.** Wait 3-5 minutes. You'll see download progress bars.
+
+&nbsp;
 
 **Step 4.** Quit Claude completely (`Cmd+Q`) and reopen it.
 
+&nbsp;
+
 **Step 5.** Type **"Set up TrueMemory"** and pick Edge, Base, or Pro.
+
+&nbsp;
 
 That's it. TrueMemory remembers your conversations automatically from here.
 
@@ -54,7 +64,7 @@ That's it. TrueMemory remembers your conversations automatically from here.
 - **Uninstall:** run `uv tool uninstall truememory`
 
 <details>
-<summary><b>Advanced</b></summary>
+<summary><b>Click here for the advanced setup guide ▸</b></summary>
 
 #### What the installer does
 


### PR DESCRIPTION
## Summary
- Adds `&nbsp;` spacing between each of the 5 Quick Start steps so they don't feel cramped on GitHub's renderer
- Changes the Advanced collapsible from generic "Advanced" to "Click here for the advanced setup guide ▸" so users know it's clickable

## Test plan
- [ ] View README on GitHub — steps should have visible breathing room
- [ ] Advanced dropdown should render with the new text and ▸ arrow
- [ ] Clicking it still expands the full advanced section