### PR TITLE
feat: universal hook framework for multi-CLI support

### DIFF
--- a/tests/test_hook_framework.py
+++ b/tests/test_hook_framework.py
@@ -8,31 +8,28 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
-
 # -- Import tests --
 
 def test_import_hooks_package():
-    import truememory.hooks
+    import truememory.hooks  # noqa: F401
 
 def test_import_core():
-    from truememory.hooks.core import recall_memories
-    from truememory.hooks.core import buffer_message
-    from truememory.hooks.core import prune_old_buffers
-    from truememory.hooks.core import save_snapshot
-    from truememory.hooks.core import run_background_ingestion
+    from truememory.hooks.core import recall_memories  # noqa: F401
+    from truememory.hooks.core import buffer_message  # noqa: F401
+    from truememory.hooks.core import prune_old_buffers  # noqa: F401
+    from truememory.hooks.core import save_snapshot  # noqa: F401
+    from truememory.hooks.core import run_background_ingestion  # noqa: F401
 
 def test_import_base_adapter():
-    from truememory.hooks.adapters.base import CLIAdapter
+    from truememory.hooks.adapters.base import CLIAdapter  # noqa: F401
 
 def test_import_claude_adapter():
-    from truememory.hooks.adapters.claude import ClaudeAdapter
+    from truememory.hooks.adapters.claude import ClaudeAdapter  # noqa: F401
 
 def test_import_registry():
-    from truememory.hooks.registry import detect_installed
-    from truememory.hooks.registry import detect_configured
-    from truememory.hooks.registry import get_adapter
+    from truememory.hooks.registry import detect_installed  # noqa: F401
+    from truememory.hooks.registry import detect_configured  # noqa: F401
+    from truememory.hooks.registry import get_adapter  # noqa: F401
 
 
 # -- CLIAdapter interface --

--- a/tests/test_hook_framework.py
+++ b/tests/test_hook_framework.py
@@ -1,0 +1,169 @@
+"""Tests for the universal hook framework (#186).
+
+Validates the adapter interface, core logic extraction, Claude adapter,
+and CLI registry without network calls.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# -- Import tests --
+
+def test_import_hooks_package():
+    import truememory.hooks
+
+def test_import_core():
+    from truememory.hooks.core import recall_memories
+    from truememory.hooks.core import buffer_message
+    from truememory.hooks.core import prune_old_buffers
+    from truememory.hooks.core import save_snapshot
+    from truememory.hooks.core import run_background_ingestion
+
+def test_import_base_adapter():
+    from truememory.hooks.adapters.base import CLIAdapter
+
+def test_import_claude_adapter():
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+
+def test_import_registry():
+    from truememory.hooks.registry import detect_installed
+    from truememory.hooks.registry import detect_configured
+    from truememory.hooks.registry import get_adapter
+
+
+# -- CLIAdapter interface --
+
+def test_claude_adapter_instantiation():
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+    adapter = ClaudeAdapter()
+    assert adapter.name == "Claude Code"
+    assert adapter.cli_id == "claude"
+    assert isinstance(adapter.config_path, Path)
+
+
+def test_claude_adapter_implements_all_abstract_methods():
+    from truememory.hooks.adapters.base import CLIAdapter
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+    import inspect
+    abstract_methods = {
+        name for name, _ in inspect.getmembers(CLIAdapter)
+        if getattr(getattr(CLIAdapter, name, None), "__isabstractmethod__", False)
+    }
+    adapter = ClaudeAdapter()
+    for method_name in abstract_methods:
+        assert hasattr(adapter, method_name), f"Missing method: {method_name}"
+
+
+# -- Registry --
+
+def test_get_adapter_claude():
+    from truememory.hooks.registry import get_adapter
+    adapter = get_adapter("claude")
+    assert adapter is not None
+    assert adapter.cli_id == "claude"
+
+
+def test_get_adapter_unknown():
+    from truememory.hooks.registry import get_adapter
+    assert get_adapter("nonexistent") is None
+
+
+def test_state_roundtrip(tmp_path, monkeypatch):
+    from truememory.hooks import registry
+    state_file = tmp_path / "integrations.json"
+    monkeypatch.setattr(registry, "STATE_FILE", state_file)
+
+    registry.mark_configured("claude")
+    state = registry.load_state()
+    assert "claude" in state["configured"]
+    assert "claude" in state["configured_at"]
+
+    registry.mark_unconfigured("claude")
+    state = registry.load_state()
+    assert "claude" not in state["configured"]
+
+
+# -- Core logic --
+
+def test_buffer_message(tmp_path, monkeypatch):
+    from truememory.hooks import core
+    monkeypatch.setattr(core, "BUFFER_DIR", tmp_path / "buffers")
+    core.buffer_message("test-session-123", "Hello world test message")
+    buffer_file = tmp_path / "buffers" / "test-session-123.jsonl"
+    assert buffer_file.exists()
+    data = json.loads(buffer_file.read_text(encoding="utf-8").strip())
+    assert data["content"] == "Hello world test message"
+    assert data["role"] == "user"
+
+
+def test_buffer_message_sanitizes_session_id(tmp_path, monkeypatch):
+    from truememory.hooks import core
+    monkeypatch.setattr(core, "BUFFER_DIR", tmp_path / "buffers")
+    core.buffer_message("../../etc/passwd", "exploit attempt")
+    buffer_file = tmp_path / "buffers" / "etcpasswd.jsonl"
+    assert buffer_file.exists()
+
+
+def test_prune_old_buffers(tmp_path, monkeypatch):
+    import time
+    from truememory.hooks import core
+    buf_dir = tmp_path / "buffers"
+    buf_dir.mkdir()
+    monkeypatch.setattr(core, "BUFFER_DIR", buf_dir)
+    monkeypatch.setattr(core, "RETENTION_DAYS", 0)
+
+    old_file = buf_dir / "old-session.jsonl"
+    old_file.write_text("{}", encoding="utf-8")
+    import os
+    os.utime(old_file, (time.time() - 86400, time.time() - 86400))
+
+    core.prune_old_buffers()
+    assert not old_file.exists()
+
+
+def test_recall_memories_empty_db():
+    from truememory.hooks.core import recall_memories
+    result = recall_memories({}, db_path=":memory:")
+    assert result == ""
+
+
+def test_sanitize_session_id():
+    from truememory.hooks.core import _sanitize_session_id
+    assert _sanitize_session_id("abc-123_def") == "abc-123_def"
+    assert _sanitize_session_id("../../etc") == "etc"
+    assert _sanitize_session_id("") == "unknown"
+
+
+# -- Claude adapter is_configured --
+
+def test_claude_is_configured_false_no_file(tmp_path, monkeypatch):
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+    adapter = ClaudeAdapter()
+    monkeypatch.setattr(
+        type(adapter), "config_path",
+        property(lambda self: tmp_path / "settings.json"),
+    )
+    assert not adapter.is_configured()
+
+
+def test_claude_is_configured_true(tmp_path, monkeypatch):
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+    adapter = ClaudeAdapter()
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({
+        "hooks": {
+            "SessionStart": [{
+                "matcher": "",
+                "hooks": [{"type": "command", "command": "/usr/bin/python truememory/hooks/session_start.py"}],
+            }]
+        }
+    }), encoding="utf-8")
+    monkeypatch.setattr(
+        type(adapter), "config_path",
+        property(lambda self: settings_path),
+    )
+    assert adapter.is_configured()

--- a/truememory/hooks/__init__.py
+++ b/truememory/hooks/__init__.py
@@ -1,0 +1,6 @@
+"""Universal hook framework for multi-CLI TrueMemory integration.
+
+Provides a CLI-agnostic adapter interface, portable core logic
+extracted from the existing Claude Code hooks, and a registry
+for detecting and managing CLI integrations.
+"""

--- a/truememory/hooks/adapters/__init__.py
+++ b/truememory/hooks/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""CLI adapter implementations for TrueMemory hook integration."""

--- a/truememory/hooks/adapters/base.py
+++ b/truememory/hooks/adapters/base.py
@@ -1,0 +1,66 @@
+"""Abstract base class for CLI adapters.
+
+Each supported CLI (Claude Code, Kimi, Hermes, OpenClaw) implements
+this interface to handle its config format, hook registration, and
+MCP server setup.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class CLIAdapter(ABC):
+    """Base interface for CLI-specific TrueMemory integration."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable CLI name (e.g. 'Claude Code')."""
+
+    @property
+    @abstractmethod
+    def cli_id(self) -> str:
+        """Machine identifier (e.g. 'claude', 'kimi', 'hermes', 'openclaw')."""
+
+    @property
+    @abstractmethod
+    def config_path(self) -> Path:
+        """Path to the CLI's main config file."""
+
+    @abstractmethod
+    def detect(self) -> bool:
+        """Return True if this CLI is installed on the system."""
+
+    @abstractmethod
+    def is_configured(self) -> bool:
+        """Return True if TrueMemory is already wired into this CLI."""
+
+    @abstractmethod
+    def install_mcp(self, python_path: str | None = None) -> None:
+        """Register the TrueMemory MCP server in the CLI's config."""
+
+    @abstractmethod
+    def install_hooks(
+        self,
+        python_path: str | None = None,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> None:
+        """Register TrueMemory lifecycle hooks in the CLI's config."""
+
+    @abstractmethod
+    def uninstall(self) -> None:
+        """Remove all TrueMemory entries from the CLI's config."""
+
+    @abstractmethod
+    def verify(self) -> bool:
+        """Smoke-test the installation (config exists, paths resolve)."""
+
+    @abstractmethod
+    def get_system_prompt_path(self) -> Path | None:
+        """Return the path to the CLI's system prompt file, or None."""
+
+    @abstractmethod
+    def get_system_prompt_content(self) -> str:
+        """Return the TrueMemory system prompt content for this CLI."""

--- a/truememory/hooks/adapters/claude.py
+++ b/truememory/hooks/adapters/claude.py
@@ -1,0 +1,138 @@
+"""Claude Code adapter — wraps the existing install logic.
+
+Delegates to truememory.ingest.cli._run_install() for hook installation.
+The existing `truememory-ingest install` command continues working unchanged.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+from truememory.hooks.adapters.base import CLIAdapter
+
+
+class ClaudeAdapter(CLIAdapter):
+    """Adapter for Claude Code CLI."""
+
+    @property
+    def name(self) -> str:
+        return "Claude Code"
+
+    @property
+    def cli_id(self) -> str:
+        return "claude"
+
+    @property
+    def config_path(self) -> Path:
+        return Path.home() / ".claude" / "settings.json"
+
+    def detect(self) -> bool:
+        return (
+            (Path.home() / ".claude").is_dir()
+            or shutil.which("claude") is not None
+        )
+
+    def is_configured(self) -> bool:
+        if not self.config_path.exists():
+            return False
+        try:
+            settings = json.loads(self.config_path.read_text(encoding="utf-8"))
+            hooks = settings.get("hooks", {})
+            for event_hooks in hooks.values():
+                if not isinstance(event_hooks, list):
+                    continue
+                for h in event_hooks:
+                    if not isinstance(h, dict):
+                        continue
+                    for inner in h.get("hooks", []):
+                        if isinstance(inner, dict) and "truememory" in inner.get("command", "").lower():
+                            return True
+                    if "truememory" in h.get("command", "").lower():
+                        return True
+        except (json.JSONDecodeError, OSError):
+            pass
+        return False
+
+    def install_mcp(self, python_path: str | None = None) -> None:
+        py = python_path or sys.executable
+        try:
+            import subprocess
+            subprocess.run(
+                ["claude", "mcp", "add", "--scope", "user", "truememory",
+                 "--", py, "-m", "truememory.mcp_server"],
+                check=False,
+                capture_output=True,
+            )
+        except FileNotFoundError:
+            pass
+
+    def install_hooks(
+        self,
+        python_path: str | None = None,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> None:
+        import argparse
+        args = argparse.Namespace(
+            user=user_id,
+            db=db_path,
+            dry_run=False,
+        )
+        from truememory.ingest.cli import _run_install
+        _run_install(args)
+
+    def uninstall(self) -> None:
+        if not self.config_path.exists():
+            return
+        try:
+            settings = json.loads(self.config_path.read_text(encoding="utf-8"))
+            hooks = settings.get("hooks", {})
+            for event in list(hooks.keys()):
+                entries = hooks[event]
+                if not isinstance(entries, list):
+                    continue
+                cleaned = []
+                for h in entries:
+                    if not isinstance(h, dict):
+                        cleaned.append(h)
+                        continue
+                    inner_hooks = h.get("hooks", [])
+                    if isinstance(inner_hooks, list):
+                        has_tm = any(
+                            isinstance(ih, dict) and "truememory" in ih.get("command", "").lower()
+                            for ih in inner_hooks
+                        )
+                        if has_tm:
+                            continue
+                    if "truememory" in h.get("command", "").lower():
+                        continue
+                    cleaned.append(h)
+                if cleaned:
+                    hooks[event] = cleaned
+                else:
+                    del hooks[event]
+            settings["hooks"] = hooks
+            self.config_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    def verify(self) -> bool:
+        if not self.config_path.exists():
+            return False
+        return self.is_configured()
+
+    def get_system_prompt_path(self) -> Path | None:
+        return Path.home() / ".claude" / "CLAUDE.md"
+
+    def get_system_prompt_content(self) -> str:
+        template_path = Path(__file__).parent.parent.parent / "ingest" / "CLAUDE_TEMPLATE.md"
+        if not template_path.exists():
+            template_path = Path(__file__).parent.parent.parent.parent / "CLAUDE_TEMPLATE.md"
+        if template_path.exists():
+            try:
+                return template_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                pass
+        return ""

--- a/truememory/hooks/cli.py
+++ b/truememory/hooks/cli.py
@@ -1,0 +1,75 @@
+"""CLI entry points for multi-CLI hook setup.
+
+Provides functions that the main `truememory-ingest setup` command can
+delegate to for per-CLI hook installation and management.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from truememory.hooks.adapters.base import CLIAdapter
+from truememory.hooks.registry import (
+    detect_installed,
+    get_adapter,
+    mark_configured,
+    mark_unconfigured,
+)
+
+log = logging.getLogger(__name__)
+
+
+def install_cli(
+    cli_id: str,
+    python_path: str | None = None,
+    user_id: str = "",
+    db_path: str = "",
+) -> bool:
+    """Install TrueMemory hooks and MCP server for a specific CLI.
+
+    Returns True on success, False if the CLI is unknown or install fails.
+    """
+    adapter = get_adapter(cli_id)
+    if adapter is None:
+        log.error("Unknown CLI: %s", cli_id)
+        return False
+
+    try:
+        adapter.install_hooks(
+            python_path=python_path,
+            user_id=user_id,
+            db_path=db_path,
+        )
+        adapter.install_mcp(python_path=python_path)
+        mark_configured(cli_id)
+        return True
+    except Exception as e:
+        log.error("Failed to install for %s: %s", cli_id, e)
+        return False
+
+
+def uninstall_cli(cli_id: str) -> bool:
+    """Remove TrueMemory from a specific CLI's config.
+
+    Returns True on success, False if the CLI is unknown or uninstall fails.
+    """
+    adapter = get_adapter(cli_id)
+    if adapter is None:
+        log.error("Unknown CLI: %s", cli_id)
+        return False
+
+    try:
+        adapter.uninstall()
+        mark_unconfigured(cli_id)
+        return True
+    except Exception as e:
+        log.error("Failed to uninstall from %s: %s", cli_id, e)
+        return False
+
+
+def verify_cli(cli_id: str) -> bool:
+    """Verify TrueMemory installation for a specific CLI."""
+    adapter = get_adapter(cli_id)
+    if adapter is None:
+        return False
+    return adapter.verify()

--- a/truememory/hooks/cli.py
+++ b/truememory/hooks/cli.py
@@ -6,11 +6,8 @@ delegate to for per-CLI hook installation and management.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
-from truememory.hooks.adapters.base import CLIAdapter
 from truememory.hooks.registry import (
-    detect_installed,
     get_adapter,
     mark_configured,
     mark_unconfigured,

--- a/truememory/hooks/core.py
+++ b/truememory/hooks/core.py
@@ -1,0 +1,356 @@
+"""CLI-agnostic core logic for TrueMemory hooks.
+
+Portable functions extracted from the Claude Code-specific hook scripts.
+These can be called by any CLI adapter without importing Claude-specific
+modules.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+MEMORY_LIMIT = int(os.environ.get("TRUEMEMORY_RECALL_LIMIT", "25"))
+
+BUFFER_DIR = Path(os.environ.get(
+    "TRUEMEMORY_BUFFER_DIR",
+    str(Path.home() / ".truememory" / "buffers"),
+))
+RETENTION_DAYS = int(os.environ.get("TRUEMEMORY_BUFFER_RETENTION_DAYS", "7"))
+MAX_BUFFER_SIZE = int(os.environ.get("TRUEMEMORY_BUFFER_MAX_BYTES", str(10 * 1024 * 1024)))
+
+TRACE_DIR = Path.home() / ".truememory" / "traces"
+LOG_DIR = Path.home() / ".truememory" / "logs"
+BACKLOG_DIR = Path.home() / ".truememory" / "backlog"
+SPAWN_CAP = int(os.environ.get("TRUEMEMORY_SPAWN_CAP", "3"))
+
+try:
+    import fcntl
+    _HAS_FCNTL = True
+except ImportError:
+    _HAS_FCNTL = False
+
+
+def recall_memories(
+    input_data: dict,
+    user_id: str = "",
+    db_path: str = "",
+    memory_limit: int | None = None,
+) -> str:
+    """Search TrueMemory and format relevant memories for context injection.
+
+    Returns a formatted string suitable for additionalContext injection,
+    or empty string if no memories found.
+    """
+    try:
+        from truememory import Memory
+    except ImportError:
+        return ""
+
+    limit = memory_limit or MEMORY_LIMIT
+    db = db_path or None
+    memory = Memory(path=db) if db else Memory()
+
+    queries = [
+        "user preferences favorites likes dislikes",
+        "personal facts name location job role",
+        "recent decisions and commitments",
+        "corrections and updates to prior information",
+        "relationships family friends coworkers",
+    ]
+
+    per_query_limit = max(1, limit // len(queries))
+
+    all_results: list[dict] = []
+    seen_ids: set = set()
+    seen_content: set[str] = set()
+
+    for query in queries:
+        added_this_query = 0
+        try:
+            if user_id:
+                results = memory.search(query, user_id=user_id, limit=per_query_limit * 3)
+            else:
+                results = memory.search(query, limit=per_query_limit * 3)
+
+            for r in results:
+                if added_this_query >= per_query_limit:
+                    break
+                rid = r.get("id")
+                if rid in seen_ids:
+                    continue
+                content = r.get("content", "").strip()
+                if not content:
+                    continue
+                normalized = content.lower().strip().rstrip(".")
+                if normalized in seen_content:
+                    continue
+                is_dup = False
+                for existing in seen_content:
+                    if normalized in existing or existing in normalized:
+                        is_dup = True
+                        break
+                if is_dup:
+                    continue
+                seen_ids.add(rid)
+                seen_content.add(normalized)
+                all_results.append(r)
+                added_this_query += 1
+        except Exception:
+            continue
+
+    if not all_results:
+        return ""
+
+    lines = [
+        "<truememory-context>",
+        "## TrueMemory — What You Know About This User",
+        "These are facts from TrueMemory (the primary long-horizon memory system).",
+        "Use these to answer user questions. Search TrueMemory for more if needed.",
+        "",
+    ]
+    for r in all_results[:limit]:
+        content = r.get("content", "").strip()
+        if content:
+            lines.append(f"- {content}")
+
+    lines.append("</truememory-context>")
+    return "\n".join(lines)
+
+
+def buffer_message(session_id: str, prompt: str) -> None:
+    """Append a user message to the session buffer file (with file locking)."""
+    BUFFER_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        BUFFER_DIR.chmod(0o700)
+    except OSError:
+        pass
+
+    safe_id = "".join(c for c in session_id if c.isalnum() or c in "-_")[:64]
+    if not safe_id:
+        safe_id = "unknown"
+
+    buffer_file = BUFFER_DIR / f"{safe_id}.jsonl"
+
+    try:
+        if buffer_file.exists() and buffer_file.stat().st_size > MAX_BUFFER_SIZE:
+            rotated = buffer_file.with_suffix(f".{int(time.time())}.jsonl")
+            buffer_file.rename(rotated)
+    except OSError:
+        pass
+
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "role": "user",
+        "content": prompt[:10000],
+    }
+    line = json.dumps(entry, ensure_ascii=False) + "\n"
+
+    try:
+        if _HAS_FCNTL:
+            with open(buffer_file, "a", encoding="utf-8") as f:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                try:
+                    f.write(line)
+                finally:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        else:
+            with open(buffer_file, "a", encoding="utf-8") as f:
+                f.write(line)
+    except OSError:
+        pass
+
+
+def prune_old_buffers() -> None:
+    """Delete buffer files older than RETENTION_DAYS."""
+    try:
+        if not BUFFER_DIR.exists():
+            return
+        cutoff = time.time() - (RETENTION_DAYS * 86400)
+        for f in BUFFER_DIR.iterdir():
+            if f.suffix == ".jsonl":
+                try:
+                    if f.stat().st_mtime < cutoff:
+                        f.unlink()
+                except OSError:
+                    pass
+    except OSError:
+        pass
+
+
+def save_snapshot(
+    transcript_path: str,
+    session_id: str,
+    user_id: str = "",
+    db_path: str = "",
+) -> None:
+    """Extract key points from the current conversation and store them."""
+    try:
+        from truememory.ingest.transcript import parse_transcript
+    except ImportError:
+        return
+
+    messages = parse_transcript(transcript_path)
+    if not messages:
+        return
+
+    user_messages = [
+        m.content for m in messages
+        if m.role in ("human", "user") and len(m.content) > 20
+    ]
+
+    if not user_messages:
+        return
+
+    substantive = [m for m in user_messages if len(m) > 50]
+    if not substantive:
+        substantive = user_messages[-3:]
+
+    recent = substantive[-5:]
+
+    try:
+        from truememory import Memory
+    except ImportError:
+        return
+
+    db = db_path or None
+    memory = Memory(path=db) if db else Memory()
+
+    summary_parts = [f"[session:{session_id} time:{datetime.now(timezone.utc).isoformat()}]"]
+    summary_parts.append("Context snapshot from active session:")
+    for msg in recent:
+        truncated = msg[:500] + "..." if len(msg) > 500 else msg
+        summary_parts.append(f"- {truncated}")
+
+    summary = "\n".join(summary_parts)
+    memory.add(summary, user_id=user_id or None)
+
+
+def _sanitize_session_id(session_id: str) -> str:
+    safe = "".join(c for c in session_id if c.isalnum() or c in "-_")[:64]
+    return safe or "unknown"
+
+
+def _count_active_ingest_processes() -> int:
+    """Count running truememory ingest processes."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "truememory.ingest.cli.*ingest"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return len([ln for ln in (result.stdout or "").splitlines() if ln.strip()])
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return 0
+
+
+def run_background_ingestion(
+    transcript_path: str,
+    session_id: str,
+    user_id: str = "",
+    db_path: str = "",
+    gate_threshold: float = 0.5,
+) -> None:
+    """Launch the ingestion pipeline as a background process."""
+    log.info(
+        "core: launching ingestion user=%r db=%r session=%r",
+        user_id, db_path, session_id,
+    )
+
+    cmd = [
+        sys.executable, "-m", "truememory.ingest.cli",
+        "ingest", transcript_path,
+    ]
+
+    if user_id:
+        cmd.extend(["--user", user_id])
+    if db_path:
+        cmd.extend(["--db", db_path])
+
+    cmd.extend(["--threshold", str(gate_threshold)])
+    if session_id:
+        cmd.extend(["--session", session_id])
+
+    safe_session = _sanitize_session_id(session_id)
+    trace_path = TRACE_DIR / f"{safe_session}.json"
+    log_path = LOG_DIR / f"{safe_session}.log"
+
+    TRACE_DIR.mkdir(parents=True, exist_ok=True)
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    cmd.extend(["--trace", str(trace_path)])
+
+    detach_kwargs: dict = {}
+    if sys.platform == "win32":
+        detach_kwargs["creationflags"] = (
+            subprocess.CREATE_NEW_PROCESS_GROUP
+            | getattr(subprocess, "DETACHED_PROCESS", 0)
+        )
+    else:
+        detach_kwargs["start_new_session"] = True
+
+    active = _count_active_ingest_processes()
+    if active >= SPAWN_CAP:
+        log.warning(
+            "core: at spawn cap (%d active / cap %d); queueing session %r",
+            active, SPAWN_CAP, session_id,
+        )
+        _queue_to_backlog(
+            transcript_path, session_id, user_id, db_path,
+            reason=f"spawn_cap_reached:{active}>=SPAWN_CAP={SPAWN_CAP}",
+        )
+        return
+
+    log_file = None
+    try:
+        log_file = open(log_path, "a", encoding="utf-8")
+        subprocess.Popen(
+            cmd,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            close_fds=(sys.platform != "win32"),
+            **detach_kwargs,
+        )
+    except Exception as e:
+        log.error("core: Popen failed: %s — queueing to backlog", e)
+        _queue_to_backlog(
+            transcript_path, session_id, user_id, db_path,
+            reason=f"popen_failed:{e}",
+        )
+    finally:
+        if log_file is not None:
+            try:
+                log_file.close()
+            except OSError:
+                pass
+
+
+def _queue_to_backlog(
+    transcript_path: str,
+    session_id: str,
+    user_id: str,
+    db_path: str,
+    reason: str,
+) -> None:
+    """Drop a queue marker for later re-attempt."""
+    try:
+        BACKLOG_DIR.mkdir(parents=True, exist_ok=True)
+        BACKLOG_DIR.chmod(0o700)
+        marker = BACKLOG_DIR / f"{_sanitize_session_id(session_id)}.json"
+        marker.write_text(json.dumps({
+            "transcript_path": transcript_path,
+            "session_id": session_id,
+            "user_id": user_id,
+            "db_path": db_path,
+            "queued_at": datetime.now(timezone.utc).isoformat(),
+            "reason": reason,
+        }), encoding="utf-8")
+    except Exception as e:
+        log.error("core: failed to queue backlog marker: %s", e)

--- a/truememory/hooks/registry.py
+++ b/truememory/hooks/registry.py
@@ -1,0 +1,89 @@
+"""CLI detection, config path mapping, and install state tracking.
+
+Discovers which CLI tools are installed and tracks which ones have
+TrueMemory configured.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from truememory.hooks.adapters.base import CLIAdapter
+
+log = logging.getLogger(__name__)
+
+STATE_FILE = Path.home() / ".truememory" / "integrations.json"
+
+
+def _get_all_adapters() -> list[CLIAdapter]:
+    """Return instances of all known CLI adapters."""
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+    return [ClaudeAdapter()]
+
+
+def detect_installed() -> list[CLIAdapter]:
+    """Return adapters for CLIs that are installed on this system."""
+    return [a for a in _get_all_adapters() if a.detect()]
+
+
+def detect_configured() -> list[CLIAdapter]:
+    """Return adapters for CLIs that have TrueMemory configured."""
+    return [a for a in _get_all_adapters() if a.is_configured()]
+
+
+def get_adapter(cli_id: str) -> CLIAdapter | None:
+    """Get a specific adapter by its CLI identifier."""
+    for a in _get_all_adapters():
+        if a.cli_id == cli_id:
+            return a
+    return None
+
+
+def load_state() -> dict:
+    """Load the integration state file."""
+    if not STATE_FILE.exists():
+        return {"configured": [], "configured_at": {}, "version": ""}
+    try:
+        return json.loads(STATE_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {"configured": [], "configured_at": {}, "version": ""}
+
+
+def save_state(state: dict) -> None:
+    """Save the integration state file."""
+    try:
+        STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        STATE_FILE.write_text(
+            json.dumps(state, indent=2),
+            encoding="utf-8",
+        )
+    except OSError as e:
+        log.warning("Failed to save integration state: %s", e)
+
+
+def mark_configured(cli_id: str) -> None:
+    """Record that a CLI has been configured."""
+    from truememory import __version__
+    state = load_state()
+    configured = state.get("configured", [])
+    if cli_id not in configured:
+        configured.append(cli_id)
+    state["configured"] = configured
+    state.setdefault("configured_at", {})[cli_id] = (
+        datetime.now(timezone.utc).isoformat()
+    )
+    state["version"] = __version__
+    save_state(state)
+
+
+def mark_unconfigured(cli_id: str) -> None:
+    """Record that a CLI has been unconfigured."""
+    state = load_state()
+    configured = state.get("configured", [])
+    if cli_id in configured:
+        configured.remove(cli_id)
+    state["configured"] = configured
+    state.get("configured_at", {}).pop(cli_id, None)
+    save_state(state)


### PR DESCRIPTION
Closes #186

## Summary
- **Core logic extraction** (`truememory/hooks/core.py`): Portable functions (`recall_memories`, `buffer_message`, `save_snapshot`, `run_background_ingestion`, `prune_old_buffers`) extracted from Claude Code-specific hook scripts, callable by any CLI adapter
- **Abstract adapter interface** (`truememory/hooks/adapters/base.py`): `CLIAdapter` ABC with 11 abstract methods covering detection, configuration, MCP registration, hook installation, uninstall, verification, and system prompt management
- **Claude Code adapter** (`truememory/hooks/adapters/claude.py`): Wraps existing `_run_install()` from `ingest/cli.py` — no behavior change, existing `truememory-ingest install` continues working unchanged
- **CLI registry** (`truememory/hooks/registry.py`): Detection of installed CLIs, install state tracking via `~/.truememory/integrations.json`, adapter lookup by CLI ID
- **Setup CLI bridge** (`truememory/hooks/cli.py`): `install_cli()`, `uninstall_cli()`, `verify_cli()` entry points for the main CLI to delegate to

## Test plan
- [x] All 17 new tests pass (`tests/test_hook_framework.py`)
- [x] All pre-existing tests pass (137 passed, 1 pre-existing version-mismatch skip)
- [x] All new modules import cleanly — no circular imports
- [x] Backward compatibility confirmed: `session_start.py`, `stop.py`, `compact.py`, `user_prompt_submit.py` still importable as `python -m` modules
- [x] `truememory-ingest --help` still works
- [x] No heavy imports at module level (torch, sentence_transformers)
- [x] Platform-safe: uses `Path` objects, `sys.platform` checks for subprocess detachment