### PR TITLE
feat: Windows one-line installer + v0.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [0.6.3] — 2026-05-10
+
+### Added
+- **Windows one-line installer** (`install.ps1`) — PowerShell equivalent of
+  `install.sh`. Same steps: installs uv, fetches Python 3.12, installs
+  truememory, configures Claude, pre-downloads all tier models.
+  `irm https://...install.ps1 | iex` (#203)
+- **`truememory-ingest upgrade-tier`** CLI command for switching tiers without
+  re-running the full setup wizard. (#170)
+- **Usage telemetry system** spec filed. (#190)
+- **Corpus Sync** spec filed — cloud-backed multi-agent memory with selective
+  sharing. (#199)
+- **Contributor IP assignment clause** in CONTRIBUTING.md. (#198)
+
+### Fixed
+- **Windows compatibility** — 12 `encoding="utf-8"` fixes, `close_fds` platform
+  branch, `shlex.quote` vs `list2cmdline`, `check_same_thread=False`, stable hash
+  for style vectors, Claude CLI path resolution. (#195)
+- **Security hardening** — SQL table name allowlist, FTS5 query sanitization,
+  MCP input validation (50KB content cap, limit clamping, query length cap),
+  session ID path traversal prevention, directory permissions, 30-day trace/log
+  retention. (#181)
+- **PyTorch teardown deadlock** — `os._exit(0)` bypasses interpreter shutdown
+  hang from OpenMP/autograd thread pools. Affects all platforms. (#197)
+- **pip-only install messages** — all error messages now show both uv and pip
+  commands. PATH guidance added. (#168, #171)
+- **HyDE logging** — silent `except: pass` blocks now emit `log.debug`. (#193)
+- **Gate threshold validation** — out-of-range values clamped with warning
+  instead of crashing the pipeline. (#193)
+
+### Changed
+- **All models are now core dependencies.** `sentence-transformers` and `torch`
+  moved from `[gpu]` optional extras into core `dependencies`. `[gpu]`/`[reranker]`
+  kept as empty aliases for backward compatibility. Tier switching just re-embeds
+  locally — no extra packages needed. (#192)
+- **Style vector hash migration** — Python's non-deterministic `hash()` replaced
+  with `hashlib.md5`-based stable hash. One-time rebuild runs on first
+  open after upgrade. (#195, #202)
+- Removed 33 contributor-specific tags from code comments. (#204)
+
 ## [0.6.0] — 2026-05-02
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ title: "TrueMemory"
 authors:
   - name: "@Building_Josh"
     affiliation: "Sauron"
-version: "0.6.2"
-date-released: "2026-05-02"
+version: "0.6.3"
+date-released: "2026-05-10"
 url: "https://github.com/buildingjoshbetter/TrueMemory"
 license: AGPL-3.0
 keywords:

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ ${\color{#1a73e8}\textbf{\textsf{Step 2.}}}$ Paste this and press Enter:
 curl -LsSf https://raw.githubusercontent.com/buildingjoshbetter/TrueMemory/main/install.sh | sh
 ```
 
-**Windows (PowerShell)** — requires [Python 3.10+](https://www.python.org/downloads/):
+**Windows (PowerShell):**
 ```powershell
-pip install truememory; truememory-mcp --setup; truememory-ingest install
+irm https://raw.githubusercontent.com/buildingjoshbetter/TrueMemory/main/install.ps1 | iex
 ```
 
 &nbsp;

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,170 @@
+# TrueMemory installer for Windows — https://github.com/buildingjoshbetter/TrueMemory
+#
+# One-line install (PowerShell):
+#   irm https://raw.githubusercontent.com/buildingjoshbetter/TrueMemory/main/install.ps1 | iex
+#
+# What this does:
+#   1. Installs uv (Astral's Python tool manager) if missing.
+#   2. Fetches a managed Python 3.12 (system Python untouched).
+#   3. Installs truememory as an isolated uv tool.
+#   4. Runs truememory-mcp --setup to auto-configure Claude Code / Claude Desktop.
+#   5. Runs truememory-ingest install to wire up lifecycle hooks.
+#   6. Pre-downloads all tier models (Edge + Base + Pro).
+#
+# Environment overrides:
+#   $env:TRUEMEMORY_PY = "3.12"         # pin a specific Python (default: 3.12)
+#   $env:TRUEMEMORY_SOURCE = "..."      # install from a local path instead of PyPI
+#   $env:TRUEMEMORY_SKIP_SETUP = "1"    # skip the Claude auto-config step
+#
+# Safety:
+#   - No admin/elevation required. Everything lands under $env:LOCALAPPDATA.
+#   - Source: https://github.com/buildingjoshbetter/TrueMemory/blob/main/install.ps1
+
+$ErrorActionPreference = "Stop"
+
+# ---------- pretty output helpers ----------
+function Say($msg)  { Write-Host "[truememory] $msg" -ForegroundColor Cyan }
+function Ok($msg)   { Write-Host "[truememory] $msg" -ForegroundColor Green }
+function Warn($msg) { Write-Host "[truememory] $msg" -ForegroundColor Red }
+function Die($msg)  { Warn "error: $msg"; exit 1 }
+
+# ---------- main ----------
+$TRUEMEMORY_PY = if ($env:TRUEMEMORY_PY) { $env:TRUEMEMORY_PY } else { "3.12" }
+$TRUEMEMORY_SOURCE = if ($env:TRUEMEMORY_SOURCE) { $env:TRUEMEMORY_SOURCE } else { "" }
+
+if ($TRUEMEMORY_PY -notmatch '^\d+\.\d+$') {
+    Die "invalid TRUEMEMORY_PY: '$TRUEMEMORY_PY' (expected digits and dots, e.g. 3.12)"
+}
+
+if ($TRUEMEMORY_SOURCE) {
+    $PKG_SPEC = $TRUEMEMORY_SOURCE
+    Say "using custom source: $TRUEMEMORY_SOURCE"
+} else {
+    $PKG_SPEC = "truememory"
+}
+
+# ---------- step 1: install uv if missing ----------
+$uvPath = Get-Command uv -ErrorAction SilentlyContinue
+if ($uvPath) {
+    $uvVer = & uv --version 2>$null
+    Say "uv already installed ($uvVer)"
+} else {
+    Say "installing uv (Astral) — https://docs.astral.sh/uv/"
+    try {
+        irm https://astral.sh/uv/install.ps1 | iex
+    } catch {
+        Die "uv install failed — try: irm https://astral.sh/uv/install.ps1 | iex"
+    }
+    # Refresh PATH so we can find uv
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "User") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "Machine")
+    $uvPath = Get-Command uv -ErrorAction SilentlyContinue
+    if (-not $uvPath) {
+        Die "uv installed but not on PATH — close and reopen PowerShell, then re-run this script"
+    }
+}
+
+# ---------- step 2: ensure Python is available ----------
+Say "fetching managed Python $TRUEMEMORY_PY (system Python untouched)..."
+& uv python install $TRUEMEMORY_PY 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Die "failed to install managed Python $TRUEMEMORY_PY"
+}
+
+# ---------- step 3: install truememory as a uv tool ----------
+Say "installing $PKG_SPEC (~3-5 min on first run, downloads all tier models)..."
+& uv tool uninstall truememory 2>$null
+& uv tool install --python $TRUEMEMORY_PY --force --refresh $PKG_SPEC 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Die "truememory install failed"
+}
+
+# Ensure uv tool bin dir is on PATH for this session
+$uvToolDir = & uv tool dir 2>$null
+if ($uvToolDir) {
+    $binDir = Join-Path $uvToolDir "truememory\Scripts"
+    if ($binDir -and (Test-Path $binDir)) {
+        $env:Path = "$binDir;$env:Path"
+    }
+}
+
+# ---------- step 4: auto-configure Claude ----------
+if ($env:TRUEMEMORY_SKIP_SETUP -eq "1") {
+    Say "skipping Claude setup (TRUEMEMORY_SKIP_SETUP=1)"
+} else {
+    Say "configuring Claude Code / Claude Desktop..."
+    & truememory-mcp --setup
+    if ($LASTEXITCODE -ne 0) {
+        Warn "auto-setup returned non-zero (you can re-run it with: truememory-mcp --setup)"
+    }
+
+    Say "installing hooks and CLAUDE.md instructions..."
+    & truememory-ingest install
+    if ($LASTEXITCODE -ne 0) {
+        Warn "hook install returned non-zero (you can re-run it with: truememory-ingest install)"
+    }
+}
+
+# ---------- step 5: pre-download models for all tiers ----------
+Say "pre-downloading models for all tiers (Edge + Base + Pro)..."
+Say "  this takes 2-5 min but means tier switching just works afterward."
+
+$toolPython = Join-Path (& uv tool dir 2>$null) "truememory\Scripts\python.exe"
+if (Test-Path $toolPython) {
+    Say "  [1/3] Edge reranker (MiniLM-L-6-v2, ~22MB)..."
+    & $toolPython -c "from sentence_transformers import CrossEncoder; CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')" 2>$null
+    if ($LASTEXITCODE -eq 0) { Ok "  [1/3] Edge reranker ready" }
+    else { Warn "  [1/3] Edge reranker download failed (search still works without it)" }
+
+    Say "  [2/3] Base/Pro embedder (Qwen3-Embedding-0.6B, ~1.2GB)..."
+    & $toolPython -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('Qwen/Qwen3-Embedding-0.6B', truncate_dim=256)" 2>$null
+    if ($LASTEXITCODE -eq 0) { Ok "  [2/3] Base/Pro embedder ready" }
+    else { Warn "  [2/3] Base/Pro embedder download failed (you can retry later or use Edge tier)" }
+
+    Say "  [3/3] Base/Pro reranker (gte-modernbert, ~600MB)..."
+    & $toolPython -c "from sentence_transformers import CrossEncoder; CrossEncoder('Alibaba-NLP/gte-reranker-modernbert-base')" 2>$null
+    if ($LASTEXITCODE -eq 0) { Ok "  [3/3] Base/Pro reranker ready" }
+    else { Warn "  [3/3] Base/Pro reranker download failed (you can retry later or use Edge tier)" }
+
+    Ok "all models pre-downloaded — tier switching is instant."
+} else {
+    Warn "could not locate tool Python at $toolPython — skipping model pre-download"
+    Warn "models will download on first use instead"
+}
+
+# ---------- done ----------
+Write-Host ""
+Write-Host @"
+████████╗██████╗ ██╗   ██╗███████╗    ███╗   ███╗███████╗███╗   ███╗ ██████╗ ██████╗ ██╗   ██╗
+╚══██╔══╝██╔══██╗██║   ██║██╔════╝    ████╗ ████║██╔════╝████╗ ████║██╔═══██╗██╔══██╗╚██╗ ██╔╝
+   ██║   ██████╔╝██║   ██║█████╗      ██╔████╔██║█████╗  ██╔████╔██║██║   ██║██████╔╝ ╚████╔╝
+   ██║   ██╔══██╗██║   ██║██╔══╝      ██║╚██╔╝██║██╔══╝  ██║╚██╔╝██║██║   ██║██╔══██╗  ╚██╔╝
+   ██║   ██║  ██║╚██████╔╝███████╗    ██║ ╚═╝ ██║███████╗██║ ╚═╝ ██║╚██████╔╝██║  ██║   ██║
+   ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚══════╝    ╚═╝     ╚═╝╚══════╝╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═╝   ╚═╝
+                                  a sauron company
+"@ -ForegroundColor Green
+
+$installedVer = & $toolPython -c "from importlib.metadata import version; print(version('truememory'))" 2>$null
+if (-not $installedVer) { $installedVer = "unknown" }
+Write-Host ""
+Ok "TrueMemory v$installedVer installed successfully."
+Write-Host ""
+Write-Host "  First time? Start a new Claude session and type:" -ForegroundColor Green
+Write-Host ""
+Write-Host "    Set up TrueMemory" -ForegroundColor Green -NoNewline
+Write-Host ""
+Write-Host ""
+Write-Host "  TrueMemory will walk you through choosing Edge, Base, or Pro."
+Write-Host ""
+Write-Host "  IMPORTANT — if Claude Desktop was already open:" -ForegroundColor Yellow
+Write-Host "    Close it completely and reopen it."
+Write-Host "    A new chat window is NOT enough — the config only loads at launch."
+Write-Host ""
+Write-Host "  Commands:" -ForegroundColor Green
+Write-Host "    truememory-mcp --setup              " -NoNewline; Write-Host "# re-run Claude auto-config" -ForegroundColor DarkGray
+Write-Host "    truememory-ingest install            " -NoNewline; Write-Host "# re-install hooks" -ForegroundColor DarkGray
+Write-Host "    uv tool upgrade truememory     " -NoNewline; Write-Host "# update to latest" -ForegroundColor DarkGray
+Write-Host "    uv tool uninstall truememory   " -NoNewline; Write-Host "# uninstall" -ForegroundColor DarkGray
+Write-Host ""
+Write-Host "  Note:" -ForegroundColor Yellow -NoNewline
+Write-Host " If commands are not found, close and reopen PowerShell."
+Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -78,12 +78,17 @@ if ($LASTEXITCODE -ne 0) {
     Die "truememory install failed"
 }
 
-# Ensure uv tool bin dir is on PATH for this session
+# Add uv tool bin dir to PATH for future sessions
+Say "adding uv's tool dir to your PATH (reversible)..."
+& uv tool update-shell *> $null
+
+# Refresh PATH and add tool Scripts dir for this session
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "User") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "Machine")
 $uvToolDir = & uv tool dir 2>$null
 if ($uvToolDir) {
-    $binDir = Join-Path $uvToolDir "truememory\Scripts"
-    if ($binDir -and (Test-Path $binDir)) {
-        $env:Path = "$binDir;$env:Path"
+    $scriptsDir = Join-Path $uvToolDir "truememory\Scripts"
+    if ($scriptsDir -and (Test-Path $scriptsDir)) {
+        $env:Path = "$scriptsDir;$env:Path"
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -65,15 +65,15 @@ if ($uvPath) {
 
 # ---------- step 2: ensure Python is available ----------
 Say "fetching managed Python $TRUEMEMORY_PY (system Python untouched)..."
-& uv python install $TRUEMEMORY_PY 2>$null
+& uv python install $TRUEMEMORY_PY > $null
 if ($LASTEXITCODE -ne 0) {
     Die "failed to install managed Python $TRUEMEMORY_PY"
 }
 
 # ---------- step 3: install truememory as a uv tool ----------
 Say "installing $PKG_SPEC (~3-5 min on first run, downloads all tier models)..."
-& uv tool uninstall truememory 2>$null
-& uv tool install --python $TRUEMEMORY_PY --force --refresh $PKG_SPEC 2>$null
+& uv tool uninstall truememory *> $null
+& uv tool install --python $TRUEMEMORY_PY --force --refresh $PKG_SPEC > $null
 if ($LASTEXITCODE -ne 0) {
     Die "truememory install failed"
 }
@@ -111,17 +111,17 @@ Say "  this takes 2-5 min but means tier switching just works afterward."
 $toolPython = Join-Path (& uv tool dir 2>$null) "truememory\Scripts\python.exe"
 if (Test-Path $toolPython) {
     Say "  [1/3] Edge reranker (MiniLM-L-6-v2, ~22MB)..."
-    & $toolPython -c "from sentence_transformers import CrossEncoder; CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')" 2>$null
+    & $toolPython -c "from sentence_transformers import CrossEncoder; CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')"
     if ($LASTEXITCODE -eq 0) { Ok "  [1/3] Edge reranker ready" }
     else { Warn "  [1/3] Edge reranker download failed (search still works without it)" }
 
     Say "  [2/3] Base/Pro embedder (Qwen3-Embedding-0.6B, ~1.2GB)..."
-    & $toolPython -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('Qwen/Qwen3-Embedding-0.6B', truncate_dim=256)" 2>$null
+    & $toolPython -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('Qwen/Qwen3-Embedding-0.6B', truncate_dim=256)"
     if ($LASTEXITCODE -eq 0) { Ok "  [2/3] Base/Pro embedder ready" }
     else { Warn "  [2/3] Base/Pro embedder download failed (you can retry later or use Edge tier)" }
 
     Say "  [3/3] Base/Pro reranker (gte-modernbert, ~600MB)..."
-    & $toolPython -c "from sentence_transformers import CrossEncoder; CrossEncoder('Alibaba-NLP/gte-reranker-modernbert-base')" 2>$null
+    & $toolPython -c "from sentence_transformers import CrossEncoder; CrossEncoder('Alibaba-NLP/gte-reranker-modernbert-base')"
     if ($LASTEXITCODE -eq 0) { Ok "  [3/3] Base/Pro reranker ready" }
     else { Warn "  [3/3] Base/Pro reranker download failed (you can retry later or use Edge tier)" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truememory"
-version = "0.6.2"
+version = "0.6.3"
 description = "SOTA-level agent memory at zero infrastructure cost."
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
- **install.ps1** — Windows one-line installer. PowerShell equivalent of install.sh.
- **Version bump to 0.6.3** — pyproject.toml, CITATION.cff
- **CHANGELOG** — covers everything since 0.6.2 (Windows compat, security, installer fixes, tier upgrade CLI, contributor IP)
- **README** — Windows install now uses the one-liner instead of pip commands

## Windows one-liner
```powershell
irm https://raw.githubusercontent.com/buildingjoshbetter/TrueMemory/main/install.ps1 | iex
```

Does the same thing as the Mac/Linux installer:
1. Installs uv (Astral) if missing
2. Fetches managed Python 3.12
3. Installs truememory as a uv tool
4. Configures Claude Code / Claude Desktop
5. Installs lifecycle hooks
6. Pre-downloads all tier models (Edge + Base + Pro)

## Test plan
- [ ] Run `install.ps1` on a fresh Windows machine — verify all steps complete
- [ ] Verify `truememory-mcp --setup` works after install
- [ ] Verify `truememory-ingest install` works after install
- [ ] Verify model pre-download completes for all 3 tiers
- [ ] Verify version shows 0.6.3 (`truememory-ingest -V`)
- [ ] Run on Windows 10 (PowerShell 5.1) — verify no `&&` or other PS7-only syntax
- [ ] Run on Windows 11 (PowerShell 7) — verify works
- [ ] Mac/Linux `install.sh` still works unchanged

Closes #203