### PR TITLE
feat: Hermes Agent integration — YAML config + plugin hooks

### DIFF
--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -1,0 +1,205 @@
+"""Tests for the Hermes Agent adapter (#185).
+
+Validates YAML MCP config, plugin hook registration, detection,
+and config merge safety without network calls.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# -- Import tests --
+
+def test_import_hermes_adapter():
+    from truememory.hooks.adapters.hermes import HermesAdapter  # noqa: F401
+
+
+def test_hermes_in_registry():
+    from truememory.hooks.registry import get_adapter
+    adapter = get_adapter("hermes")
+    assert adapter is not None
+    assert adapter.cli_id == "hermes"
+
+
+# -- Instantiation --
+
+def test_hermes_adapter_properties():
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    adapter = HermesAdapter()
+    assert adapter.name == "Hermes Agent"
+    assert adapter.cli_id == "hermes"
+    assert isinstance(adapter.config_path, Path)
+    assert adapter.config_path.name == "config.yaml"
+
+
+def test_hermes_implements_all_abstract_methods():
+    from truememory.hooks.adapters.base import CLIAdapter
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    import inspect
+    abstract_methods = {
+        name for name, _ in inspect.getmembers(CLIAdapter)
+        if getattr(getattr(CLIAdapter, name, None), "__isabstractmethod__", False)
+    }
+    adapter = HermesAdapter()
+    for method_name in abstract_methods:
+        assert hasattr(adapter, method_name), f"Missing: {method_name}"
+
+
+# -- Detection --
+
+def test_detect_false_no_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import hermes as hermes_mod
+    monkeypatch.setattr(hermes_mod, "_HERMES_DIR", tmp_path / "nonexistent")
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    adapter = HermesAdapter()
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    assert not adapter.detect()
+
+
+def test_detect_true_with_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import hermes as hermes_mod
+    hermes_dir = tmp_path / ".hermes"
+    hermes_dir.mkdir()
+    monkeypatch.setattr(hermes_mod, "_HERMES_DIR", hermes_dir)
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    assert HermesAdapter().detect()
+
+
+# -- MCP config --
+
+def test_install_mcp_creates_yaml(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import hermes as hermes_mod
+    mcp_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(hermes_mod, "_MCP_CONFIG", mcp_path)
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    HermesAdapter().install_mcp(python_path="/usr/bin/python3")
+
+    data = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))
+    assert "truememory" in data["mcp_servers"]
+    assert data["mcp_servers"]["truememory"]["command"] == "/usr/bin/python3"
+    assert data["mcp_servers"]["truememory"]["args"] == ["-m", "truememory.mcp_server"]
+
+
+def test_install_mcp_preserves_existing(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import hermes as hermes_mod
+    mcp_path = tmp_path / "config.yaml"
+    mcp_path.write_text(yaml.safe_dump({
+        "mcp_servers": {"other-server": {"command": "other"}},
+        "general": {"theme": "dark"},
+    }), encoding="utf-8")
+    monkeypatch.setattr(hermes_mod, "_MCP_CONFIG", mcp_path)
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    HermesAdapter().install_mcp(python_path="/usr/bin/python3")
+
+    data = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))
+    assert "truememory" in data["mcp_servers"]
+    assert "other-server" in data["mcp_servers"]
+    assert data["general"]["theme"] == "dark"
+
+
+# -- Plugin hooks --
+
+def test_install_hooks_creates_cli_config(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import hermes as hermes_mod
+    cli_config = tmp_path / "cli-config.yaml"
+    monkeypatch.setattr(hermes_mod, "_CLI_CONFIG", cli_config)
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    HermesAdapter().install_hooks(python_path="/usr/bin/python3")
+
+    data = yaml.safe_load(cli_config.read_text(encoding="utf-8"))
+    plugins = data["plugins"]
+    assert len(plugins) == 2
+
+    names = {p["name"] for p in plugins}
+    assert "truememory-session-start" in names
+    assert "truememory-session-end" in names
+
+    events = {p["event"] for p in plugins}
+    assert "on_session_start" in events
+    assert "on_session_end" in events
+
+
+def test_install_hooks_preserves_existing(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import hermes as hermes_mod
+    cli_config = tmp_path / "cli-config.yaml"
+    cli_config.write_text(yaml.safe_dump({
+        "plugins": [{"name": "my-plugin", "event": "custom", "command": "my-cmd"}],
+    }), encoding="utf-8")
+    monkeypatch.setattr(hermes_mod, "_CLI_CONFIG", cli_config)
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    HermesAdapter().install_hooks(python_path="/usr/bin/python3")
+
+    data = yaml.safe_load(cli_config.read_text(encoding="utf-8"))
+    names = {p["name"] for p in data["plugins"]}
+    assert "my-plugin" in names
+    assert "truememory-session-start" in names
+
+
+def test_install_hooks_idempotent(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import hermes as hermes_mod
+    cli_config = tmp_path / "cli-config.yaml"
+    monkeypatch.setattr(hermes_mod, "_CLI_CONFIG", cli_config)
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    adapter = HermesAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    first = cli_config.read_text(encoding="utf-8")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    second = cli_config.read_text(encoding="utf-8")
+    assert first == second
+
+
+# -- Uninstall --
+
+def test_uninstall_removes_entries(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import hermes as hermes_mod
+    mcp_path = tmp_path / "config.yaml"
+    cli_config = tmp_path / "cli-config.yaml"
+    monkeypatch.setattr(hermes_mod, "_MCP_CONFIG", mcp_path)
+    monkeypatch.setattr(hermes_mod, "_CLI_CONFIG", cli_config)
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    adapter = HermesAdapter()
+
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    assert adapter.is_configured()
+
+    adapter.uninstall()
+    mcp_data = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))
+    assert "truememory" not in mcp_data.get("mcp_servers", {})
+
+    cli_data = yaml.safe_load(cli_config.read_text(encoding="utf-8"))
+    tm_plugins = [
+        p for p in cli_data.get("plugins", [])
+        if "truememory" in p.get("name", "").lower()
+    ]
+    assert len(tm_plugins) == 0
+
+
+# -- is_configured --
+
+def test_is_configured_false_clean(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import hermes as hermes_mod
+    monkeypatch.setattr(hermes_mod, "_MCP_CONFIG", tmp_path / "config.yaml")
+    monkeypatch.setattr(hermes_mod, "_CLI_CONFIG", tmp_path / "cli-config.yaml")
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    assert not HermesAdapter().is_configured()
+
+
+# -- Build command --
+
+def test_build_command_with_args():
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    cmd = HermesAdapter._build_command(
+        "/usr/bin/python3",
+        Path("/path/to/session_start.py"),
+        user_id="bob",
+        db_path="/data/mem.db",
+    )
+    assert "/usr/bin/python3" in cmd
+    assert "session_start.py" in cmd
+    assert "--user" in cmd
+    assert "bob" in cmd

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -5,10 +5,8 @@ and config merge safety without network calls.
 """
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
-import pytest
 import yaml
 
 

--- a/truememory/hooks/adapters/hermes.py
+++ b/truememory/hooks/adapters/hermes.py
@@ -1,0 +1,230 @@
+"""Hermes Agent adapter — YAML config + plugin/gateway hooks.
+
+Hermes Agent uses:
+- ~/.hermes/config.yaml for MCP server registration (mcp_servers: key)
+- ~/.hermes/cli-config.yaml for plugin hooks (plugins: key, CLI mode)
+- ~/.hermes/hooks/<name>/ for gateway hooks (Telegram/Discord/etc.)
+- Same JSON stdin/stdout hook protocol as Claude Code for plugin hooks
+"""
+from __future__ import annotations
+
+import logging
+import shlex
+import shutil
+import sys
+from pathlib import Path
+
+from truememory.hooks.adapters.base import CLIAdapter
+
+log = logging.getLogger(__name__)
+
+_HERMES_DIR = Path.home() / ".hermes"
+_MCP_CONFIG = _HERMES_DIR / "config.yaml"
+_CLI_CONFIG = _HERMES_DIR / "cli-config.yaml"
+_GATEWAY_HOOKS_DIR = _HERMES_DIR / "hooks"
+
+_PLUGIN_HOOKS = {
+    "on_session_start": {
+        "name": "truememory-session-start",
+        "script": "session_start.py",
+    },
+    "on_session_end": {
+        "name": "truememory-session-end",
+        "script": "stop.py",
+    },
+}
+
+_TRUEMEMORY_MARKER = "truememory"
+
+
+def _yaml_safe_load(text: str) -> dict:
+    try:
+        import yaml
+    except ImportError:
+        return {}
+    data = yaml.safe_load(text)
+    return data if isinstance(data, dict) else {}
+
+
+def _yaml_safe_dump(data: dict) -> str:
+    try:
+        import yaml
+    except ImportError:
+        raise ImportError("PyYAML is required for Hermes integration")
+    return yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+
+
+class HermesAdapter(CLIAdapter):
+    """Adapter for Hermes Agent (Nous Research)."""
+
+    @property
+    def name(self) -> str:
+        return "Hermes Agent"
+
+    @property
+    def cli_id(self) -> str:
+        return "hermes"
+
+    @property
+    def config_path(self) -> Path:
+        return _MCP_CONFIG
+
+    def detect(self) -> bool:
+        return _HERMES_DIR.is_dir() or shutil.which("hermes") is not None
+
+    def is_configured(self) -> bool:
+        return self._has_mcp_entry() or self._has_plugin_entries()
+
+    def install_mcp(self, python_path: str | None = None) -> None:
+        py = python_path or sys.executable
+        _MCP_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+
+        existing: dict = {}
+        if _MCP_CONFIG.exists():
+            try:
+                existing = _yaml_safe_load(_MCP_CONFIG.read_text(encoding="utf-8"))
+            except OSError:
+                existing = {}
+
+        servers = existing.setdefault("mcp_servers", {})
+        if not isinstance(servers, dict):
+            servers = {}
+            existing["mcp_servers"] = servers
+
+        servers["truememory"] = {
+            "command": py,
+            "args": ["-m", "truememory.mcp_server"],
+        }
+
+        _MCP_CONFIG.write_text(_yaml_safe_dump(existing), encoding="utf-8")
+
+    def install_hooks(
+        self,
+        python_path: str | None = None,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> None:
+        py = python_path or sys.executable
+        hooks_dir = Path(__file__).parent.parent.parent / "ingest" / "hooks"
+
+        _CLI_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+
+        existing: dict = {}
+        if _CLI_CONFIG.exists():
+            try:
+                existing = _yaml_safe_load(_CLI_CONFIG.read_text(encoding="utf-8"))
+            except OSError:
+                existing = {}
+
+        plugins = existing.setdefault("plugins", [])
+        if not isinstance(plugins, list):
+            plugins = []
+            existing["plugins"] = plugins
+
+        existing_names = {
+            p.get("name", "") for p in plugins if isinstance(p, dict)
+        }
+
+        for event, info in _PLUGIN_HOOKS.items():
+            if info["name"] in existing_names:
+                continue
+
+            script_path = hooks_dir / info["script"]
+            cmd = self._build_command(py, script_path, user_id, db_path)
+
+            plugins.append({
+                "name": info["name"],
+                "event": event,
+                "command": cmd,
+            })
+
+        _CLI_CONFIG.write_text(_yaml_safe_dump(existing), encoding="utf-8")
+
+    def uninstall(self) -> None:
+        self._remove_mcp_entry()
+        self._remove_plugin_entries()
+
+    def verify(self) -> bool:
+        return self._has_mcp_entry() and self._has_plugin_entries()
+
+    def get_system_prompt_path(self) -> Path | None:
+        return None
+
+    def get_system_prompt_content(self) -> str:
+        return ""
+
+    # -- Private helpers --
+
+    @staticmethod
+    def _build_command(
+        python_path: str,
+        script_path: Path,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> str:
+        parts: list[str] = [python_path, str(script_path)]
+        if user_id:
+            parts.extend(["--user", user_id])
+        if db_path:
+            parts.extend(["--db", db_path])
+        if sys.platform == "win32":
+            import subprocess as _sp
+            return _sp.list2cmdline(parts)
+        return " ".join(shlex.quote(p) for p in parts)
+
+    def _has_mcp_entry(self) -> bool:
+        if not _MCP_CONFIG.exists():
+            return False
+        try:
+            data = _yaml_safe_load(_MCP_CONFIG.read_text(encoding="utf-8"))
+            return "truememory" in data.get("mcp_servers", {})
+        except OSError:
+            return False
+
+    def _has_plugin_entries(self) -> bool:
+        if not _CLI_CONFIG.exists():
+            return False
+        try:
+            data = _yaml_safe_load(_CLI_CONFIG.read_text(encoding="utf-8"))
+            plugins = data.get("plugins", [])
+            if not isinstance(plugins, list):
+                return False
+            return any(
+                isinstance(p, dict)
+                and _TRUEMEMORY_MARKER in p.get("name", "").lower()
+                for p in plugins
+            )
+        except OSError:
+            return False
+
+    def _remove_mcp_entry(self) -> None:
+        if not _MCP_CONFIG.exists():
+            return
+        try:
+            data = _yaml_safe_load(_MCP_CONFIG.read_text(encoding="utf-8"))
+            servers = data.get("mcp_servers", {})
+            if isinstance(servers, dict) and "truememory" in servers:
+                del servers["truememory"]
+                _MCP_CONFIG.write_text(_yaml_safe_dump(data), encoding="utf-8")
+        except OSError:
+            pass
+
+    def _remove_plugin_entries(self) -> None:
+        if not _CLI_CONFIG.exists():
+            return
+        try:
+            data = _yaml_safe_load(_CLI_CONFIG.read_text(encoding="utf-8"))
+            plugins = data.get("plugins", [])
+            if not isinstance(plugins, list):
+                return
+            cleaned = [
+                p for p in plugins
+                if not (
+                    isinstance(p, dict)
+                    and _TRUEMEMORY_MARKER in p.get("name", "").lower()
+                )
+            ]
+            data["plugins"] = cleaned
+            _CLI_CONFIG.write_text(_yaml_safe_dump(data), encoding="utf-8")
+        except OSError:
+            pass

--- a/truememory/hooks/registry.py
+++ b/truememory/hooks/registry.py
@@ -20,7 +20,8 @@ STATE_FILE = Path.home() / ".truememory" / "integrations.json"
 def _get_all_adapters() -> list[CLIAdapter]:
     """Return instances of all known CLI adapters."""
     from truememory.hooks.adapters.claude import ClaudeAdapter
-    return [ClaudeAdapter()]
+    from truememory.hooks.adapters.hermes import HermesAdapter
+    return [ClaudeAdapter(), HermesAdapter()]
 
 
 def detect_installed() -> list[CLIAdapter]:


### PR DESCRIPTION
Closes #185

## Summary
- **HermesAdapter** (`truememory/hooks/adapters/hermes.py`): Full CLIAdapter implementation for Hermes Agent with detection (`~/.hermes/` directory or `hermes` binary), MCP registration (YAML at `~/.hermes/config.yaml`), and plugin hook registration (YAML at `~/.hermes/cli-config.yaml`)
- **Two plugin hooks**: `on_session_start` → `session_start.py`, `on_session_end` → `stop.py` — same scripts as Claude Code, different config format (YAML plugins list)
- **Additive YAML merges**: Both MCP config and CLI config are read-merge-write via `yaml.safe_load`/`yaml.safe_dump` — existing user entries preserved. Hook install is idempotent
- **Registry updated**: HermesAdapter registered in `_get_all_adapters()`

**Not included (future work per issue):** Gateway hooks (`HOOK.yaml` + `handler.py` for Telegram/Discord) — the issue marks these as optional. Per-agent scoping for Hermes sub-agents is also future work.

## Test plan
- [x] 14 new tests pass (`tests/test_hermes_adapter.py`)
- [x] All 17 existing hook framework tests still pass
- [x] Interface compliance: all 11 CLIAdapter abstract methods implemented
- [x] YAML merge safety: existing entries and non-hook config preserved
- [x] Idempotent install: running twice produces identical config
- [x] Uninstall removes only TrueMemory entries
- [x] Backward compatibility: existing hooks still importable, `truememory-ingest --help` works