### PR TITLE
feat: conversational onboarding with auto-detect CLI integration

### DIFF
--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -5,11 +5,7 @@ integration state tracking.
 """
 from __future__ import annotations
 
-import json
-from pathlib import Path
 from unittest.mock import patch
-
-import pytest
 
 
 # -- Import tests --

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,111 @@
+"""Tests for conversational onboarding (#188).
+
+Validates CLI detection display, --cli flag parsing, and
+integration state tracking.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# -- Import tests --
+
+def test_import_setup_cli_integrations():
+    from truememory.ingest.cli import _setup_cli_integrations  # noqa: F401
+
+
+def test_import_hooks_cli():
+    from truememory.hooks.cli import install_cli, uninstall_cli, verify_cli  # noqa: F401
+
+
+# -- CLI flag parsing --
+
+def test_setup_accepts_cli_flag():
+    import subprocess
+    import sys
+    result = subprocess.run(
+        [sys.executable, "-m", "truememory.ingest.cli", "setup", "--help"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert "--cli" in result.stdout
+
+
+# -- Registry integration --
+
+def test_detect_installed_returns_adapters():
+    from truememory.hooks.registry import detect_installed
+    installed = detect_installed()
+    assert isinstance(installed, list)
+
+
+def test_get_adapter_known():
+    from truememory.hooks.registry import get_adapter
+    adapter = get_adapter("claude")
+    assert adapter is not None
+    assert adapter.cli_id == "claude"
+
+
+def test_get_adapter_unknown_returns_none():
+    from truememory.hooks.registry import get_adapter
+    assert get_adapter("nonexistent") is None
+
+
+# -- State tracking --
+
+def test_mark_configured_and_load(tmp_path, monkeypatch):
+    from truememory.hooks import registry
+    state_file = tmp_path / "integrations.json"
+    monkeypatch.setattr(registry, "STATE_FILE", state_file)
+
+    registry.mark_configured("kimi")
+    state = registry.load_state()
+    assert "kimi" in state["configured"]
+    assert "kimi" in state["configured_at"]
+
+
+# -- _setup_cli_integrations with --cli flag --
+
+def test_setup_cli_integrations_with_cli_flag(capsys):
+    import argparse
+
+    args = argparse.Namespace(cli="claude", non_interactive=True)
+    config = {"user_id": ""}
+
+    from truememory.ingest.cli import _setup_cli_integrations
+
+    with patch("truememory.hooks.cli.install_cli", return_value=True):
+        _setup_cli_integrations(args, config)
+
+    captured = capsys.readouterr()
+    assert "Claude Code" in captured.out
+
+
+def test_setup_cli_integrations_unknown_cli(capsys):
+    import argparse
+    args = argparse.Namespace(cli="nonexistent", non_interactive=True)
+    config = {}
+
+    from truememory.ingest.cli import _setup_cli_integrations
+    _setup_cli_integrations(args, config)
+
+    captured = capsys.readouterr()
+    assert "Unknown CLI" in captured.out
+
+
+def test_setup_cli_integrations_multiple(capsys):
+    import argparse
+    args = argparse.Namespace(cli="claude,nonexistent", non_interactive=True)
+    config = {"user_id": ""}
+
+    from truememory.ingest.cli import _setup_cli_integrations
+
+    with patch("truememory.hooks.cli.install_cli", return_value=True):
+        _setup_cli_integrations(args, config)
+
+    captured = capsys.readouterr()
+    assert "Claude Code" in captured.out
+    assert "Unknown CLI" in captured.out

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -82,6 +82,7 @@ def main():
     # --- setup command (first-time onboarding) ---
     p_setup = sub.add_parser("setup", help="Interactive first-time setup wizard")
     p_setup.add_argument("--non-interactive", action="store_true", help="Skip prompts, use defaults + env vars")
+    p_setup.add_argument("--cli", default="", help="Comma-separated CLI IDs to configure (e.g. claude,kimi,hermes)")
 
     # --- upgrade-tier command ---
     p_upgrade = sub.add_parser("upgrade-tier", help="Switch embedding tier (edge/base/pro)")
@@ -323,6 +324,73 @@ def _save_truememory_config(config: dict) -> None:
         )
 
 
+def _setup_cli_integrations(args, config):
+    """Step 3 of setup: detect installed CLIs and configure TrueMemory."""
+    from truememory.hooks.registry import detect_installed, get_adapter
+    from truememory.hooks.cli import install_cli
+
+    cli_arg = getattr(args, "cli", "")
+
+    if cli_arg:
+        requested_ids = [c.strip() for c in cli_arg.split(",") if c.strip()]
+        for cli_id in requested_ids:
+            adapter = get_adapter(cli_id)
+            if adapter is None:
+                print(f"  \033[33m⚠ Unknown CLI: {cli_id}\033[0m")
+                continue
+            print(f"  Setting up {adapter.name}...")
+            if install_cli(cli_id, user_id=config.get("user_id", "")):
+                print(f"  \033[32m✓ {adapter.name} — configured\033[0m")
+            else:
+                print(f"  \033[31m✗ {adapter.name} — failed\033[0m")
+        return
+
+    installed = detect_installed()
+
+    if not installed:
+        print("  No supported CLIs detected. Install hooks manually later with:")
+        print("    truememory-ingest setup --cli <name>")
+        return
+
+    print("  \033[1mCLI Integration\033[0m")
+    print("  ──────────────")
+    for i, adapter in enumerate(installed, 1):
+        status = "\033[32m✓\033[0m" if adapter.is_configured() else " "
+        print(f"  [{i}] {status} {adapter.name}")
+    print(f"  [a] All detected ({len(installed)})")
+    print()
+
+    if args.non_interactive:
+        selected = installed
+    else:
+        choice = input(f"  Which CLIs to set up? [1-{len(installed)}/a] (default: a): ").strip().lower()
+        if not choice or choice == "a":
+            selected = installed
+        else:
+            selected = []
+            for part in choice.replace(",", " ").split():
+                try:
+                    idx = int(part) - 1
+                    if 0 <= idx < len(installed):
+                        selected.append(installed[idx])
+                except ValueError:
+                    pass
+            if not selected:
+                selected = installed
+
+    print()
+    for adapter in selected:
+        print(f"  Setting up {adapter.name}...")
+        if install_cli(adapter.cli_id, user_id=config.get("user_id", "")):
+            print(f"  \033[32m✓ {adapter.name} — MCP server configured, hooks installed\033[0m")
+        else:
+            print(f"  \033[31m✗ {adapter.name} — setup failed\033[0m")
+
+    if len(selected) > 1:
+        names = ", ".join(a.name for a in selected)
+        print(f"\n  TrueMemory is ready. Your memories sync across {names}.")
+
+
 def _run_setup(args):
     """Interactive first-time setup wizard for TrueMemory."""
     print(_SAURON_BANNER)
@@ -455,19 +523,9 @@ def _run_setup(args):
     print()
     print(f"  \033[32m✓ Config saved to {_TRUEMEMORY_CONFIG_PATH}\033[0m")
 
-    # ── Step 3: Install hooks ─────────────────────────────────────────
+    # ── Step 3: CLI integration ─────────────────────────────────────────
     print()
-    if not args.non_interactive:
-        do_hooks = input("  Install Claude Code hooks now? [Y/n]: ").strip().lower()
-    else:
-        do_hooks = "y"
-
-    if do_hooks != "n":
-        class _InstallArgs:
-            user = config.get("user_id", "")
-            db = None
-            dry_run = False
-        _run_install(_InstallArgs())
+    _setup_cli_integrations(args, config)
 
     # ���─ Done ──────────────────────────────────────────────────────────
     print()


### PR DESCRIPTION
Closes #188

## Summary
- **Multi-CLI setup wizard**: Replace Claude-specific Step 3 in `_run_setup()` with `_setup_cli_integrations()` that detects installed CLIs via the adapter registry and lets users interactively select which to configure
- **`--cli` flag**: `truememory-ingest setup --cli claude,kimi` for non-interactive per-CLI setup, compatible with CI/scripting
- **Detection display**: Shows installed CLIs with checkmarks for already-configured ones, numbered selection, and "all detected" option
- **State tracking**: Leverages `registry.mark_configured()` from #186 — stores configured CLIs in `~/.truememory/integrations.json`

## Test plan
- [x] 10 new tests pass (`tests/test_onboarding.py`)
- [x] All 17 existing hook framework tests still pass
- [x] `--cli` flag appears in `truememory-ingest setup --help`
- [x] Unknown CLI IDs produce warning, not crash
- [x] Multiple CLI IDs comma-separated work
- [x] Backward compatibility: `truememory-ingest --help` works, existing hooks importable