### PR TITLE
fix: Qwen3 NaN embeddings on macOS — platform-gated eager attention + migration

### DIFF
--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -335,6 +335,50 @@ class TrueMemoryEngine:
                 self._has_vectors = False
 
         self._has_hybrid = _HAS_HYBRID and self._has_vectors
+
+        # Qwen3 NaN fix: macOS SDPA kernel produces NaN embeddings.
+        # Re-embed once for Base/Pro users on macOS.
+        import sys as _sys
+        if _sys.platform == "darwin" and self._has_vectors:
+            try:
+                _embed_model = os.environ.get("TRUEMEMORY_EMBED_MODEL", "edge")
+                if _embed_model in ("base", "pro", "qwen3_256"):
+                    _tables = {r[0] for r in self.conn.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table'"
+                    ).fetchall()}
+                    if "metadata" in _tables:
+                        _row = self.conn.execute(
+                            "SELECT value FROM metadata WHERE key = 'qwen3_nan_fix_applied'"
+                        ).fetchone()
+                        if _row is None:
+                            from truememory.vector_search import (
+                                build_vectors as _bv,
+                                build_separation_vectors as _bsv,
+                                init_vec_table as _ivt,
+                            )
+                            self.conn.execute("DROP TABLE IF EXISTS vec_messages")
+                            self.conn.execute("DROP TABLE IF EXISTS vec_messages_sep")
+                            self.conn.commit()
+                            _ivt(self.conn)
+                            _bv(self.conn)
+                            _bsv(self.conn)
+                            logger.warning(
+                                "Qwen3 NaN fix: re-embedded all vectors with "
+                                "eager attention (one-time macOS migration)"
+                            )
+                            self.conn.execute(
+                                "INSERT OR REPLACE INTO metadata (key, value) "
+                                "VALUES (?, ?)",
+                                ("qwen3_nan_fix_applied", "1"),
+                            )
+                            self.conn.commit()
+            except Exception:
+                logger.warning(
+                    "Qwen3 NaN migration failed — run "
+                    "'truememory-ingest upgrade-tier base --force' to fix manually",
+                    exc_info=True,
+                )
+
         self.ready = True
 
     # ──────────────────────────────────────────────────────────────────────

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -152,9 +152,14 @@ def get_model():
             _embedding_dim = 384
         elif resolved == "qwen3_256":
             from sentence_transformers import SentenceTransformer
+            import sys as _sys
+            _mkwargs = {}
+            if _sys.platform == "darwin":
+                _mkwargs["attn_implementation"] = "eager"
             _model = SentenceTransformer(
                 "Qwen/Qwen3-Embedding-0.6B",
                 truncate_dim=256,
+                model_kwargs=_mkwargs or None,
             )
             _embedding_dim = 256
         else:


### PR DESCRIPTION
## Summary

Fixes the critical Qwen3 NaN embedding bug on macOS. The PyTorch SDPA attention kernel produces NaN embeddings for Qwen3-Embedding-0.6B on macOS (both Apple Silicon and Intel), causing semantic search to return garbage-ordered results while FTS5 still works.

**This is a rewrite of the original PR** — the previous version had two critical bugs:
1. Migration was placed in `open()` which is dead code (production uses `_ensure_connection()`)
2. `attn_implementation="eager"` was applied globally instead of macOS-only

## Changes

| File | Change |
|------|--------|
| `truememory/vector_search.py` | Gate `attn_implementation="eager"` by `sys.platform == "darwin"` so Windows/Linux keep full SDPA performance |
| `truememory/engine.py` | Add one-time NaN fix migration to `_ensure_connection()` — drops and rebuilds vec tables for macOS Base/Pro users |

## Validation (6 rounds)

- [x] **Round 1 — Syntax & Import:** AST valid, full `from truememory import Memory` works
- [x] **Round 2 — Call Chain:** Migration is in `_ensure_connection()` (15+ production callers), NOT `open()` (0 callers)
- [x] **Round 3 — Edge Cases:** Windows/Linux skip, Edge tier skips, empty DB is a no-op, failure retries on restart
- [x] **Round 4 — Dependencies:** No new deps. `sentence-transformers>=3.0` guarantees `transformers>=4.38` (supports `attn_implementation`)
- [x] **Round 5 — Impact:** All 5 sub-issues addressed, no regressions for non-macOS or Edge tier
- [x] **Round 6 — Final:** 432 tests pass (0 failures), no debug code, commit message accurate

## Test plan

- [ ] macOS + Base/Pro tier: verify `model.encode(["test"])` produces valid floats (no NaN)
- [ ] macOS + Base/Pro tier with existing DB: verify migration runs once and logs warning
- [ ] macOS + Edge tier: verify migration is skipped (env var check)
- [ ] Linux/Windows: verify no code path changes (platform gate)
- [ ] Verify marker `qwen3_nan_fix_applied` prevents re-running migration

Closes #215