### PR TITLE
feat: Kimi CLI integration — MCP config + lifecycle hooks

### DIFF
--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 
 
 # -- Import tests --

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -1,0 +1,202 @@
+"""Tests for the Kimi CLI adapter (#183).
+
+Validates MCP config, TOML hook registration, detection, and
+config merge safety without network calls.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# -- Import tests --
+
+def test_import_kimi_adapter():
+    from truememory.hooks.adapters.kimi import KimiAdapter  # noqa: F401
+
+
+def test_kimi_in_registry():
+    from truememory.hooks.registry import get_adapter
+    adapter = get_adapter("kimi")
+    assert adapter is not None
+    assert adapter.cli_id == "kimi"
+
+
+# -- Instantiation --
+
+def test_kimi_adapter_properties():
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+    assert adapter.name == "Kimi CLI"
+    assert adapter.cli_id == "kimi"
+    assert isinstance(adapter.config_path, Path)
+    assert adapter.config_path.name == "config.toml"
+
+
+def test_kimi_implements_all_abstract_methods():
+    from truememory.hooks.adapters.base import CLIAdapter
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    import inspect
+    abstract_methods = {
+        name for name, _ in inspect.getmembers(CLIAdapter)
+        if getattr(getattr(CLIAdapter, name, None), "__isabstractmethod__", False)
+    }
+    adapter = KimiAdapter()
+    for method_name in abstract_methods:
+        assert hasattr(adapter, method_name), f"Missing: {method_name}"
+
+
+# -- Detection --
+
+def test_detect_false_no_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import kimi as kimi_mod
+    monkeypatch.setattr(kimi_mod, "_KIMI_DIR", tmp_path / "nonexistent")
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    assert not adapter.detect()
+
+
+def test_detect_true_with_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import kimi as kimi_mod
+    kimi_dir = tmp_path / ".kimi"
+    kimi_dir.mkdir()
+    monkeypatch.setattr(kimi_mod, "_KIMI_DIR", kimi_dir)
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+    assert adapter.detect()
+
+
+# -- MCP config --
+
+def test_install_mcp_creates_config(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import kimi as kimi_mod
+    mcp_path = tmp_path / "mcp.json"
+    monkeypatch.setattr(kimi_mod, "_MCP_CONFIG", mcp_path)
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+
+    data = json.loads(mcp_path.read_text(encoding="utf-8"))
+    assert "truememory" in data["mcpServers"]
+    assert data["mcpServers"]["truememory"]["command"] == "/usr/bin/python3"
+    assert data["mcpServers"]["truememory"]["args"] == ["-m", "truememory.mcp_server"]
+
+
+def test_install_mcp_preserves_existing(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import kimi as kimi_mod
+    mcp_path = tmp_path / "mcp.json"
+    mcp_path.write_text(json.dumps({
+        "mcpServers": {
+            "other-server": {"command": "other", "args": ["arg"]}
+        }
+    }), encoding="utf-8")
+    monkeypatch.setattr(kimi_mod, "_MCP_CONFIG", mcp_path)
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+
+    data = json.loads(mcp_path.read_text(encoding="utf-8"))
+    assert "truememory" in data["mcpServers"]
+    assert "other-server" in data["mcpServers"]
+
+
+# -- TOML hook config --
+
+def test_install_hooks_creates_toml(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import kimi as kimi_mod
+    hook_config = tmp_path / "config.toml"
+    monkeypatch.setattr(kimi_mod, "_HOOK_CONFIG", hook_config)
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    text = hook_config.read_text(encoding="utf-8")
+    assert "[[hooks]]" in text
+    assert 'event = "SessionStart"' in text
+    assert 'event = "Stop"' in text
+    assert 'event = "PreCompact"' in text
+    assert "truememory" in text.lower()
+
+
+def test_install_hooks_preserves_existing_toml(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import kimi as kimi_mod
+    hook_config = tmp_path / "config.toml"
+    hook_config.write_text(
+        '[general]\ntheme = "dark"\n\n[[hooks]]\nevent = "MyCustomHook"\ncommand = "my-cmd"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(kimi_mod, "_HOOK_CONFIG", hook_config)
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    text = hook_config.read_text(encoding="utf-8")
+    assert 'theme = "dark"' in text
+    assert 'event = "MyCustomHook"' in text
+    assert 'event = "SessionStart"' in text
+
+
+def test_install_hooks_idempotent(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import kimi as kimi_mod
+    hook_config = tmp_path / "config.toml"
+    monkeypatch.setattr(kimi_mod, "_HOOK_CONFIG", hook_config)
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    first_text = hook_config.read_text(encoding="utf-8")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    second_text = hook_config.read_text(encoding="utf-8")
+    assert first_text == second_text
+
+
+# -- Uninstall --
+
+def test_uninstall_removes_entries(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import kimi as kimi_mod
+    mcp_path = tmp_path / "mcp.json"
+    hook_config = tmp_path / "config.toml"
+    monkeypatch.setattr(kimi_mod, "_MCP_CONFIG", mcp_path)
+    monkeypatch.setattr(kimi_mod, "_HOOK_CONFIG", hook_config)
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    assert adapter.is_configured()
+
+    adapter.uninstall()
+    data = json.loads(mcp_path.read_text(encoding="utf-8"))
+    assert "truememory" not in data.get("mcpServers", {})
+
+    text = hook_config.read_text(encoding="utf-8")
+    assert "truememory" not in text.lower()
+
+
+# -- is_configured --
+
+def test_is_configured_false_clean(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import kimi as kimi_mod
+    monkeypatch.setattr(kimi_mod, "_MCP_CONFIG", tmp_path / "mcp.json")
+    monkeypatch.setattr(kimi_mod, "_HOOK_CONFIG", tmp_path / "config.toml")
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    assert not KimiAdapter().is_configured()
+
+
+# -- Build command --
+
+def test_build_command_with_user_and_db():
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    cmd = KimiAdapter._build_command(
+        "/usr/bin/python3",
+        Path("/path/to/session_start.py"),
+        user_id="alice",
+        db_path="/data/mem.db",
+    )
+    assert "/usr/bin/python3" in cmd
+    assert "session_start.py" in cmd
+    assert "--user" in cmd
+    assert "alice" in cmd
+    assert "--db" in cmd

--- a/truememory/hooks/adapters/kimi.py
+++ b/truememory/hooks/adapters/kimi.py
@@ -1,0 +1,254 @@
+"""Kimi CLI adapter — MCP config + TOML lifecycle hooks.
+
+Kimi CLI uses:
+- ~/.kimi/mcp.json for MCP server registration (Claude Desktop-compatible format)
+- ~/.kimi/config.toml for hook registration ([[hooks]] entries)
+- Same JSON stdin/stdout hook protocol as Claude Code
+"""
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+import shutil
+import sys
+import tomllib
+from pathlib import Path
+
+from truememory.hooks.adapters.base import CLIAdapter
+
+log = logging.getLogger(__name__)
+
+_KIMI_DIR = Path.home() / ".kimi"
+_MCP_CONFIG = _KIMI_DIR / "mcp.json"
+_HOOK_CONFIG = _KIMI_DIR / "config.toml"
+
+_HOOK_EVENTS = {
+    "SessionStart": {
+        "script": "session_start.py",
+        "timeout": 10000,
+    },
+    "Stop": {
+        "script": "stop.py",
+        "timeout": 5000,
+    },
+    "PreCompact": {
+        "script": "compact.py",
+        "timeout": 5000,
+    },
+}
+
+_TRUEMEMORY_MARKER = "truememory"
+
+
+class KimiAdapter(CLIAdapter):
+    """Adapter for Kimi CLI (Moonshot AI)."""
+
+    @property
+    def name(self) -> str:
+        return "Kimi CLI"
+
+    @property
+    def cli_id(self) -> str:
+        return "kimi"
+
+    @property
+    def config_path(self) -> Path:
+        return _HOOK_CONFIG
+
+    def detect(self) -> bool:
+        return _KIMI_DIR.is_dir() or shutil.which("kimi") is not None
+
+    def is_configured(self) -> bool:
+        mcp_ok = self._has_mcp_entry()
+        hooks_ok = self._has_hook_entries()
+        return mcp_ok or hooks_ok
+
+    def install_mcp(self, python_path: str | None = None) -> None:
+        py = python_path or sys.executable
+        _MCP_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+
+        existing: dict = {}
+        if _MCP_CONFIG.exists():
+            try:
+                existing = json.loads(_MCP_CONFIG.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                existing = {}
+
+        if not isinstance(existing, dict):
+            existing = {}
+
+        servers = existing.setdefault("mcpServers", {})
+        if not isinstance(servers, dict):
+            servers = {}
+            existing["mcpServers"] = servers
+
+        servers["truememory"] = {
+            "command": py,
+            "args": ["-m", "truememory.mcp_server"],
+        }
+
+        _MCP_CONFIG.write_text(
+            json.dumps(existing, indent=2),
+            encoding="utf-8",
+        )
+
+    def install_hooks(
+        self,
+        python_path: str | None = None,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> None:
+        py = python_path or sys.executable
+        hooks_dir = Path(__file__).parent.parent.parent / "ingest" / "hooks"
+
+        _HOOK_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+
+        existing_text = ""
+        if _HOOK_CONFIG.exists():
+            try:
+                existing_text = _HOOK_CONFIG.read_text(encoding="utf-8")
+            except OSError:
+                existing_text = ""
+
+        existing_hooks = self._parse_existing_hooks(existing_text)
+
+        lines_to_append: list[str] = []
+        for event, info in _HOOK_EVENTS.items():
+            if self._event_already_registered(existing_hooks, event):
+                continue
+
+            script_path = hooks_dir / info["script"]
+            cmd = self._build_command(py, script_path, user_id, db_path)
+
+            lines_to_append.append("")
+            lines_to_append.append("[[hooks]]")
+            lines_to_append.append(f'event = "{event}"')
+            lines_to_append.append(f'command = "{cmd}"')
+            lines_to_append.append(f'timeout = {info["timeout"]}')
+
+        if lines_to_append:
+            new_text = existing_text.rstrip() + "\n" + "\n".join(lines_to_append) + "\n"
+            _HOOK_CONFIG.write_text(new_text, encoding="utf-8")
+
+    def uninstall(self) -> None:
+        self._remove_mcp_entry()
+        self._remove_hook_entries()
+
+    def verify(self) -> bool:
+        return self._has_mcp_entry() and self._has_hook_entries()
+
+    def get_system_prompt_path(self) -> Path | None:
+        return None
+
+    def get_system_prompt_content(self) -> str:
+        return ""
+
+    # -- Private helpers --
+
+    @staticmethod
+    def _build_command(
+        python_path: str,
+        script_path: Path,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> str:
+        parts: list[str] = [python_path, str(script_path)]
+        if user_id:
+            parts.extend(["--user", user_id])
+        if db_path:
+            parts.extend(["--db", db_path])
+        if sys.platform == "win32":
+            import subprocess as _sp
+            return _sp.list2cmdline(parts)
+        return " ".join(shlex.quote(p) for p in parts)
+
+    @staticmethod
+    def _parse_existing_hooks(toml_text: str) -> list[dict]:
+        if not toml_text.strip():
+            return []
+        try:
+            data = tomllib.loads(toml_text)
+            return data.get("hooks", [])
+        except Exception:
+            return []
+
+    @staticmethod
+    def _event_already_registered(hooks: list[dict], event: str) -> bool:
+        for h in hooks:
+            if (
+                h.get("event") == event
+                and _TRUEMEMORY_MARKER in h.get("command", "").lower()
+            ):
+                return True
+        return False
+
+    def _has_mcp_entry(self) -> bool:
+        if not _MCP_CONFIG.exists():
+            return False
+        try:
+            data = json.loads(_MCP_CONFIG.read_text(encoding="utf-8"))
+            return "truememory" in data.get("mcpServers", {})
+        except (json.JSONDecodeError, OSError):
+            return False
+
+    def _has_hook_entries(self) -> bool:
+        if not _HOOK_CONFIG.exists():
+            return False
+        try:
+            text = _HOOK_CONFIG.read_text(encoding="utf-8")
+            hooks = self._parse_existing_hooks(text)
+            return any(
+                _TRUEMEMORY_MARKER in h.get("command", "").lower()
+                for h in hooks
+            )
+        except OSError:
+            return False
+
+    def _remove_mcp_entry(self) -> None:
+        if not _MCP_CONFIG.exists():
+            return
+        try:
+            data = json.loads(_MCP_CONFIG.read_text(encoding="utf-8"))
+            servers = data.get("mcpServers", {})
+            if "truememory" in servers:
+                del servers["truememory"]
+                _MCP_CONFIG.write_text(
+                    json.dumps(data, indent=2), encoding="utf-8",
+                )
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    def _remove_hook_entries(self) -> None:
+        if not _HOOK_CONFIG.exists():
+            return
+        try:
+            text = _HOOK_CONFIG.read_text(encoding="utf-8")
+        except OSError:
+            return
+
+        lines = text.splitlines(keepends=True)
+        cleaned: list[str] = []
+        skip_block = False
+
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.strip()
+
+            if stripped == "[[hooks]]":
+                block_lines = [line]
+                i += 1
+                while i < len(lines) and lines[i].strip() and not lines[i].strip().startswith("[["):
+                    block_lines.append(lines[i])
+                    i += 1
+
+                block_text = "".join(block_lines)
+                if _TRUEMEMORY_MARKER not in block_text.lower():
+                    cleaned.extend(block_lines)
+                continue
+
+            cleaned.append(line)
+            i += 1
+
+        _HOOK_CONFIG.write_text("".join(cleaned), encoding="utf-8")

--- a/truememory/hooks/adapters/kimi.py
+++ b/truememory/hooks/adapters/kimi.py
@@ -229,7 +229,6 @@ class KimiAdapter(CLIAdapter):
 
         lines = text.splitlines(keepends=True)
         cleaned: list[str] = []
-        skip_block = False
 
         i = 0
         while i < len(lines):

--- a/truememory/hooks/adapters/kimi.py
+++ b/truememory/hooks/adapters/kimi.py
@@ -12,7 +12,6 @@ import logging
 import shlex
 import shutil
 import sys
-import tomllib
 from pathlib import Path
 
 from truememory.hooks.adapters.base import CLIAdapter
@@ -168,8 +167,30 @@ class KimiAdapter(CLIAdapter):
         if not toml_text.strip():
             return []
         try:
+            import tomllib
             data = tomllib.loads(toml_text)
             return data.get("hooks", [])
+        except ModuleNotFoundError:
+            import re
+            hooks: list[dict] = []
+            for block in re.split(r'(?=^\[\[hooks\]\])', toml_text, flags=re.MULTILINE):
+                if not block.strip().startswith("[[hooks]]"):
+                    continue
+                entry: dict[str, str] = {}
+                for line in block.splitlines()[1:]:
+                    line = line.strip()
+                    if not line or line.startswith("["):
+                        break
+                    m = re.match(r'(\w+)\s*=\s*"([^"]*)"', line)
+                    if m:
+                        entry[m.group(1)] = m.group(2)
+                    else:
+                        m = re.match(r'(\w+)\s*=\s*(\d+)', line)
+                        if m:
+                            entry[m.group(1)] = m.group(2)
+                if entry:
+                    hooks.append(entry)
+            return hooks
         except Exception:
             return []
 

--- a/truememory/hooks/registry.py
+++ b/truememory/hooks/registry.py
@@ -20,7 +20,8 @@ STATE_FILE = Path.home() / ".truememory" / "integrations.json"
 def _get_all_adapters() -> list[CLIAdapter]:
     """Return instances of all known CLI adapters."""
     from truememory.hooks.adapters.claude import ClaudeAdapter
-    return [ClaudeAdapter()]
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    return [ClaudeAdapter(), KimiAdapter()]
 
 
 def detect_installed() -> list[CLIAdapter]:


### PR DESCRIPTION
Closes #183

## Summary
- **KimiAdapter** (`truememory/hooks/adapters/kimi.py`): Full CLIAdapter implementation for Kimi CLI with detection (`~/.kimi/` directory or `kimi` binary), MCP registration (JSON at `~/.kimi/mcp.json`), and TOML hook registration (`~/.kimi/config.toml`)
- **Three hook events**: SessionStart (10s timeout), Stop (5s timeout), PreCompact (5s timeout) — same scripts as Claude Code, different config format
- **Additive config merges**: Both JSON MCP config and TOML hook config are read-merge-write — existing user entries are preserved. Hook install is idempotent (no duplicates on re-run)
- **Registry updated**: KimiAdapter registered in `_get_all_adapters()` so `detect_installed()` and `get_adapter("kimi")` work

## Test plan
- [x] 14 new tests pass (`tests/test_kimi_adapter.py`)
- [x] All 17 existing hook framework tests still pass
- [x] Import chain verified — no circular imports
- [x] Interface compliance: all 11 CLIAdapter abstract methods implemented
- [x] Additive merge safety: existing JSON entries and TOML config preserved
- [x] Idempotent install: running twice produces identical config
- [x] Uninstall removes only TrueMemory entries
- [x] Backward compatibility: existing hooks still importable, `truememory-ingest --help` works