### PR TITLE
feat: incremental extraction during long sessions

### DIFF
--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -1,0 +1,26 @@
+"""Shared utilities for TrueMemory hooks."""
+
+from pathlib import Path
+import time
+
+MARKER_PATH = Path.home() / ".truememory" / "last_incremental_extraction"
+DEFAULT_INTERVAL = 14400  # 4 hours in seconds
+
+
+def should_extract(interval: int = DEFAULT_INTERVAL) -> bool:
+    """Check if enough time has elapsed since the last incremental extraction."""
+    if not MARKER_PATH.exists():
+        return True
+    try:
+        return (time.time() - MARKER_PATH.stat().st_mtime) >= interval
+    except OSError:
+        return True
+
+
+def mark_extracted():
+    """Update the timestamp marker after a successful extraction trigger."""
+    try:
+        MARKER_PATH.parent.mkdir(parents=True, exist_ok=True)
+        MARKER_PATH.write_text(str(time.time()), encoding="utf-8")
+    except OSError:
+        pass

--- a/truememory/ingest/hooks/compact.py
+++ b/truememory/ingest/hooks/compact.py
@@ -77,7 +77,10 @@ def main():
         if should_extract(interval=0):
             from truememory.ingest.hooks.stop import (
                 _has_enough_messages, _run_background_ingestion,
+                TRACE_DIR, LOG_DIR,
             )
+            TRACE_DIR.mkdir(parents=True, exist_ok=True)
+            LOG_DIR.mkdir(parents=True, exist_ok=True)
             if _has_enough_messages(transcript_path, 5):
                 _run_background_ingestion(
                     transcript_path, session_id,

--- a/truememory/ingest/hooks/compact.py
+++ b/truememory/ingest/hooks/compact.py
@@ -67,6 +67,26 @@ def main():
     except Exception as e:
         log.error("Compact hook failed: %s", e)
 
+    # Background extraction: context is about to be compressed, so run
+    # the full extraction pipeline on the transcript before it's lost.
+    # The snapshot above is a lightweight breadcrumb; this does deep
+    # LLM-based fact extraction. Uses the shared timestamp marker to
+    # coordinate with the UserPromptSubmit incremental trigger.
+    try:
+        from truememory.ingest.hooks._shared import should_extract, mark_extracted
+        if should_extract(interval=0):
+            from truememory.ingest.hooks.stop import (
+                _has_enough_messages, _run_background_ingestion,
+            )
+            if _has_enough_messages(transcript_path, 5):
+                _run_background_ingestion(
+                    transcript_path, session_id,
+                    user_id=args.user, db_path=args.db,
+                )
+                mark_extracted()
+    except Exception as e:
+        log.error("Compact background extraction failed: %s", e)
+
 
 def save_snapshot(
     transcript_path: str,

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -66,7 +66,7 @@ def _parse_args() -> argparse.Namespace:
 
 
 def main():
-    _parse_args()  # accept installer-passed flags even though we don't use them
+    args = _parse_args()
 
     try:
         input_data = json.load(sys.stdin)
@@ -75,6 +75,7 @@ def main():
 
     prompt = input_data.get("prompt", "").strip()
     session_id = input_data.get("session_id", "unknown")
+    transcript_path = input_data.get("transcript_path", "")
 
     if not prompt or len(prompt) < 3:
         return
@@ -84,6 +85,27 @@ def main():
         _prune_old_buffers()
     except Exception:
         pass  # Never crash the hook
+
+    # Incremental extraction: if enough time has passed since the last
+    # extraction, trigger background ingestion of the transcript so far.
+    # This captures memories during long-running sessions without waiting
+    # for the Stop hook. The encoding gate + dedup pipeline handles
+    # overlap with the Stop hook's extraction gracefully.
+    if transcript_path and Path(transcript_path).exists():
+        try:
+            interval = int(os.environ.get("TRUEMEMORY_INCREMENTAL_INTERVAL", "14400"))
+            from truememory.ingest.hooks._shared import should_extract, mark_extracted
+            if should_extract(interval):
+                from truememory.ingest.hooks.stop import (
+                    _has_enough_messages, _run_background_ingestion,
+                )
+                if _has_enough_messages(transcript_path, 5):
+                    _run_background_ingestion(
+                        transcript_path, session_id, args.user, args.db,
+                    )
+                    mark_extracted()
+        except Exception:
+            pass  # Never crash the hook
 
 
 def buffer_message(session_id: str, prompt: str):

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -98,7 +98,10 @@ def main():
             if should_extract(interval):
                 from truememory.ingest.hooks.stop import (
                     _has_enough_messages, _run_background_ingestion,
+                    TRACE_DIR, LOG_DIR,
                 )
+                TRACE_DIR.mkdir(parents=True, exist_ok=True)
+                LOG_DIR.mkdir(parents=True, exist_ok=True)
                 if _has_enough_messages(transcript_path, 5):
                     _run_background_ingestion(
                         transcript_path, session_id, args.user, args.db,


### PR DESCRIPTION
## Summary

Adds two mid-session extraction triggers so memories are captured during long-running sessions without waiting for the Stop hook.

### #175: UserPromptSubmit incremental extraction
Every 4 hours (configurable via `TRUEMEMORY_INCREMENTAL_INTERVAL`), checks a timestamp marker and spawns background ingestion of the transcript so far. Fires on every user message but the time check makes it a no-op 99.9% of the time (~1ms overhead).

### #176: PreCompact extraction
Always triggers when context is about to be compressed. This is the last chance to capture information before Claude discards it. The existing snapshot (`Memory.add()`) is kept as a lightweight breadcrumb — the new extraction does deep LLM-based fact extraction alongside it.

## How they coordinate
- Shared timestamp marker at `~/.truememory/last_incremental_extraction`
- UserPromptSubmit checks `should_extract(interval=14400)` — only fires if 4+ hours since last extraction
- PreCompact checks `should_extract(interval=0)` — always fires (context is about to be lost)
- Both call `mark_extracted()` after triggering, which resets the timer
- The encoding gate + dedup pipeline handles overlap with the Stop hook

## Files changed

| File | Change |
|------|--------|
| `truememory/ingest/hooks/_shared.py` | NEW — shared timestamp marker (`should_extract`, `mark_extracted`) |
| `truememory/ingest/hooks/user_prompt_submit.py` | Added incremental extraction after buffer write |
| `truememory/ingest/hooks/compact.py` | Added background extraction after snapshot |

## What is NOT changed
- `stop.py` — untouched, only imported from (no code duplication)
- No dependencies added
- No config files modified

## Test plan
- [ ] `pytest tests/ -v` passes
- [ ] Keep a session open 5+ hours — verify incremental extraction fires (check `~/.truememory/logs/`)
- [ ] Trigger context compression (long session) — verify compact extraction fires
- [ ] Verify `~/.truememory/last_incremental_extraction` marker file is created
- [ ] Verify Stop hook still fires normally at session end
- [ ] Verify no duplicate facts stored (encoding gate + dedup handles this)

Closes #175, closes #176