### PR TITLE
perf: SQLite tuning, indexes, encode params, and batch operations

### DIFF
--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -157,6 +157,9 @@ CREATE TABLE IF NOT EXISTS metadata (
     value TEXT NOT NULL,
     updated_at TEXT
 );
+
+CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender);
+CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages(timestamp);
 """
 
 
@@ -190,6 +193,9 @@ def create_db(db_path: str | Path) -> sqlite3.Connection:
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute("PRAGMA cache_size=-64000")
+    conn.execute("PRAGMA mmap_size=268435456")
     conn.executescript(_SCHEMA_SQL)
     conn.commit()
     return conn
@@ -228,11 +234,11 @@ def bulk_replace_messages(conn: sqlite3.Connection, messages: list[dict]) -> int
     except sqlite3.OperationalError:
         pass  # FTS table might already be clean
 
-    for msg in messages:
-        conn.execute(
-            """INSERT INTO messages
-               (content, sender, recipient, timestamp, category, modality)
-               VALUES (?, ?, ?, ?, ?, ?)""",
+    conn.executemany(
+        """INSERT INTO messages
+           (content, sender, recipient, timestamp, category, modality)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        [
             (
                 msg["content"],
                 msg.get("sender", ""),
@@ -240,8 +246,10 @@ def bulk_replace_messages(conn: sqlite3.Connection, messages: list[dict]) -> int
                 msg.get("timestamp", ""),
                 msg.get("category", ""),
                 msg.get("modality", ""),
-            ),
-        )
+            )
+            for msg in messages
+        ],
+    )
 
     conn.commit()
     return len(messages)

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -416,7 +416,7 @@ def build_vectors(
         texts = [m["content"] for m in batch]
         ids = [m["id"] for m in batch]
 
-        embeddings = model.encode(texts)  # shape (len(batch), 256)
+        embeddings = model.encode(texts, show_progress_bar=False)
 
         for msg_id, embedding in zip(ids, embeddings):
             conn.execute(
@@ -624,7 +624,7 @@ def build_separation_vectors(
             texts.append(sep_text)
             ids.append(m["id"])
 
-        embeddings = model.encode(texts)
+        embeddings = model.encode(texts, show_progress_bar=False)
 
         for msg_id, embedding in zip(ids, embeddings):
             conn.execute(


### PR DESCRIPTION
## Summary

SQLite performance tuning and batch operation improvements.

## Changes

| # | Sub-issue | File | Change |
|---|-----------|------|--------|
| 1 | PRAGMAs | `storage.py` | Add `synchronous=NORMAL` (~2x faster writes with WAL), `cache_size=-64000` (64MB), `mmap_size=268435456` (256MB) |
| 2 | Indexes | `storage.py` | Add `idx_messages_sender` and `idx_messages_timestamp` for faster WHERE/DISTINCT queries |
| 3 | encode() | `vector_search.py` | Add `show_progress_bar=False` to batch encode calls |
| 4 | Thread-local | — | Deferred — parallel overhead is negligible |
| 5 | bulk_replace | `storage.py` | Convert row-by-row INSERT to `executemany()` |

## Validation (6 rounds)

- [x] **Round 1 — Syntax & Import:** Both files pass AST parse, full import chain works
- [x] **Round 2 — Call Chain:** `create_db()` called from `_ensure_connection()` (production path), indexes in schema DDL
- [x] **Round 3 — Edge Cases:** `IF NOT EXISTS` handles existing DBs, `synchronous=NORMAL` safe with WAL, mmap falls back on low memory
- [x] **Round 4 — Dependencies:** No new imports, all PRAGMAs standard SQLite
- [x] **Round 5 — Impact:** All addressed sub-issues improve performance, no regressions
- [x] **Round 6 — Final:** 432 tests pass, diff clean

## Test plan

- [ ] Verify PRAGMAs: `PRAGMA synchronous` returns 1 (NORMAL)
- [ ] Verify indexes: `SELECT name FROM sqlite_master WHERE type='index'` includes sender/timestamp
- [ ] Bulk replace with >100 messages works correctly
- [ ] No tqdm progress bars during vector rebuild

Closes #218