### PR TITLE
fix(platform): bypass Python teardown deadlock on Windows MCP exit (closes #196)

### DIFF
--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1228,8 +1228,38 @@ def main():
     # load in background threads (~2.5s) while the MCP handshake
     # completes (~1-3s), so the first search arrives with warm models.
     _preload_models()
-    mcp.run(transport="stdio")
-    return 0
+
+    # Hunter F41: bypass Python interpreter teardown via os._exit(0).
+    #
+    # On Windows, when the MCP client (Claude Code) closes the stdio pipe,
+    # mcp.run() returns and Python begins normal shutdown — atexit handlers,
+    # threading._shutdown(), gc, etc. PyTorch (loaded by sentence-transformers
+    # in our daemon preload threads) holds OpenMP thread pools and memory-
+    # mapped weight files that don't release cleanly during this teardown
+    # phase, causing the process to hang indefinitely. The result: every
+    # /mcp toggle in Claude Code spawns a new subprocess WITHOUT killing
+    # the old one, leaking ~450 MB of resident RAM per zombie.
+    #
+    # Wrapping mcp.run() in try/finally and force-exiting via os._exit(0)
+    # bypasses Python's teardown entirely. SQLite WAL is checkpoint-safe
+    # under sudden termination (this is what SQLite is designed for), so
+    # no DB consistency is lost. We also explicitly close the global
+    # _memory connection before the hard exit as a courtesy — it's not
+    # required for correctness (OS reclaims the FD), but it lets the WAL
+    # checkpoint flush cleanly so the next process starts faster.
+    try:
+        mcp.run(transport="stdio")
+    except (BrokenPipeError, EOFError, KeyboardInterrupt):
+        pass  # Normal disconnect paths — fall through to cleanup + exit.
+    finally:
+        global _memory
+        if _memory is not None:
+            try:
+                _memory._engine.conn.close()
+            except Exception:
+                pass
+        os._exit(0)
+    return 0  # Unreachable — kept for type-checker happiness.
 
 
 if __name__ == "__main__":

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1229,28 +1229,15 @@ def main():
     # completes (~1-3s), so the first search arrives with warm models.
     _preload_models()
 
-    # Hunter F41: bypass Python interpreter teardown via os._exit(0).
-    #
-    # On Windows, when the MCP client (Claude Code) closes the stdio pipe,
-    # mcp.run() returns and Python begins normal shutdown — atexit handlers,
-    # threading._shutdown(), gc, etc. PyTorch (loaded by sentence-transformers
-    # in our daemon preload threads) holds OpenMP thread pools and memory-
-    # mapped weight files that don't release cleanly during this teardown
-    # phase, causing the process to hang indefinitely. The result: every
-    # /mcp toggle in Claude Code spawns a new subprocess WITHOUT killing
-    # the old one, leaking ~450 MB of resident RAM per zombie.
-    #
-    # Wrapping mcp.run() in try/finally and force-exiting via os._exit(0)
-    # bypasses Python's teardown entirely. SQLite WAL is checkpoint-safe
-    # under sudden termination (this is what SQLite is designed for), so
-    # no DB consistency is lost. We also explicitly close the global
-    # _memory connection before the hard exit as a courtesy — it's not
-    # required for correctness (OS reclaims the FD), but it lets the WAL
-    # checkpoint flush cleanly so the next process starts faster.
+    # Force-exit after mcp.run() to avoid PyTorch teardown deadlocks.
+    # PyTorch's C++ threads (OpenMP pools, autograd engine) deadlock against
+    # Python's interpreter shutdown on all platforms. On Windows the hang is
+    # indefinite; on macOS/Linux it's usually temporary but still wasteful.
+    # os._exit(0) bypasses teardown entirely. SQLite WAL handles this safely.
     try:
         mcp.run(transport="stdio")
     except (BrokenPipeError, EOFError, KeyboardInterrupt):
-        pass  # Normal disconnect paths — fall through to cleanup + exit.
+        pass
     finally:
         global _memory
         if _memory is not None:
@@ -1259,7 +1246,6 @@ def main():
             except Exception:
                 pass
         os._exit(0)
-    return 0  # Unreachable — kept for type-checker happiness.
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes the Windows MCP zombie subprocess leak (closes #196). On stdin EOF, Python's teardown phase deadlocks because PyTorch (loaded by sentence-transformers daemon preload threads) holds resources that don't release cleanly. Every `/mcp` toggle leaks ~450 MB. 5 zombies observed in one session.

Patch: wrap `mcp.run()` in `try/finally`, close `_memory` SQLite connection (WAL checkpoint), force-exit via `os._exit(0)` — bypasses teardown entirely. Convergent diagnosis from 4 explorer agents + Gemini 3.1 Pro + Grok 4.1 Fast.

## Changes

| File | Change |
|------|--------|
| `truememory/mcp_server.py` | Wrap `mcp.run()` in try/finally; close `_memory._engine.conn`; `os._exit(0)` to bypass Python teardown deadlock |

## Test plan

- [x] Lint clean (`ruff check truememory/mcp_server.py`)
- [x] Smoke test: `python -c "from truememory import mcp_server"` imports cleanly
- [ ] CI green
- [ ] User-side validation: `/mcp` toggle in Claude Code on Windows — old subprocess dies before new one spawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
