### PR TITLE
fix: include email in session_start telemetry event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.6] — 2026-05-10
+
+### Fixed
+- **Telemetry email persistence** — `session_start` now includes the email from
+  `config.json` on every session, so the dashboard always has it. Previously
+  email was only sent during initial onboarding. (#211)
+
 ## [0.6.5] — 2026-05-10
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ title: "TrueMemory"
 authors:
   - name: "@Building_Josh"
     affiliation: "Sauron"
-version: "0.6.5"
+version: "0.6.6"
 date-released: "2026-05-10"
 url: "https://github.com/buildingjoshbetter/TrueMemory"
 license: AGPL-3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truememory"
-version = "0.6.5"
+version = "0.6.6"
 description = "SOTA-level agent memory at zero infrastructure cost."
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/truememory/telemetry.py
+++ b/truememory/telemetry.py
@@ -62,13 +62,16 @@ def init(config: dict) -> dict | None:
         _save_user_id(config)
 
     # Track session start and do a synchronous flush to check for updates
-    track("session_start", {
+    session_props = {
         "tier": config.get("tier", "edge"),
         "version": _get_version(),
         "platform": sys.platform,
         "arch": platform.machine(),
         "python": platform.python_version(),
-    })
+    }
+    if config.get("email"):
+        session_props["email"] = config["email"]
+    track("session_start", session_props)
     update_info = _flush_sync()
 
     # Start background flush thread for subsequent events


### PR DESCRIPTION
## Summary

Email was only sent to the telemetry server during initial onboarding (via the `identify` event in `truememory_configure`). Users who already onboarded never re-sent their email, so the dashboard showed blank emails for existing installs.

Now `session_start` includes the email from `config.json` if it exists, so every session re-sends it. The server-side upsert (already deployed) only overwrites the stored email if the new one is non-empty.

## Changes

| File | Change |
|------|--------|
| `truememory/telemetry.py` | `session_start` properties include `email` from config if present |

## Test plan
- [ ] New session sends email in session_start event
- [ ] Dashboard shows email for existing users after their next session
- [ ] Users without email in config still work (no email sent, no error)