### PR TITLE
feat: add upgrade-tier CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Everything lives locally in a single SQLite file at `~/.truememory/memories.db`.
 
 **How do I switch tiers (Edge → Base → Pro)?**
 
-Call `truememory_configure(tier="base")` (or `"pro"`) in any session. TrueMemory will automatically download the new models and re-embed all your existing memories. Base/Pro require `pip install "truememory[gpu]"` for the larger models. Pro also needs an API key for HyDE query expansion.
+Call `truememory_configure(tier="base")` (or `"pro"`) in any session, or run `truememory-ingest upgrade-tier base` from the terminal. All tier models are included in the standard install — switching just re-embeds your existing memories with the new model. Pro also needs an API key for HyDE query expansion.
 
 **I switched tiers and search results seem off. How do I fix it?**
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The database is created automatically at `~/.truememory/memories.db`.
 
 ## 🏗️ Edge / Base / Pro
 
-Same architecture, three tiers. Trade off install size and hardware for accuracy.
+Same architecture, three tiers. All included in a single install — switch anytime.
 
 | | Edge | Base | Pro |
 |---|------|------|-----|
@@ -122,7 +122,7 @@ Same architecture, three tiers. Trade off install size and hardware for accuracy
 | **Reranker** | MiniLM-L-6-v2 (22M) | gte-reranker-modernbert (149M) | gte-reranker-modernbert (149M) |
 | **HyDE** | off | off | on (requires LLM API key) |
 | **Runs on** | Any machine, CPU only | 4GB+ RAM, CPU or GPU | 4GB+ RAM + LLM API key |
-| **Install size** | ~30MB | ~1.5GB | ~1.5GB |
+| **Model size** | ~30MB | ~1.5GB | ~1.5GB |
 
 **Edge** works everywhere. **Base** is the strongest fully-offline tier. **Pro** adds HyDE query expansion for the highest scores.
 

--- a/install.sh
+++ b/install.sh
@@ -61,10 +61,10 @@ main() {
   esac
 
   if [ -n "$TRUEMEMORY_SOURCE" ]; then
-    PKG_SPEC="${TRUEMEMORY_SOURCE}[gpu]"
+    PKG_SPEC="${TRUEMEMORY_SOURCE}"
     say "using custom source: $TRUEMEMORY_SOURCE"
   else
-    PKG_SPEC="truememory[gpu]"
+    PKG_SPEC="truememory"
   fi
 
   # ---------- preflight ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,22 +29,20 @@ dependencies = [
     "model2vec>=0.6.0,<1.0",
     "sqlite-vec>=0.1.0,<1.0",
     "numpy>=1.24.0,<3.0",
-    # mcp[cli] and httpx are required by truememory.mcp_server, which is the
-    # primary entry point of this package (`truememory-mcp`). Previously these
-    # lived in the `[mcp]` optional extra, which caused `pip install truememory
-    # && truememory-mcp --setup` to crash with ModuleNotFoundError on first run.
-    # Moved to core in 0.3.0.
     "mcp[cli]>=1.0.0,<2.0",
     "httpx>=0.27.0,<1.0",
+    "sentence-transformers>=3.0.0,<6.0",
+    "torch>=2.0.0,<3.0",
 ]
 
 [project.optional-dependencies]
-# "gpu" and "reranker" name the same stack — one alias to keep them in sync.
-reranker = ["sentence-transformers>=3.0.0,<6.0", "torch>=2.0.0,<3.0"]
-gpu = ["truememory[reranker]"]
+# gpu/reranker kept as empty aliases so existing `pip install truememory[gpu]`
+# commands still work. All models are now included in the base install.
+reranker = []
+gpu = []
 agentic = ["anthropic>=0.80.0,<1.0"]
 dev = ["pytest>=7.0,<10.0", "ruff>=0.4,<1.0", "build>=1.2,<2.0", "twine>=5.0,<7.0"]
-all = ["truememory[gpu,reranker,agentic]"]
+all = ["truememory[agentic]"]
 
 [project.scripts]
 truememory-mcp = "truememory.mcp_server:main"

--- a/tests/test_configure_reembed.py
+++ b/tests/test_configure_reembed.py
@@ -63,9 +63,8 @@ def test_rebuild_exception_surfaces_in_result(server, monkeypatch):
 
     monkeypatch.setattr(vs, "build_vectors", _boom)
 
-    # Switch tier (edge → base) which triggers re-embed. truememory_configure
-    # imports sentence_transformers to validate the tier has its deps — stub
-    # the import so this test doesn't require the [gpu] extra installed.
+    # Switch tier (edge → base) which triggers re-embed. Stub
+    # sentence_transformers import so this test works in minimal envs.
     import builtins
     real_import = builtins.__import__
 

--- a/tests/test_reranker_init.py
+++ b/tests/test_reranker_init.py
@@ -1,9 +1,9 @@
 """Regression lock for Hunter F06 — `_set_reranker` must log + store
 errors instead of silently swallowing them.
 
-Prior behavior: `try: ... except Exception: pass`. ImportError on a user
-who installed `truememory` without `[gpu]`, HF hub offline + uncached
-model, CUDA OOM — all swallowed, Base/Pro silently degraded below Edge.
+Prior behavior: `try: ... except Exception: pass`. ImportError from a
+broken install, HF hub offline + uncached model, CUDA OOM — all
+swallowed, Base/Pro silently degraded below Edge.
 """
 from __future__ import annotations
 
@@ -38,7 +38,7 @@ def test_import_error_stores_last_error_with_install_hint(server, monkeypatch, c
 
     assert server._reranker_last_error is not None
     assert "ImportError" in server._reranker_last_error
-    assert "truememory[gpu]" in server._reranker_last_error
+    assert "reinstall truememory" in server._reranker_last_error
     assert any("Reranker init failed" in rec.message for rec in caplog.records)
 
 

--- a/tests/test_subprocess_timeouts.py
+++ b/tests/test_subprocess_timeouts.py
@@ -1,12 +1,11 @@
-"""Regression lock for Hunter F23 + F25 — subprocess.run timeouts.
+"""Regression lock for Hunter F23 — subprocess.run timeouts.
 
 F23: the four `claude` CLI calls in `mcp_server._setup_claude` now route
 through a `_run_claude` helper that passes `timeout=30` and reports
 `TimeoutExpired` to stderr instead of hanging forever.
 
-F25: the `pip install truememory[gpu]` call in `ingest/cli.py` now has
-`timeout=600` and a clear stderr message + fallback to Edge tier on
-timeout.
+(F25 tests removed — the truememory[gpu] auto-install subprocess was
+removed when all models became core dependencies.)
 """
 from __future__ import annotations
 
@@ -99,44 +98,3 @@ def test_setup_claude_timeout_on_list_call_is_handled(monkeypatch, capsys):
     assert "timed out" in captured.err.lower()
 
 
-# ---------------------------------------------------------------------------
-# F25 — `pip install truememory[gpu]` bounded by timeout
-# ---------------------------------------------------------------------------
-
-
-def test_pip_install_has_timeout_kwarg(monkeypatch):
-    """Source-level check: the pip install subprocess.run call must include
-    a timeout kwarg. This guards against accidental removal."""
-    import pathlib
-    cli_source = pathlib.Path(__file__).parent.parent / "truememory" / "ingest" / "cli.py"
-    text = cli_source.read_text()
-    # Locate the pip install call and verify timeout is declared nearby.
-    idx = text.find('"truememory[gpu]"]')
-    assert idx != -1, "pip install call for truememory[gpu] not found in cli.py"
-    surrounding = text[idx : idx + 300]
-    assert "timeout=600" in surrounding, (
-        "F25 regression: pip install must declare timeout=600 (10 min) "
-        "so PyPI/mirror stalls don't wedge `truememory-ingest setup`"
-    )
-
-
-def test_pip_install_timeout_handler_prints_stderr_and_falls_back_to_edge():
-    """Simulate the TimeoutExpired path by reading the source and
-    confirming the expected recovery behaviour is wired up."""
-    import pathlib
-    cli_source = pathlib.Path(__file__).parent.parent / "truememory" / "ingest" / "cli.py"
-    text = cli_source.read_text()
-    # Must have a TimeoutExpired handler for the pip call.
-    assert "subprocess.TimeoutExpired" in text, (
-        "F25 regression: TimeoutExpired must be caught, not propagated"
-    )
-    # Must warn the user to stderr with an actionable message.
-    assert "file=sys.stderr" in text
-    # Must fall back to edge tier on install failure.
-    pip_idx = text.find('"truememory[gpu]"]')
-    assert pip_idx != -1
-    post = text[pip_idx : pip_idx + 1200]
-    assert 'tier = "edge"' in post, (
-        "F25 regression: on install failure, setup must fall back to Edge tier "
-        "rather than leave the user in an indeterminate state"
-    )

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -526,7 +526,7 @@ def _run_setup(args):
 
 
 def _run_upgrade_tier(args):
-    """Switch embedding tier without re-running the full setup wizard."""
+    """Switch embedding tier and re-embed all memories with the new model."""
     tier = args.tier.lower().strip()
     config = _load_truememory_config()
     old_tier = config.get("tier", "edge")
@@ -535,48 +535,25 @@ def _run_upgrade_tier(args):
         print(f"Already on {tier} tier. Use --force to re-embed anyway.")
         return
 
-    # Check dependencies for base/pro
-    if tier in ("base", "pro"):
-        try:
-            import sentence_transformers  # noqa: F401
-        except ImportError:
-            print(f'\033[33m{tier.capitalize()} tier requires GPU extras.\033[0m')
-            import shutil
-            _is_uv = (
-                "/uv/tools/" in sys.executable.replace("\\", "/")
-                and shutil.which("uv")
-            )
-            if _is_uv:
-                print(f'Run:  uv tool install "truememory[gpu]"')
-            else:
-                print(f'Run:  pip install "truememory[gpu]"')
-            print("Then re-run this command.")
-            sys.exit(1)
-
-    print(f"Switching from {old_tier} → {tier}...")
+    print(f"Switching from {old_tier} to {tier}...")
 
     # Save tier to config
     config["tier"] = tier
     _save_truememory_config(config)
 
-    # Switch embedding model + reranker
+    # Switch active models and re-embed.
+    # All models are pre-downloaded during install — this just switches
+    # which one is active and re-embeds existing memories.
     os.environ.pop("HF_HUB_OFFLINE", None)
     os.environ.pop("TRANSFORMERS_OFFLINE", None)
     try:
         os.environ["TRUEMEMORY_EMBED_MODEL"] = tier
-        from truememory.vector_search import set_embedding_model, get_model
+        from truememory.vector_search import set_embedding_model
         set_embedding_model(tier)
-        print("  Downloading embedding model...")
-        get_model()
-        print("  \033[32m✓ Embedding model ready\033[0m")
 
-        from truememory.reranker import set_active_tier, get_reranker
+        from truememory.reranker import set_active_tier
         set_active_tier(tier)
-        print("  Downloading reranker model...")
-        get_reranker()
-        print("  \033[32m✓ Reranker ready\033[0m")
 
-        # Re-embed existing memories if tier changed (or --force)
         from truememory import Memory
         mem = Memory()
         engine = mem._engine
@@ -609,12 +586,12 @@ def _run_upgrade_tier(args):
         os.environ["TRANSFORMERS_OFFLINE"] = "1"
 
     _tier_descriptions = {
-        "edge": "Edge — 89.6% LoCoMo, Model2Vec + MiniLM (~30MB)",
-        "base": "Base — 92.0% LoCoMo, Qwen3 + gte-modernbert (~1.5GB)",
-        "pro": "Pro  — 93.0% LoCoMo, Qwen3 + gte-modernbert + HyDE (~1.5GB + API key)",
+        "edge": "Edge — 89.6% LoCoMo, Model2Vec + MiniLM",
+        "base": "Base — 92.0% LoCoMo, Qwen3 + gte-modernbert",
+        "pro": "Pro  — 93.0% LoCoMo, Qwen3 + gte-modernbert + HyDE",
     }
     print()
-    print(f"\033[32m✓ Tier upgraded: {_tier_descriptions.get(tier, tier)}\033[0m")
+    print(f"\033[32m✓ Tier switched: {_tier_descriptions.get(tier, tier)}\033[0m")
     print()
     print("\033[1mIMPORTANT:\033[0m If Claude is currently running, start a new session")
     print("for the tier change to take effect.")

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -333,9 +333,9 @@ def _run_setup(args):
     existing_tier = config.get("tier", "")
     print("  \033[1mEmbedding Tier\033[0m")
     print("  ─────────────")
-    print("  [1] Edge — 89.6% LoCoMo, CPU-only, ~30MB install. Works anywhere.")
-    print("  [2] Base — 92.0% LoCoMo, GPU recommended, ~1.5GB install. No API key needed.")
-    print("  [3] Pro  — 93.0% LoCoMo, GPU recommended, ~1.5GB install. Requires LLM API key (HyDE).")
+    print("  [1] Edge — 89.6% LoCoMo, lightweight. Works anywhere.")
+    print("  [2] Base — 92.0% LoCoMo, higher accuracy. No API key needed.")
+    print("  [3] Pro  — 93.0% LoCoMo, maximum accuracy. Requires LLM API key for HyDE.")
     print()
 
     _TIER_NUM = {"edge": "1", "base": "2", "pro": "3"}

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -615,6 +615,9 @@ def _run_upgrade_tier(args):
     }
     print()
     print(f"\033[32m✓ Tier upgraded: {_tier_descriptions.get(tier, tier)}\033[0m")
+    print()
+    print("\033[1mIMPORTANT:\033[0m If Claude is currently running, start a new session")
+    print("for the tier change to take effect.")
     if tier == "pro":
         has_key = bool(
             config.get("anthropic_api_key")
@@ -622,8 +625,9 @@ def _run_upgrade_tier(args):
             or config.get("openai_api_key")
         )
         if not has_key:
-            print("\033[33m  Pro tier works without an API key, but HyDE search is disabled.")
-            print("  Run truememory-ingest setup to add one, or set ANTHROPIC_API_KEY.\033[0m")
+            print()
+            print("\033[33mPro tier works without an API key, but HyDE search is disabled.")
+            print("Run truememory-ingest setup to add one, or set ANTHROPIC_API_KEY.\033[0m")
 
 
 def _run_install(args):

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -346,54 +346,7 @@ def _run_setup(args):
         choice = input(f"  Choose tier [1/2/3] (default: {default_num}): ").strip() or default_num
         tier = {"1": "edge", "2": "base", "3": "pro"}.get(choice, "edge")
 
-    if tier in ("base", "pro"):
-        try:
-            import sentence_transformers  # noqa: F401
-            print(f"  \033[32m✓ {tier.capitalize()} dependencies already installed\033[0m")
-        except ImportError:
-            print(f'  \033[33m⚠ {tier.capitalize()} tier requires GPU extras.\033[0m')
-            print('  \033[33m  curl installer: uv tool install "truememory[gpu]"\033[0m')
-            print('  \033[33m  pip:            pip install "truememory[gpu]"\033[0m')
-            if not args.non_interactive:
-                do_install = input("  Install now? [y/N]: ").strip().lower()
-                if do_install == "y":
-                    import shutil
-                    import subprocess
-                    # Hunter F25: bound install with a 10-minute timeout —
-                    # long enough for model downloads from slow mirrors,
-                    # short enough that a dead mirror doesn't wedge setup.
-                    _is_uv = (
-                        "/uv/tools/" in sys.executable.replace("\\", "/")
-                        and shutil.which("uv")
-                    )
-                    try:
-                        if _is_uv:
-                            subprocess.run(
-                                ["uv", "tool", "install", "truememory[gpu]"],
-                                timeout=600,
-                            )
-                        else:
-                            subprocess.run(
-                                [sys.executable, "-m", "pip", "install",
-                                 "truememory[gpu]"],
-                                timeout=600,
-                            )
-                    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-                        print(
-                            '  \033[33m⚠ Auto-install failed. '
-                            'Try running directly:\n'
-                            '    uv tool install "truememory[gpu]"   (curl installer)\n'
-                            '    pip install "truememory[gpu]"       (pip)\n'
-                            '  then re-run `truememory-ingest setup`.\033[0m',
-                            file=sys.stderr,
-                        )
-                        print("  Falling back to Edge tier.")
-                        tier = "edge"
-                else:
-                    print("  Falling back to Edge tier.")
-                    tier = "edge"
-
-    # Pre-download the embedding model so first search isn't slow
+    # Pre-load the embedding model so first search isn't slow
     print()
     print("  \033[1mDownloading embedding model...\033[0m")
     try:

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -82,6 +82,11 @@ def main():
     p_setup = sub.add_parser("setup", help="Interactive first-time setup wizard")
     p_setup.add_argument("--non-interactive", action="store_true", help="Skip prompts, use defaults + env vars")
 
+    # --- upgrade-tier command ---
+    p_upgrade = sub.add_parser("upgrade-tier", help="Switch embedding tier (edge/base/pro)")
+    p_upgrade.add_argument("tier", choices=["edge", "base", "pro"], help="Target tier")
+    p_upgrade.add_argument("--force", action="store_true", help="Re-embed even if tier is unchanged")
+
     args = parser.parse_args()
 
     if args.command == "ingest":
@@ -102,6 +107,8 @@ def main():
         _run_facts(args)
     elif args.command == "setup":
         _run_setup(args)
+    elif args.command == "upgrade-tier":
+        _run_upgrade_tier(args)
     else:
         parser.print_help()
 
@@ -516,6 +523,107 @@ def _run_setup(args):
     print()
     print("  \033[2mThanks for using TrueMemory, a Sauron company.\033[0m")
     print()
+
+
+def _run_upgrade_tier(args):
+    """Switch embedding tier without re-running the full setup wizard."""
+    tier = args.tier.lower().strip()
+    config = _load_truememory_config()
+    old_tier = config.get("tier", "edge")
+
+    if tier == old_tier and not args.force:
+        print(f"Already on {tier} tier. Use --force to re-embed anyway.")
+        return
+
+    # Check dependencies for base/pro
+    if tier in ("base", "pro"):
+        try:
+            import sentence_transformers  # noqa: F401
+        except ImportError:
+            print(f'\033[33m{tier.capitalize()} tier requires GPU extras.\033[0m')
+            import shutil
+            _is_uv = (
+                "/uv/tools/" in sys.executable.replace("\\", "/")
+                and shutil.which("uv")
+            )
+            if _is_uv:
+                print(f'Run:  uv tool install "truememory[gpu]"')
+            else:
+                print(f'Run:  pip install "truememory[gpu]"')
+            print("Then re-run this command.")
+            sys.exit(1)
+
+    print(f"Switching from {old_tier} → {tier}...")
+
+    # Save tier to config
+    config["tier"] = tier
+    _save_truememory_config(config)
+
+    # Switch embedding model + reranker
+    os.environ.pop("HF_HUB_OFFLINE", None)
+    os.environ.pop("TRANSFORMERS_OFFLINE", None)
+    try:
+        os.environ["TRUEMEMORY_EMBED_MODEL"] = tier
+        from truememory.vector_search import set_embedding_model, get_model
+        set_embedding_model(tier)
+        print("  Downloading embedding model...")
+        get_model()
+        print("  \033[32m✓ Embedding model ready\033[0m")
+
+        from truememory.reranker import set_active_tier, get_reranker
+        set_active_tier(tier)
+        print("  Downloading reranker model...")
+        get_reranker()
+        print("  \033[32m✓ Reranker ready\033[0m")
+
+        # Re-embed existing memories if tier changed (or --force)
+        from truememory import Memory
+        mem = Memory()
+        engine = mem._engine
+        engine._ensure_connection()
+        conn = engine.conn
+        count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+
+        if count > 0:
+            print(f"  Re-embedding {count} memories with {tier} model...")
+            conn.execute("DROP TABLE IF EXISTS vec_messages")
+            conn.execute("DROP TABLE IF EXISTS vec_messages_sep")
+            conn.commit()
+            from truememory.vector_search import (
+                build_separation_vectors,
+                build_vectors,
+                init_vec_table,
+            )
+            init_vec_table(conn)
+            build_vectors(conn)
+            build_separation_vectors(conn)
+            print(f"  \033[32m✓ {count} memories re-embedded\033[0m")
+        else:
+            print("  No existing memories to re-embed.")
+    except Exception as e:
+        print(f"\033[31mError during tier switch: {e}\033[0m", file=sys.stderr)
+        print("Config was saved. Re-run to retry, or use truememory-ingest setup.")
+        sys.exit(1)
+    finally:
+        os.environ["HF_HUB_OFFLINE"] = "1"
+        os.environ["TRANSFORMERS_OFFLINE"] = "1"
+
+    _tier_descriptions = {
+        "edge": "Edge — 89.6% LoCoMo, Model2Vec + MiniLM (~30MB)",
+        "base": "Base — 92.0% LoCoMo, Qwen3 + gte-modernbert (~1.5GB)",
+        "pro": "Pro  — 93.0% LoCoMo, Qwen3 + gte-modernbert + HyDE (~1.5GB + API key)",
+    }
+    print()
+    print(f"\033[32m✓ Tier upgraded: {_tier_descriptions.get(tier, tier)}\033[0m")
+    if tier == "pro":
+        has_key = bool(
+            config.get("anthropic_api_key")
+            or config.get("openrouter_api_key")
+            or config.get("openai_api_key")
+        )
+        if not has_key:
+            print("\033[33m  Pro tier works without an API key, but HyDE search is disabled.")
+            print("  Run truememory-ingest setup to add one, or set ANTHROPIC_API_KEY.\033[0m")
 
 
 def _run_install(args):

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -658,12 +658,12 @@ def truememory_stats() -> str:
             "\n"
             "**Choose your tier:**\n"
             "\n"
-            "- **Edge** — 89.6% accuracy on LoCoMo. CPU-only, works anywhere. "
-            "Lightweight (~30MB). No API key needed.\n"
-            "- **Base** — 92.0% accuracy on LoCoMo. GPU recommended. "
-            "Qwen3 @ 256d + gte-reranker (~1.5GB). No API key needed.\n"
-            "- **Pro** — 93.0% accuracy on LoCoMo. GPU recommended. "
-            "Same as Base plus HyDE query expansion. Requires an API key.\n"
+            "- **Edge** — 89.6% accuracy on LoCoMo. Lightweight, works anywhere. "
+            "No API key needed.\n"
+            "- **Base** — 92.0% accuracy on LoCoMo. Higher accuracy with "
+            "Qwen3 embeddings + gte-reranker. No API key needed.\n"
+            "- **Pro** — 93.0% accuracy on LoCoMo. Maximum accuracy — "
+            "same as Base plus HyDE query expansion. Requires an API key.\n"
             "\n"
             "Which would you like: **Edge**, **Base**, or **Pro**?"
         )
@@ -797,9 +797,9 @@ def truememory_configure(
 
     # Build result with onboarding info
     _tier_descriptions = {
-        "edge": "Edge: Model2Vec embeddings (8M params), MiniLM reranker (~30MB)",
-        "base": "Base: Qwen3 embeddings (256d), gte-reranker-modernbert (~1.5GB)",
-        "pro": "Pro: Qwen3 + HyDE query expansion (~1.5GB + API key)",
+        "edge": "Edge: Model2Vec embeddings (8M params), MiniLM reranker",
+        "base": "Base: Qwen3 embeddings (256d), gte-reranker-modernbert",
+        "pro": "Pro: Qwen3 + HyDE query expansion",
     }
     result = {
         "status": "configured",

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -418,7 +418,7 @@ def _set_reranker(model_name: str):
         _clear_reranker_error()
     except ImportError as e:
         _record_reranker_error(
-            f"ImportError: {e} — install truememory[gpu] for reranker support"
+            f"ImportError: {e} — reinstall truememory to restore reranker support"
         )
     except Exception as e:
         _record_reranker_error(f"{type(e).__name__}: {e}")
@@ -710,20 +710,6 @@ def truememory_configure(
         if api_provider not in ("anthropic", "openrouter", "openai"):
             return json.dumps({
                 "error": "api_provider must be one of: anthropic, openrouter, openai",
-            })
-
-    # Check Base / Pro dependencies before committing (both need sentence-transformers
-    # for the Qwen3 embedder + gte-reranker).
-    if tier in ("base", "pro"):
-        try:
-            import sentence_transformers  # noqa: F401
-        except ImportError:
-            return json.dumps({
-                "error": f"{tier.capitalize()} tier requires GPU extras. "
-                         f"If you installed via the curl installer, run:  uv tool install \"truememory[gpu]\"  "
-                         f"If you used pip, run:  pip install \"truememory[gpu]\"  "
-                         f"Then restart Claude and try again.",
-                "current_tier": _load_config().get("tier", "edge"),
             })
 
     # Save to persistent config

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -28,10 +28,10 @@ Usage::
     build_vectors(conn)
     results = search_vector(conn, "networking problems", limit=5)
 
-Dependencies:
-    - model2vec (``pip install model2vec``) — for the edge tier
-    - sentence-transformers (``pip install truememory[gpu]``) — for base / pro
-    - sqlite-vec (``pip install sqlite-vec``)
+Dependencies (all included in ``pip install truememory``):
+    - model2vec — edge tier embeddings
+    - sentence-transformers — base / pro tier embeddings + reranker
+    - sqlite-vec — vector search extension
     - numpy
 """
 


### PR DESCRIPTION
## Summary

Two changes that go together:

### 1. New `upgrade-tier` CLI command (#170)
```bash
truememory-ingest upgrade-tier base    # switch to Base
truememory-ingest upgrade-tier pro     # switch to Pro
truememory-ingest upgrade-tier edge    # switch to Edge
truememory-ingest upgrade-tier base --force  # re-embed without tier change
```

Switches the active tier and re-embeds all existing memories with the new model. All models are already installed — this just switches which one is active. Warns user to restart Claude after switching.

### 2. Eliminate `[gpu]` optional extras — one package, all tiers included
- **pyproject.toml**: sentence-transformers + torch moved from `[gpu]` optional extras into core dependencies. `[gpu]`/`[reranker]` kept as empty aliases for backward compatibility.
- **install.sh**: installs `truememory` instead of `truememory[gpu]`
- **mcp_server.py**: removed the 14-line `sentence_transformers` import check from `truememory_configure`. Updated reranker error message. Updated tier descriptions (removed install sizes).
- **ingest/cli.py**: removed the 45-line dependency check + auto-install subprocess from the setup wizard. Updated tier descriptions.
- **README.md**: updated tier table ("Model size" not "Install size"), updated FAQ, updated intro.
- **vector_search.py**: updated docstring
- **Tests**: removed dead F25 tests, updated reranker error assertion, updated configure test comment.

The philosophy: install once, get everything. Switching tiers is just re-embedding locally — no extra packages, no downloads, no `[gpu]` brackets.

## Test plan
- [ ] `pip install truememory` installs sentence-transformers + torch (core deps now)
- [ ] `pip install truememory[gpu]` still works (empty alias, no error)
- [ ] `truememory-ingest upgrade-tier base` — re-embeds memories, warns to restart Claude
- [ ] `truememory-ingest upgrade-tier edge` when already on edge — says "already on edge"
- [ ] `truememory-ingest upgrade-tier edge --force` — re-embeds with edge model
- [ ] `truememory-ingest setup` — no `sentence_transformers` import check, no auto-install prompt
- [ ] `truememory_configure(tier="pro")` via MCP — no dependency check, just switches
- [ ] README tier table shows "Model size" not "Install size"
- [ ] No remaining `[gpu]` references in production code (only in explanatory comments + CHANGELOG)

Closes #170