### PR TITLE
fix: log HyDE failures, warn on invalid tier choice, validate gate_threshold bounds              

### DIFF
--- a/truememory/hyde.py
+++ b/truememory/hyde.py
@@ -24,7 +24,10 @@ Dependencies:
 
 from __future__ import annotations
 
+import logging
 import sqlite3
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Prompts
@@ -79,8 +82,8 @@ def generate_hypothetical_doc(
         result = llm_fn(prompt)
         if result and len(result.strip()) > 10:
             return result.strip()
-    except Exception:
-        pass
+    except Exception as e:
+        log.debug("HyDE hypothetical doc generation failed: %s", e)
 
     return None
 
@@ -225,8 +228,8 @@ def hyde_multi_search(
                 fts_weight=fts_weight, vec_weight=vec_weight,
             )
             all_result_lists.append(hyde_results)
-        except Exception:
-            pass
+        except Exception as e:
+            log.debug("HyDE hybrid search failed for hypothetical doc: %s", e)
 
     if len(all_result_lists) == 1:
         return original_results[:limit]

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -337,7 +337,10 @@ def _run_setup(args):
     else:
         default_num = _TIER_NUM.get(existing_tier, "1")
         choice = input(f"  Choose tier [1/2/3] (default: {default_num}): ").strip() or default_num
-        tier = {"1": "edge", "2": "base", "3": "pro"}.get(choice, "edge")
+        tier = {"1": "edge", "2": "base", "3": "pro"}.get(choice)
+        if tier is None:
+            print(f"  \033[33m⚠ Invalid choice '{choice}', defaulting to Edge tier.\033[0m")
+            tier = "edge"
 
     if tier in ("base", "pro"):
         try:

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -156,6 +156,10 @@ class EncodingGate:
         salience_floor: float | None = None,
         user_id: str = "",
     ):
+        if not (0.0 <= threshold <= 1.0):
+            raise ValueError(
+                f"gate_threshold must be in [0.0, 1.0], got {threshold}"
+            )
         self.memory = memory
         self.threshold = threshold
         if w_novelty is None:

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -156,11 +156,11 @@ class EncodingGate:
         salience_floor: float | None = None,
         user_id: str = "",
     ):
-        if not (0.0 <= threshold <= 1.0):
-            raise ValueError(
-                f"gate_threshold must be in [0.0, 1.0], got {threshold}"
-            )
         self.memory = memory
+        if not (0.0 <= threshold <= 1.0):
+            clamped = max(0.0, min(1.0, threshold))
+            log.warning("gate threshold %.2f outside [0, 1], clamped to %.2f", threshold, clamped)
+            threshold = clamped
         self.threshold = threshold
         if w_novelty is None:
             w_novelty = float(os.environ.get("TRUEMEMORY_GATE_W_NOVELTY", "0.25"))


### PR DESCRIPTION
## Summary                                                                                                                        
                                                                                                                                      
  - **`truememory/hyde.py`** - Two silent `except Exception: pass` blocks in                                                          
    `generate_hypothetical_doc()` and `hyde_multi_search()` now emit
    `log.debug(...)` so HyDE degradation is visible when debug logging is enabled.                                                    
                                                                                                                                      
  - **`truememory/ingest/cli.py`** - Invalid tier input during `setup` (e.g. typing                                                   
    `"abc"` at the `[1/2/3]` prompt) previously fell back to Edge silently. Now                                                       
    prints a yellow warning: `⚠ Invalid choice '...', defaulting to Edge tier.`                                                       
                                                                                                                                    
  - **`truememory/ingest/encoding_gate.py`** - `EncodingGate` now raises a                                                            
    `ValueError` immediately if `threshold` is outside `[0.0, 1.0]`, rather than                                                    
    silently accepting values like `2.5` or `-0.1` that make the gate behave                                                          
    nonsensically.                                                                                                                    
                                                                                                                                      
  ## Test plan                                                                                                                        
                                                                                                                                    
  - [x] `python3 test_fixes.py` - HyDE debug log fires + `ValueError` raised for out-of-range threshold              
<img width="946" height="146" alt="image" src="https://github.com/user-attachments/assets/0d2dbdcd-a5c4-4c4c-b055-3964e0a239f9" />
                 
  - [x] `.venv/bin/truememory-ingest setup` with invalid tier input -> warning printed
<img width="1040" height="559" alt="image" src="https://github.com/user-attachments/assets/4afa76dd-c5b9-477a-b235-0c6de7b9934e" />

  - [x] `pytest tests/ -v` - all existing tests pass                                                                                  
                                                                                                                                    
  ---         