### PR TITLE
release: v0.6.8 — performance fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [0.6.8] — 2026-05-11
+
+### Fixed
+- **CRITICAL: Qwen3 NaN embeddings on macOS** — PyTorch SDPA kernel produces
+  NaN embeddings for Qwen3 on macOS. Added platform-gated
+  `attn_implementation="eager"` and one-time auto-migration to re-embed
+  corrupted vectors. (#215)
+- **anthropic missing from core dependencies** — `anthropic` was in optional
+  `[agentic]` extras but `install.sh` installs the base package, so every user
+  fell back to OpenRouter. Moved to core dependencies. (#216)
+
+### Performance
+- **MPS device detection for reranker** — CrossEncoder now uses Apple Silicon
+  GPU instead of falling back to CPU (~150-500ms saved per search). (#216)
+- **Session start 2-4x faster** — skip cross-encoder reranker for recall
+  queries (reranker adds latency but doesn't improve recall quality). (#217)
+- **Non-blocking telemetry** — initial flush moved to background thread so MCP
+  server startup doesn't block on HTTP POST (up to 3s saved). (#217)
+- **Faster ingestion dedup** — use lightweight `search_vectors()` instead of
+  full 6-layer `search()` pipeline for duplicate detection. (#217)
+- **Hybrid search query caching** — pre-compute query embedding once and share
+  across vector + separation search (~50ms saved per search). (#217)
+- **executemany for vector builds** — batch INSERT for both `build_vectors()`
+  and `build_separation_vectors()`. (#217)
+- **Remove double commit** — `insert_message()` no longer commits redundantly
+  (engine.add() handles it). (#217)
+- **SQLite performance PRAGMAs** — `synchronous=NORMAL` (~2x faster writes
+  with WAL), 64MB page cache, 256MB memory-mapped I/O. (#218)
+- **Missing indexes** — added `idx_messages_sender` and
+  `idx_messages_timestamp` for faster WHERE/DISTINCT queries. (#218)
+- **Batch bulk_replace** — converted row-by-row INSERT to `executemany()`. (#218)
+- **Suppress progress bars** — `show_progress_bar=False` on batch encode
+  calls to prevent tqdm noise during vector rebuilds. (#218)
+
 ## [0.6.7] — 2026-05-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truememory"
-version = "0.6.7"
+version = "0.6.8"
 description = "SOTA-level agent memory at zero infrastructure cost."
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Release v0.6.8

Performance release addressing 32 findings from a comprehensive 6-pass audit across 4 GitHub issues.

### Critical Fix
- **Qwen3 NaN embeddings on macOS** — SDPA kernel bug produces corrupt vectors. Platform-gated `attn_implementation="eager"` + auto-migration. (#215)

### Performance Improvements
- **anthropic in core deps** — eliminates OpenRouter proxy overhead (#216)
- **MPS reranker** — Apple Silicon GPU for CrossEncoder (#216)
- **Session start 2-4x faster** — skip reranker for recall queries (#217)
- **Non-blocking telemetry** — background thread init flush (#217)
- **Faster dedup** — vector-only search instead of full pipeline (#217)
- **Query embedding caching** — one encode per hybrid search (#217)
- **executemany everywhere** — batch INSERTs for vectors and messages (#217, #218)
- **SQLite PRAGMAs** — synchronous=NORMAL, 64MB cache, 256MB mmap (#218)
- **Missing indexes** — sender and timestamp for faster queries (#218)

### PRs included
- PR #219 — Closes #215
- PR #220 — Closes #216
- PR #222 — Closes #217
- PR #223 — Closes #218

### Validation
- 432 tests pass across all PRs and the release commit
- 6-round validation protocol per PR (syntax, call chain, edge cases, deps, impact, final reconciliation)