### PR TITLE
feat: OpenClaw integration — JSON config + JS plugin system

### DIFF
--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -1,0 +1,195 @@
+"""Tests for the OpenClaw adapter (#184).
+
+Validates JSON config merge for MCP, JS plugin installation,
+detection, and config safety without network calls.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# -- Import tests --
+
+def test_import_openclaw_adapter():
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter  # noqa: F401
+
+
+def test_openclaw_in_registry():
+    from truememory.hooks.registry import get_adapter
+    adapter = get_adapter("openclaw")
+    assert adapter is not None
+    assert adapter.cli_id == "openclaw"
+
+
+# -- Instantiation --
+
+def test_openclaw_adapter_properties():
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    adapter = OpenClawAdapter()
+    assert adapter.name == "OpenClaw"
+    assert adapter.cli_id == "openclaw"
+    assert adapter.config_path.name == "openclaw.json"
+
+
+def test_openclaw_implements_all_abstract_methods():
+    from truememory.hooks.adapters.base import CLIAdapter
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    import inspect
+    abstract_methods = {
+        name for name, _ in inspect.getmembers(CLIAdapter)
+        if getattr(getattr(CLIAdapter, name, None), "__isabstractmethod__", False)
+    }
+    adapter = OpenClawAdapter()
+    for method_name in abstract_methods:
+        assert hasattr(adapter, method_name), f"Missing: {method_name}"
+
+
+# -- Detection --
+
+def test_detect_false_no_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import openclaw as oc_mod
+    monkeypatch.setattr(oc_mod, "_OPENCLAW_DIR", tmp_path / "nonexistent")
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    assert not OpenClawAdapter().detect()
+
+
+def test_detect_true_with_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import openclaw as oc_mod
+    oc_dir = tmp_path / ".openclaw"
+    oc_dir.mkdir()
+    monkeypatch.setattr(oc_mod, "_OPENCLAW_DIR", oc_dir)
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    assert OpenClawAdapter().detect()
+
+
+# -- MCP config --
+
+def test_install_mcp_creates_config(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import openclaw as oc_mod
+    config_path = tmp_path / "openclaw.json"
+    monkeypatch.setattr(oc_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    OpenClawAdapter().install_mcp(python_path="/usr/bin/python3")
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "truememory" in data["mcp"]["servers"]
+    assert data["mcp"]["servers"]["truememory"]["command"] == "/usr/bin/python3"
+
+
+def test_install_mcp_preserves_existing(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import openclaw as oc_mod
+    config_path = tmp_path / "openclaw.json"
+    config_path.write_text(json.dumps({
+        "mcp": {"servers": {"other": {"command": "x"}}},
+        "settings": {"debug": True},
+    }), encoding="utf-8")
+    monkeypatch.setattr(oc_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    OpenClawAdapter().install_mcp(python_path="/usr/bin/python3")
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "truememory" in data["mcp"]["servers"]
+    assert "other" in data["mcp"]["servers"]
+    assert data["settings"]["debug"] is True
+
+
+def test_install_mcp_handles_json5_comments(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import openclaw as oc_mod
+    config_path = tmp_path / "openclaw.json"
+    config_path.write_text(
+        '// OpenClaw config\n{\n  "mcp": {"servers": {}}\n}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(oc_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    OpenClawAdapter().install_mcp(python_path="/usr/bin/python3")
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "truememory" in data["mcp"]["servers"]
+
+
+# -- Plugin install --
+
+def test_install_hooks_creates_plugin(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import openclaw as oc_mod
+    plugins_dir = tmp_path / "plugins"
+    monkeypatch.setattr(oc_mod, "_PLUGINS_DIR", plugins_dir)
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    OpenClawAdapter().install_hooks(python_path="/usr/bin/python3")
+
+    plugin_dir = plugins_dir / "truememory"
+    assert plugin_dir.is_dir()
+    assert (plugin_dir / "plugin.json").exists()
+    assert (plugin_dir / "index.js").exists()
+
+    manifest = json.loads((plugin_dir / "plugin.json").read_text(encoding="utf-8"))
+    assert manifest["name"] == "truememory"
+    assert "before_agent_run" in manifest["events"]
+    assert "agent_end" in manifest["events"]
+
+
+def test_install_hooks_idempotent(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import openclaw as oc_mod
+    plugins_dir = tmp_path / "plugins"
+    monkeypatch.setattr(oc_mod, "_PLUGINS_DIR", plugins_dir)
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    adapter = OpenClawAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    first_js = (plugins_dir / "truememory" / "index.js").read_text(encoding="utf-8")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    second_js = (plugins_dir / "truememory" / "index.js").read_text(encoding="utf-8")
+    assert first_js == second_js
+
+
+# -- Uninstall --
+
+def test_uninstall_removes_entries(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import openclaw as oc_mod
+    config_path = tmp_path / "openclaw.json"
+    plugins_dir = tmp_path / "plugins"
+    monkeypatch.setattr(oc_mod, "_CONFIG_PATH", config_path)
+    monkeypatch.setattr(oc_mod, "_PLUGINS_DIR", plugins_dir)
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    adapter = OpenClawAdapter()
+
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    assert adapter.is_configured()
+
+    adapter.uninstall()
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "truememory" not in data.get("mcp", {}).get("servers", {})
+    assert not (plugins_dir / "truememory").exists()
+
+
+# -- is_configured --
+
+def test_is_configured_false_clean(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import openclaw as oc_mod
+    monkeypatch.setattr(oc_mod, "_CONFIG_PATH", tmp_path / "openclaw.json")
+    monkeypatch.setattr(oc_mod, "_PLUGINS_DIR", tmp_path / "plugins")
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    assert not OpenClawAdapter().is_configured()
+
+
+# -- JSON5 comment stripping --
+
+def test_strip_json5_comments():
+    from truememory.hooks.adapters.openclaw import _strip_json5_comments
+    text = '// comment\n{"key": "val", // inline\n}'
+    cleaned = _strip_json5_comments(text)
+    data = json.loads(cleaned)
+    assert data["key"] == "val"
+
+
+def test_strip_json5_trailing_commas():
+    from truememory.hooks.adapters.openclaw import _strip_json5_comments
+    text = '{"a": 1, "b": 2,}'
+    cleaned = _strip_json5_comments(text)
+    data = json.loads(cleaned)
+    assert data["a"] == 1
+    assert data["b"] == 2

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -6,9 +6,6 @@ detection, and config safety without network calls.
 from __future__ import annotations
 
 import json
-from pathlib import Path
-
-import pytest
 
 
 # -- Import tests --

--- a/truememory/hooks/adapters/openclaw.py
+++ b/truememory/hooks/adapters/openclaw.py
@@ -1,0 +1,179 @@
+"""OpenClaw adapter — JSON config + JS plugin system.
+
+OpenClaw uses:
+- ~/.openclaw/openclaw.json (JSON5-compatible) for MCP server registration
+  under the nested mcp.servers key
+- ~/.openclaw/plugins/<name>/ for plugins (plugin.json + index.js)
+- Plugin hooks: before_agent_run, agent_end (JS API, not shell commands)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import sys
+from pathlib import Path
+
+from truememory.hooks.adapters.base import CLIAdapter
+
+log = logging.getLogger(__name__)
+
+_OPENCLAW_DIR = Path.home() / ".openclaw"
+_CONFIG_PATH = _OPENCLAW_DIR / "openclaw.json"
+_PLUGINS_DIR = _OPENCLAW_DIR / "plugins"
+_PLUGIN_NAME = "truememory"
+
+_TEMPLATE_DIR = Path(__file__).parent.parent / "templates" / "openclaw"
+
+
+def _read_json_config(path: Path) -> dict:
+    """Read a JSON config file, tolerating minor JSON5 features."""
+    if not path.exists():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+        return json.loads(text)
+    except json.JSONDecodeError:
+        stripped = _strip_json5_comments(text)
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            log.warning("Cannot parse %s as JSON — skipping", path)
+            return {}
+    except OSError:
+        return {}
+
+
+def _strip_json5_comments(text: str) -> str:
+    """Best-effort removal of single-line // comments and trailing commas."""
+    import re
+    text = re.sub(r'(?m)^\s*//.*$', '', text)
+    text = re.sub(r'//[^\n]*', '', text)
+    text = re.sub(r',(\s*[}\]])', r'\1', text)
+    return text
+
+
+class OpenClawAdapter(CLIAdapter):
+    """Adapter for OpenClaw agent gateway."""
+
+    @property
+    def name(self) -> str:
+        return "OpenClaw"
+
+    @property
+    def cli_id(self) -> str:
+        return "openclaw"
+
+    @property
+    def config_path(self) -> Path:
+        return _CONFIG_PATH
+
+    def detect(self) -> bool:
+        return _OPENCLAW_DIR.is_dir() or shutil.which("openclaw") is not None
+
+    def is_configured(self) -> bool:
+        return self._has_mcp_entry() or self._has_plugin()
+
+    def install_mcp(self, python_path: str | None = None) -> None:
+        py = python_path or sys.executable
+        _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+        existing = _read_json_config(_CONFIG_PATH)
+
+        mcp = existing.setdefault("mcp", {})
+        if not isinstance(mcp, dict):
+            mcp = {}
+            existing["mcp"] = mcp
+
+        servers = mcp.setdefault("servers", {})
+        if not isinstance(servers, dict):
+            servers = {}
+            mcp["servers"] = servers
+
+        servers[_PLUGIN_NAME] = {
+            "command": py,
+            "args": ["-m", "truememory.mcp_server"],
+        }
+
+        _CONFIG_PATH.write_text(
+            json.dumps(existing, indent=2),
+            encoding="utf-8",
+        )
+
+    def install_hooks(
+        self,
+        python_path: str | None = None,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> None:
+        plugin_dir = _PLUGINS_DIR / _PLUGIN_NAME
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+
+        for template_file in ("plugin.json", "index.js"):
+            src = _TEMPLATE_DIR / template_file
+            dst = plugin_dir / template_file
+            if src.exists():
+                content = src.read_text(encoding="utf-8")
+                if python_path:
+                    content = content.replace(
+                        'process.env.TRUEMEMORY_PYTHON || "python3"',
+                        f'process.env.TRUEMEMORY_PYTHON || "{python_path}"',
+                    )
+                dst.write_text(content, encoding="utf-8")
+
+    def uninstall(self) -> None:
+        self._remove_mcp_entry()
+        self._remove_plugin()
+
+    def verify(self) -> bool:
+        return self._has_mcp_entry() and self._has_plugin()
+
+    def get_system_prompt_path(self) -> Path | None:
+        return None
+
+    def get_system_prompt_content(self) -> str:
+        return ""
+
+    # -- Private helpers --
+
+    def _has_mcp_entry(self) -> bool:
+        data = _read_json_config(_CONFIG_PATH)
+        mcp = data.get("mcp", {})
+        if not isinstance(mcp, dict):
+            return False
+        servers = mcp.get("servers", {})
+        if not isinstance(servers, dict):
+            return False
+        return _PLUGIN_NAME in servers
+
+    def _has_plugin(self) -> bool:
+        plugin_dir = _PLUGINS_DIR / _PLUGIN_NAME
+        return (
+            plugin_dir.is_dir()
+            and (plugin_dir / "plugin.json").exists()
+            and (plugin_dir / "index.js").exists()
+        )
+
+    def _remove_mcp_entry(self) -> None:
+        if not _CONFIG_PATH.exists():
+            return
+        try:
+            data = _read_json_config(_CONFIG_PATH)
+            mcp = data.get("mcp", {})
+            if isinstance(mcp, dict):
+                servers = mcp.get("servers", {})
+                if isinstance(servers, dict) and _PLUGIN_NAME in servers:
+                    del servers[_PLUGIN_NAME]
+                    _CONFIG_PATH.write_text(
+                        json.dumps(data, indent=2), encoding="utf-8",
+                    )
+        except OSError:
+            pass
+
+    def _remove_plugin(self) -> None:
+        plugin_dir = _PLUGINS_DIR / _PLUGIN_NAME
+        if plugin_dir.is_dir():
+            try:
+                shutil.rmtree(plugin_dir)
+            except OSError as e:
+                log.warning("Failed to remove plugin dir %s: %s", plugin_dir, e)

--- a/truememory/hooks/registry.py
+++ b/truememory/hooks/registry.py
@@ -20,7 +20,8 @@ STATE_FILE = Path.home() / ".truememory" / "integrations.json"
 def _get_all_adapters() -> list[CLIAdapter]:
     """Return instances of all known CLI adapters."""
     from truememory.hooks.adapters.claude import ClaudeAdapter
-    return [ClaudeAdapter()]
+    from truememory.hooks.adapters.openclaw import OpenClawAdapter
+    return [ClaudeAdapter(), OpenClawAdapter()]
 
 
 def detect_installed() -> list[CLIAdapter]:

--- a/truememory/hooks/templates/openclaw/index.js
+++ b/truememory/hooks/templates/openclaw/index.js
@@ -1,0 +1,75 @@
+/**
+ * TrueMemory plugin for OpenClaw.
+ *
+ * Hooks into the agent lifecycle to recall memories before each run
+ * and trigger extraction after each run. Uses the TrueMemory MCP server
+ * for memory operations.
+ */
+const { execSync, spawn } = require("child_process");
+const path = require("path");
+
+const PYTHON_PATH = process.env.TRUEMEMORY_PYTHON || "python3";
+const HOOKS_DIR = process.env.TRUEMEMORY_HOOKS_DIR || "";
+
+function getHooksDir() {
+  if (HOOKS_DIR) return HOOKS_DIR;
+  try {
+    const out = execSync(
+      `${PYTHON_PATH} -c "from pathlib import Path; import truememory; print(Path(truememory.__file__).parent / 'ingest' / 'hooks')"`,
+      { encoding: "utf-8", timeout: 10000 }
+    ).trim();
+    return out;
+  } catch {
+    return "";
+  }
+}
+
+module.exports = {
+  register(api) {
+    const hooksDir = getHooksDir();
+    if (!hooksDir) {
+      console.error("[truememory] Could not locate hook scripts");
+      return;
+    }
+
+    api.on("before_agent_run", async (ctx) => {
+      try {
+        const input = JSON.stringify({
+          session_id: ctx.sessionId || "openclaw",
+          cwd: process.cwd(),
+          transcript_path: ctx.transcriptPath || "",
+        });
+        const result = execSync(
+          `echo '${input.replace(/'/g, "\\'")}' | ${PYTHON_PATH} ${path.join(hooksDir, "session_start.py")}`,
+          { encoding: "utf-8", timeout: 10000 }
+        ).trim();
+        if (result) {
+          const parsed = JSON.parse(result);
+          if (parsed.additionalContext) {
+            ctx.additionalContext = (ctx.additionalContext || "") + "\n" + parsed.additionalContext;
+          }
+        }
+      } catch (err) {
+        // Never block the agent run
+      }
+    });
+
+    api.on("agent_end", async (ctx) => {
+      try {
+        const input = JSON.stringify({
+          session_id: ctx.sessionId || "openclaw",
+          transcript_path: ctx.transcriptPath || "",
+        });
+        const child = spawn(PYTHON_PATH, [path.join(hooksDir, "stop.py")], {
+          stdio: ["pipe", "ignore", "ignore"],
+          detached: true,
+        });
+        child.stdin.write(input);
+        child.stdin.end();
+        child.unref();
+      } catch (err) {
+        // Never block agent shutdown
+      }
+    });
+  },
+};

--- a/truememory/hooks/templates/openclaw/plugin.json
+++ b/truememory/hooks/templates/openclaw/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "truememory",
+  "version": "1.0.0",
+  "description": "TrueMemory persistent memory integration for OpenClaw",
+  "main": "index.js",
+  "events": ["before_agent_run", "agent_end"]
+}


### PR DESCRIPTION
Closes #184

## Summary
- **OpenClawAdapter** (`truememory/hooks/adapters/openclaw.py`): Full CLIAdapter implementation with detection, MCP registration via nested `mcp.servers` key in `~/.openclaw/openclaw.json`, and JS plugin installation
- **JS plugin** (`truememory/hooks/templates/openclaw/`): `plugin.json` manifest + `index.js` with `before_agent_run` (memory recall via session_start.py) and `agent_end` (background extraction via stop.py) event handlers
- **JSON5 tolerance**: Config reader strips `//` comments and trailing commas before parsing, so existing JSON5 configs aren't rejected
- **Additive merges**: MCP config is read-merge-write. Plugin install creates/overwrites only the truememory plugin directory
- **Registry updated**: OpenClawAdapter registered in `_get_all_adapters()`

## Test plan
- [x] 15 new tests pass (`tests/test_openclaw_adapter.py`)
- [x] All 17 existing hook framework tests still pass
- [x] Interface compliance: all 11 CLIAdapter abstract methods implemented
- [x] JSON config merge safety: existing MCP entries and other config preserved
- [x] JSON5 comment stripping works for `//` comments and trailing commas
- [x] Plugin idempotent: running install twice produces identical files
- [x] Uninstall removes MCP entry and plugin directory
- [x] Backward compatibility confirmed