### PR TITLE
release: v0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.6.7] — 2026-05-10
+
+### Added
+- **Comprehensive API documentation** — Python SDK reference, MCP tool reference,
+  CLI reference, environment variables, getting started guide, tier selection guide,
+  debugging guide. All verified against source code. (#212)
+- **Email prompt for existing users** — session start asks for email if not yet
+  provided, ensuring the telemetry dashboard captures emails from all users.
+- **Stronger onboarding email prompt** — setup guide actively asks for email
+  instead of marking it optional.
+
 ## [0.6.6] — 2026-05-10
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ title: "TrueMemory"
 authors:
   - name: "@Building_Josh"
     affiliation: "Sauron"
-version: "0.6.6"
+version: "0.6.7"
 date-released: "2026-05-10"
 url: "https://github.com/buildingjoshbetter/TrueMemory"
 license: AGPL-3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truememory"
-version = "0.6.6"
+version = "0.6.7"
 description = "SOTA-level agent memory at zero infrastructure cost."
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump to 0.6.7. Includes comprehensive API docs, email prompt for existing users, and stronger onboarding email collection.

See CHANGELOG.md for full details.