### PR TITLE
fix: pip-only install messages + PATH guidance

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -198,6 +198,9 @@ BANNER
   printf '    uv tool upgrade truememory     %b# update to latest%b\n' "$DIM" "$RESET"
   printf '    uv tool uninstall truememory   %b# uninstall%b\n' "$DIM" "$RESET"
   printf '\n'
+  printf '  %bNote:%b If commands are not found, open a new terminal window\n' "$YELLOW" "$RESET"
+  printf '        or run: %bsource ~/.zshrc%b  (or %bsource ~/.bashrc%b)\n' "$BOLD" "$RESET" "$BOLD" "$RESET"
+  printf '\n'
 }
 
 main "$@"

--- a/tests/test_subprocess_timeouts.py
+++ b/tests/test_subprocess_timeouts.py
@@ -132,11 +132,11 @@ def test_pip_install_timeout_handler_prints_stderr_and_falls_back_to_edge():
     )
     # Must warn the user to stderr with an actionable message.
     assert "file=sys.stderr" in text
-    # Must fall back to edge tier on timeout.
+    # Must fall back to edge tier on install failure.
     pip_idx = text.find('"truememory[gpu]"]')
     assert pip_idx != -1
-    post = text[pip_idx : pip_idx + 800]
+    post = text[pip_idx : pip_idx + 1200]
     assert 'tier = "edge"' in post, (
-        "F25 regression: on pip timeout, setup must fall back to Edge tier "
+        "F25 regression: on install failure, setup must fall back to Edge tier "
         "rather than leave the user in an indeterminate state"
     )

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -355,8 +355,9 @@ def _run_setup(args):
                     # Hunter F25: bound install with a 10-minute timeout —
                     # long enough for model downloads from slow mirrors,
                     # short enough that a dead mirror doesn't wedge setup.
-                    _is_uv = "uv" in sys.executable or (
-                        shutil.which("uv") and ".local/share/uv/tools" in sys.executable
+                    _is_uv = (
+                        "/uv/tools/" in sys.executable
+                        and shutil.which("uv")
                     )
                     try:
                         if _is_uv:
@@ -370,10 +371,10 @@ def _run_setup(args):
                                  "truememory[gpu]"],
                                 timeout=600,
                             )
-                    except subprocess.TimeoutExpired:
+                    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
                         print(
-                            '  \033[33m⚠ Install timed out after '
-                            '10 minutes. Try running directly:\n'
+                            '  \033[33m⚠ Auto-install failed. '
+                            'Try running directly:\n'
                             '    uv tool install "truememory[gpu]"   (curl installer)\n'
                             '    pip install "truememory[gpu]"       (pip)\n'
                             '  then re-run `truememory-ingest setup`.\033[0m',

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -118,7 +118,8 @@ def _run_ingest(args):
     except ImportError:
         print(
             "ERROR: truememory is not installed.\n"
-            "       Install with: pip install truememory\n"
+            '       Install with: uv tool install truememory  (or: pip install truememory)\n'
+            "       If already installed, ensure ~/.local/bin is on your PATH.\n"
             "       (truememory-ingest depends on truememory>=0.1.3)",
             file=sys.stderr,
         )
@@ -349,16 +350,26 @@ def _run_setup(args):
             if not args.non_interactive:
                 do_install = input("  Install now? [y/N]: ").strip().lower()
                 if do_install == "y":
+                    import shutil
                     import subprocess
-                    # Hunter F25: bound pip with a 10-minute timeout —
+                    # Hunter F25: bound install with a 10-minute timeout —
                     # long enough for model downloads from slow mirrors,
                     # short enough that a dead mirror doesn't wedge setup.
+                    _is_uv = "uv" in sys.executable or (
+                        shutil.which("uv") and ".local/share/uv/tools" in sys.executable
+                    )
                     try:
-                        subprocess.run(
-                            [sys.executable, "-m", "pip", "install",
-                             "truememory[gpu]"],
-                            timeout=600,
-                        )
+                        if _is_uv:
+                            subprocess.run(
+                                ["uv", "tool", "install", "truememory[gpu]"],
+                                timeout=600,
+                            )
+                        else:
+                            subprocess.run(
+                                [sys.executable, "-m", "pip", "install",
+                                 "truememory[gpu]"],
+                                timeout=600,
+                            )
                     except subprocess.TimeoutExpired:
                         print(
                             '  \033[33m⚠ Install timed out after '
@@ -771,7 +782,8 @@ def _run_status(args):
         print(f"  [OK] truememory {version} importable")
     except ImportError as e:
         print(f"  [FAIL] truememory not importable: {e}")
-        print("         Install with: pip install truememory")
+        print('         Install with: uv tool install truememory  (or: pip install truememory)')
+        print("         If already installed, ensure ~/.local/bin is on your PATH.")
         return
 
     # 2. LLM backend

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -356,7 +356,7 @@ def _run_setup(args):
                     # long enough for model downloads from slow mirrors,
                     # short enough that a dead mirror doesn't wedge setup.
                     _is_uv = (
-                        "/uv/tools/" in sys.executable
+                        "/uv/tools/" in sys.executable.replace("\\", "/")
                         and shutil.which("uv")
                     )
                     try:

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1133,6 +1133,7 @@ def _setup_claude():
     else:
         if not claude_bin:
             print("  Claude Code CLI not found on PATH.")
+            print("  If you just installed it, try opening a new terminal window.")
         if not desktop_config_path.parent.exists():
             print("  Claude Desktop not detected.")
         print()
@@ -1151,7 +1152,7 @@ TrueMemory MCP server — persistent memory for AI agents.
 
 Options:
   --setup       Auto-configure TrueMemory as an MCP server in Claude Code
-                and/or Claude Desktop. Run this once after `pip install`.
+                and/or Claude Desktop. Run this once after installing.
   --help, -h    Show this help message and exit.
   --version, -V Show version and exit.
 


### PR DESCRIPTION
## Summary
- Fix 3 pip-only install/error messages to show both uv and pip commands (#168)
- Auto-detect uv vs pip for the setup wizard's GPU extras auto-install subprocess (#168)
- Add "open a new terminal" guidance to install output and error messages (#171)

## Changes

### #168: pip-only messages
- `ingest/cli.py:121` — preflight error now shows `uv tool install truememory (or: pip install truememory)`
- `ingest/cli.py:774` — status check error, same fix
- `mcp_server.py:1154` — help text changed from "after `pip install`" to "after installing"
- `ingest/cli.py:357-360` — **behavioral fix**: the setup wizard's auto-install now detects if running inside a uv tool environment and uses `uv tool install` instead of `pip install`

### #171: PATH guidance
- `install.sh` final output — added "If commands are not found, open a new terminal window"
- `mcp_server.py:1135` — "Claude Code CLI not found on PATH" now suggests opening a new terminal
- `ingest/cli.py:121,774` — "not installed" errors now suggest checking `~/.local/bin` on PATH

## Test plan
- [ ] Run `install.sh` on a fresh Mac — verify final output shows the new terminal note
- [ ] Run `truememory-ingest status` without truememory importable — verify error shows uv + pip + PATH hint
- [ ] Run `truememory-ingest setup`, select Base tier with missing deps, say "y" to install — verify uv is used (not pip) when running inside a uv tool environment
- [ ] Run `truememory-mcp --setup` without Claude CLI on PATH — verify "try opening a new terminal" message appears
- [ ] Run `truememory-mcp --help` — verify help text says "after installing" not "after pip install"

Closes #168, closes #171