### PR TITLE
feat: Codex CLI integration — MCP config + lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - **93.0% on LoCoMo, 92.0% on LongMemEval, SOTA on BEAM-1M.** Beats every live-retrieval memory system across three major benchmarks. Independently reproducible.
 - **Runs locally on a single SQLite file.** Zero cloud, zero API keys for Edge and Base tiers. Your memories never leave your machine.
 - **Neuroscience-inspired architecture.** Six retrieval layers plus an encoding gate that filters noise from signal before anything gets stored.
-- **Works with Claude Code and Claude Desktop.** Four lifecycle hooks capture conversations automatically. No manual work needed.
+- **Works with Claude Code, Codex CLI, and Claude Desktop.** Lifecycle hooks capture conversations automatically. No manual work needed.
 
 ---
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,35 +4,36 @@ TrueMemory integrates with multiple AI CLI tools. Each CLI has different config 
 
 ## Feature Support
 
-| Feature | Claude Code | Kimi CLI | Hermes Agent | OpenClaw |
-|---------|:-----------:|:--------:|:------------:|:--------:|
-| MCP server | JSON | JSON | YAML | JSON |
-| Auto-recall at session start | Yes | Yes | Yes | Yes |
-| Auto-extract at session end | Yes | Yes | Yes | Yes |
-| Mid-session extraction (PreCompact) | Yes | Yes | No | No |
-| Message buffering (UserPromptSubmit) | Yes | No | No | No |
-| System prompt injection | Yes | No | No | No |
-| Hook protocol | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JS plugin API |
-| Config format | JSON | TOML + JSON | YAML | JSON5 + JS |
-| Non-interactive install | `--cli claude` | `--cli kimi` | `--cli hermes` | `--cli openclaw` |
+| Feature | Claude Code | Codex CLI | Kimi CLI | Hermes Agent | OpenClaw |
+|---------|:-----------:|:---------:|:--------:|:------------:|:--------:|
+| MCP server | JSON | TOML | JSON | YAML | JSON |
+| Auto-recall at session start | Yes | Yes | Yes | Yes | Yes |
+| Auto-extract at session end | Yes | Yes | Yes | Yes | Yes |
+| Mid-session extraction (PreCompact) | Yes | No | Yes | No | No |
+| Message buffering (UserPromptSubmit) | Yes | Yes | No | No | No |
+| System prompt injection | Yes | Yes | No | No | No |
+| Hook protocol | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JS plugin API |
+| Config format | JSON | TOML | TOML + JSON | YAML | JSON5 + JS |
+| Non-interactive install | `--cli claude` | `--cli codex` | `--cli kimi` | `--cli hermes` | `--cli openclaw` |
 
 ## Config Locations
 
 | CLI | MCP Config | Hook Config | Detection Path |
 |-----|-----------|------------|----------------|
 | Claude Code | `~/.claude/settings.json` | `~/.claude/settings.json` | `~/.claude/` |
+| Codex CLI | `~/.codex/config.toml` | `~/.codex/config.toml` | `~/.codex/` |
 | Kimi CLI | `~/.kimi/mcp.json` | `~/.kimi/config.toml` | `~/.kimi/` |
 | Hermes Agent | `~/.hermes/config.yaml` | `~/.hermes/cli-config.yaml` | `~/.hermes/` |
 | OpenClaw | `~/.openclaw/openclaw.json` | `~/.openclaw/plugins/truememory/` | `~/.openclaw/` |
 
 ## Hook Events
 
-| Event | Claude Code | Kimi CLI | Hermes Agent | OpenClaw |
-|-------|------------|----------|-------------|----------|
-| Session start | `SessionStart` | `SessionStart` | `on_session_start` | `before_agent_run` |
-| Session end | `Stop` | `Stop` | `on_session_end` | `agent_end` |
-| Pre-compact | `PreCompact` | `PreCompact` | — | — |
-| User message | `UserPromptSubmit` | — | — | — |
+| Event | Claude Code | Codex CLI | Kimi CLI | Hermes Agent | OpenClaw |
+|-------|------------|-----------|----------|-------------|----------|
+| Session start | `SessionStart` | `SessionStart` | `SessionStart` | `on_session_start` | `before_agent_run` |
+| Session end | `Stop` | `Stop` | `Stop` | `on_session_end` | `agent_end` |
+| Pre-compact | `PreCompact` | — | `PreCompact` | — | — |
+| User message | `UserPromptSubmit` | `UserPromptSubmit` | — | — | — |
 
 ## Shared Memory
 
@@ -40,6 +41,7 @@ All CLIs share the same TrueMemory database (`~/.truememory/memories.db`). Memor
 
 ## Known Limitations
 
+- **Codex CLI**: MCP and hooks share a single `config.toml`. TrueMemory uses additive merges to avoid overwriting other settings.
 - **Kimi CLI**: Hooks are in beta. Event availability may change.
 - **Hermes Agent**: Gateway hooks (Telegram/Discord/etc.) require separate `handler.py` setup.
 - **OpenClaw**: Uses a JS plugin system — requires Node.js at runtime for the plugin.

--- a/docs/setup-codex.md
+++ b/docs/setup-codex.md
@@ -1,0 +1,73 @@
+# Codex CLI Setup
+
+## Prerequisites
+
+- Codex CLI installed (`~/.codex/` exists)
+- TrueMemory installed: `uv tool install truememory`
+- Python 3.10+
+
+## Automatic Setup
+
+```bash
+truememory-ingest setup --cli codex
+```
+
+Or during the interactive setup wizard:
+
+```bash
+truememory-ingest setup
+# Select Codex CLI when prompted
+```
+
+## Manual Setup
+
+### 1. MCP Server + Lifecycle Hooks
+
+Both MCP and hooks live in `~/.codex/config.toml`. Add the following:
+
+```toml
+[mcp_servers.truememory]
+command = "/path/to/python"
+args = ["-m", "truememory.mcp_server"]
+
+[[hooks]]
+event = "SessionStart"
+command = "/path/to/python /path/to/truememory/ingest/hooks/session_start.py"
+timeout = 10000
+
+[[hooks]]
+event = "Stop"
+command = "/path/to/python /path/to/truememory/ingest/hooks/stop.py"
+timeout = 5000
+
+[[hooks]]
+event = "UserPromptSubmit"
+command = "/path/to/python /path/to/truememory/ingest/hooks/user_prompt_submit.py"
+timeout = 5000
+```
+
+Find your Python path: `python3 -c "import sys; print(sys.executable)"`
+
+Find hook paths: `python3 -c "from pathlib import Path; import truememory; print(Path(truememory.__file__).parent / 'ingest' / 'hooks')"`
+
+### 2. AGENTS.md (Optional)
+
+For auto-recall/auto-store instructions, run:
+
+```bash
+truememory-ingest setup --cli codex
+```
+
+This creates `~/.codex/AGENTS.md` with TrueMemory system prompt instructions.
+
+## Verification
+
+```bash
+truememory-ingest status
+```
+
+## Troubleshooting
+
+- **MCP not connecting**: Verify the Python path in `config.toml` points to the environment with TrueMemory installed.
+- **Existing config**: TrueMemory uses additive merges — your existing Codex config is preserved.
+- **Hooks not firing**: Check that the hook script paths are absolute and the Python executable is correct.

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -1,0 +1,300 @@
+"""Tests for the Codex CLI adapter (#182).
+
+Validates TOML-based MCP config, hook registration, detection,
+config merge safety, and TOML section removal without network calls.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+
+# -- Import tests --
+
+def test_import_codex_adapter():
+    from truememory.hooks.adapters.codex import CodexAdapter  # noqa: F401
+
+
+def test_codex_in_registry():
+    from truememory.hooks.registry import get_adapter
+    adapter = get_adapter("codex")
+    assert adapter is not None
+    assert adapter.cli_id == "codex"
+
+
+# -- Instantiation --
+
+def test_codex_adapter_properties():
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    assert adapter.name == "Codex CLI"
+    assert adapter.cli_id == "codex"
+    assert isinstance(adapter.config_path, Path)
+    assert adapter.config_path.name == "config.toml"
+
+
+def test_codex_implements_all_abstract_methods():
+    from truememory.hooks.adapters.base import CLIAdapter
+    from truememory.hooks.adapters.codex import CodexAdapter
+    abstract_methods = {
+        name for name, _ in inspect.getmembers(CLIAdapter)
+        if getattr(getattr(CLIAdapter, name, None), "__isabstractmethod__", False)
+    }
+    adapter = CodexAdapter()
+    for method_name in abstract_methods:
+        assert hasattr(adapter, method_name), f"Missing: {method_name}"
+
+
+# -- Detection --
+
+def test_detect_false_no_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    monkeypatch.setattr(codex_mod, "_CODEX_DIR", tmp_path / "nonexistent")
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    assert not adapter.detect()
+
+
+def test_detect_true_with_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    monkeypatch.setattr(codex_mod, "_CODEX_DIR", codex_dir)
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    assert adapter.detect()
+
+
+# -- MCP config (TOML-based, not JSON) --
+
+def test_install_mcp_creates_config(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setattr(codex_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+
+    text = config_path.read_text(encoding="utf-8")
+    assert "[mcp_servers.truememory]" in text
+    assert '"/usr/bin/python3"' in text
+    assert 'truememory.mcp_server' in text
+
+
+def test_install_mcp_preserves_existing(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        '[general]\ntheme = "dark"\n\n[mcp_servers.other]\ncommand = "other"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(codex_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+
+    text = config_path.read_text(encoding="utf-8")
+    assert '[mcp_servers.truememory]' in text
+    assert '[mcp_servers.other]' in text
+    assert 'theme = "dark"' in text
+
+
+def test_install_mcp_idempotent(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setattr(codex_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    first_text = config_path.read_text(encoding="utf-8")
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    second_text = config_path.read_text(encoding="utf-8")
+    assert first_text == second_text
+
+
+# -- Hook config --
+
+def test_install_hooks_creates_toml(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setattr(codex_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    text = config_path.read_text(encoding="utf-8")
+    assert "[[hooks]]" in text
+    assert 'event = "SessionStart"' in text
+    assert 'event = "Stop"' in text
+    assert 'event = "UserPromptSubmit"' in text
+    assert "truememory" in text.lower()
+    assert "PreCompact" not in text
+
+
+def test_install_hooks_preserves_existing_toml(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        '[general]\ntheme = "dark"\n\n[[hooks]]\nevent = "MyCustomHook"\ncommand = "my-cmd"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(codex_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    text = config_path.read_text(encoding="utf-8")
+    assert 'theme = "dark"' in text
+    assert 'event = "MyCustomHook"' in text
+    assert 'event = "SessionStart"' in text
+
+
+def test_install_hooks_idempotent(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setattr(codex_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    first_text = config_path.read_text(encoding="utf-8")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    second_text = config_path.read_text(encoding="utf-8")
+    assert first_text == second_text
+
+
+# -- MCP + hooks together (both in same file) --
+
+def test_install_mcp_and_hooks_in_same_file(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setattr(codex_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    text = config_path.read_text(encoding="utf-8")
+    assert "[mcp_servers.truememory]" in text
+    assert "[[hooks]]" in text
+    assert 'event = "SessionStart"' in text
+
+
+# -- Uninstall --
+
+def test_uninstall_removes_mcp_and_hooks(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setattr(codex_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    assert adapter.is_configured()
+
+    adapter.uninstall()
+    text = config_path.read_text(encoding="utf-8")
+    assert "[mcp_servers.truememory]" not in text
+    assert "truememory" not in text.lower()
+
+
+def test_uninstall_preserves_other_entries(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        '[general]\ntheme = "dark"\n\n'
+        '[[hooks]]\nevent = "MyCustomHook"\ncommand = "my-cmd"\ntimeout = 5000\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(codex_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    adapter.uninstall()
+
+    text = config_path.read_text(encoding="utf-8")
+    assert 'theme = "dark"' in text
+    assert 'event = "MyCustomHook"' in text
+    assert "[mcp_servers.truememory]" not in text
+
+
+# -- MCP section removal (line-by-line TOML parsing) --
+
+def test_remove_mcp_section_boundary():
+    from truememory.hooks.adapters.codex import CodexAdapter
+    text = (
+        '[general]\ntheme = "dark"\n\n'
+        '[mcp_servers.truememory]\n'
+        'command = "/usr/bin/python3"\n'
+        'args = ["-m", "truememory.mcp_server"]\n\n'
+        '[mcp_servers.other]\n'
+        'command = "other"\n'
+    )
+    result = CodexAdapter._remove_mcp_section(text)
+    assert "[mcp_servers.truememory]" not in result
+    assert "[mcp_servers.other]" in result
+    assert 'theme = "dark"' in result
+    assert 'command = "other"' in result
+
+
+# -- is_configured --
+
+def test_is_configured_false_clean(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    monkeypatch.setattr(codex_mod, "_CONFIG_PATH", tmp_path / "config.toml")
+    from truememory.hooks.adapters.codex import CodexAdapter
+    assert not CodexAdapter().is_configured()
+
+
+# -- verify --
+
+def test_verify_requires_both(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import codex as codex_mod
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setattr(codex_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    assert not adapter.verify()
+
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    assert adapter.verify()
+
+
+# -- AGENTS.md system prompt --
+
+def test_system_prompt_path():
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    path = adapter.get_system_prompt_path()
+    assert path is not None
+    assert path.name == "AGENTS.md"
+
+
+def test_system_prompt_content():
+    from truememory.hooks.adapters.codex import CodexAdapter
+    adapter = CodexAdapter()
+    content = adapter.get_system_prompt_content()
+    assert len(content) > 0
+    assert "TrueMemory" in content
+    assert "truememory_search" in content
+
+
+# -- Build command --
+
+def test_build_command_with_user_and_db():
+    from truememory.hooks.adapters.codex import CodexAdapter
+    cmd = CodexAdapter._build_command(
+        "/usr/bin/python3",
+        Path("/path/to/session_start.py"),
+        user_id="alice",
+        db_path="/data/mem.db",
+    )
+    assert "/usr/bin/python3" in cmd
+    assert "session_start.py" in cmd
+    assert "--user" in cmd
+    assert "alice" in cmd
+    assert "--db" in cmd

--- a/truememory/hooks/adapters/codex.py
+++ b/truememory/hooks/adapters/codex.py
@@ -1,0 +1,332 @@
+"""Codex CLI adapter — MCP config + TOML lifecycle hooks.
+
+Codex CLI uses:
+- ~/.codex/config.toml for BOTH MCP server registration AND hook registration
+- MCP under [mcp_servers.name] sections
+- Hooks as [[hooks]] entries
+- Same JSON stdin/stdout hook protocol as Claude Code
+"""
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+import shutil
+import sys
+from pathlib import Path
+
+from truememory.hooks.adapters.base import CLIAdapter
+
+log = logging.getLogger(__name__)
+
+_CODEX_DIR = Path.home() / ".codex"
+_CONFIG_PATH = _CODEX_DIR / "config.toml"
+
+_HOOK_EVENTS = {
+    "SessionStart": {
+        "script": "session_start.py",
+        "timeout": 10000,
+    },
+    "Stop": {
+        "script": "stop.py",
+        "timeout": 5000,
+    },
+    "UserPromptSubmit": {
+        "script": "user_prompt_submit.py",
+        "timeout": 5000,
+    },
+}
+
+_TRUEMEMORY_MARKER = "truememory"
+
+_AGENTS_TEMPLATE = """\
+# TrueMemory — Persistent Memory
+
+TrueMemory is the **primary long-horizon memory** for this user. \
+It persists facts, preferences, decisions, and corrections across \
+sessions, projects, and machines.
+
+When the `truememory` MCP server is connected, follow these rules:
+
+## Auto-Recall (every session)
+- At the START of each conversation, call `truememory_search` with a \
+broad query about the user to load relevant memories before responding.
+- Before making recommendations, check TrueMemory for stored preferences.
+- When the user asks anything about past conversations or personal \
+facts — search TrueMemory first.
+
+## Auto-Store (during conversation)
+- When the user shares a personal preference, store it immediately \
+via `truememory_store`. Do not ask permission.
+- When an important decision is made, store it.
+- When the user corrects you, store the correction.
+- Write each memory as a clear, atomic statement.
+- Do NOT store full conversations, large code blocks, or transient \
+debugging context.
+
+## Background Processing
+- Memories are also extracted automatically from conversations via \
+background processing.
+- The Stop hook captures the full transcript and runs deep extraction \
+after sessions end.
+- You do NOT need to store everything manually — focus on \
+in-conversation corrections and explicit preferences.
+"""
+
+
+class CodexAdapter(CLIAdapter):
+    """Adapter for OpenAI Codex CLI."""
+
+    @property
+    def name(self) -> str:
+        return "Codex CLI"
+
+    @property
+    def cli_id(self) -> str:
+        return "codex"
+
+    @property
+    def config_path(self) -> Path:
+        return _CONFIG_PATH
+
+    def detect(self) -> bool:
+        return _CODEX_DIR.is_dir() or shutil.which("codex") is not None
+
+    def is_configured(self) -> bool:
+        return self._has_mcp_entry() or self._has_hook_entries()
+
+    def install_mcp(self, python_path: str | None = None) -> None:
+        py = python_path or sys.executable
+        _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+        existing_text = ""
+        if _CONFIG_PATH.exists():
+            try:
+                existing_text = _CONFIG_PATH.read_text(encoding="utf-8")
+            except OSError:
+                existing_text = ""
+
+        if self._has_mcp_entry_in_text(existing_text):
+            return
+
+        section = (
+            "\n[mcp_servers.truememory]\n"
+            f'command = "{py}"\n'
+            'args = ["-m", "truememory.mcp_server"]\n'
+        )
+
+        new_text = existing_text.rstrip() + "\n" + section
+        _CONFIG_PATH.write_text(new_text, encoding="utf-8")
+
+    def install_hooks(
+        self,
+        python_path: str | None = None,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> None:
+        py = python_path or sys.executable
+        hooks_dir = Path(__file__).parent.parent.parent / "ingest" / "hooks"
+
+        _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+        existing_text = ""
+        if _CONFIG_PATH.exists():
+            try:
+                existing_text = _CONFIG_PATH.read_text(encoding="utf-8")
+            except OSError:
+                existing_text = ""
+
+        existing_hooks = self._parse_existing_hooks(existing_text)
+
+        lines_to_append: list[str] = []
+        for event, info in _HOOK_EVENTS.items():
+            if self._event_already_registered(existing_hooks, event):
+                continue
+
+            script_path = hooks_dir / info["script"]
+            cmd = self._build_command(py, script_path, user_id, db_path)
+
+            lines_to_append.append("")
+            lines_to_append.append("[[hooks]]")
+            lines_to_append.append(f'event = "{event}"')
+            lines_to_append.append(f'command = "{cmd}"')
+            lines_to_append.append(f'timeout = {info["timeout"]}')
+
+        if lines_to_append:
+            new_text = existing_text.rstrip() + "\n" + "\n".join(lines_to_append) + "\n"
+            _CONFIG_PATH.write_text(new_text, encoding="utf-8")
+
+    def uninstall(self) -> None:
+        if not _CONFIG_PATH.exists():
+            return
+        try:
+            text = _CONFIG_PATH.read_text(encoding="utf-8")
+        except OSError:
+            return
+
+        text = self._remove_mcp_section(text)
+        text = self._remove_hook_blocks(text)
+        _CONFIG_PATH.write_text(text, encoding="utf-8")
+
+    def verify(self) -> bool:
+        if not _CONFIG_PATH.exists():
+            return False
+        try:
+            text = _CONFIG_PATH.read_text(encoding="utf-8")
+        except OSError:
+            return False
+        return (
+            self._has_mcp_entry_in_text(text)
+            and self._has_hook_entries_in_text(text)
+        )
+
+    def get_system_prompt_path(self) -> Path | None:
+        return Path.home() / ".codex" / "AGENTS.md"
+
+    def get_system_prompt_content(self) -> str:
+        return _AGENTS_TEMPLATE.strip()
+
+    # -- Private helpers --
+
+    @staticmethod
+    def _build_command(
+        python_path: str,
+        script_path: Path,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> str:
+        parts: list[str] = [python_path, str(script_path)]
+        if user_id:
+            parts.extend(["--user", user_id])
+        if db_path:
+            parts.extend(["--db", db_path])
+        if sys.platform == "win32":
+            import subprocess as _sp
+            return _sp.list2cmdline(parts)
+        return " ".join(shlex.quote(p) for p in parts)
+
+    @staticmethod
+    def _parse_existing_hooks(toml_text: str) -> list[dict]:
+        if not toml_text.strip():
+            return []
+        try:
+            import tomllib
+            data = tomllib.loads(toml_text)
+            return data.get("hooks", [])
+        except ModuleNotFoundError:
+            hooks: list[dict] = []
+            for block in re.split(r'(?=^\[\[hooks\]\])', toml_text, flags=re.MULTILINE):
+                if not block.strip().startswith("[[hooks]]"):
+                    continue
+                entry: dict[str, str] = {}
+                for line in block.splitlines()[1:]:
+                    line = line.strip()
+                    if not line or line.startswith("["):
+                        break
+                    m = re.match(r'(\w+)\s*=\s*"([^"]*)"', line)
+                    if m:
+                        entry[m.group(1)] = m.group(2)
+                    else:
+                        m = re.match(r'(\w+)\s*=\s*(\d+)', line)
+                        if m:
+                            entry[m.group(1)] = m.group(2)
+                if entry:
+                    hooks.append(entry)
+            return hooks
+        except Exception:
+            return []
+
+    @staticmethod
+    def _event_already_registered(hooks: list[dict], event: str) -> bool:
+        for h in hooks:
+            if (
+                h.get("event") == event
+                and _TRUEMEMORY_MARKER in h.get("command", "").lower()
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _has_mcp_entry_in_text(text: str) -> bool:
+        return "[mcp_servers.truememory]" in text
+
+    def _has_mcp_entry(self) -> bool:
+        if not _CONFIG_PATH.exists():
+            return False
+        try:
+            text = _CONFIG_PATH.read_text(encoding="utf-8")
+            return self._has_mcp_entry_in_text(text)
+        except OSError:
+            return False
+
+    def _has_hook_entries_in_text(self, text: str) -> bool:
+        hooks = self._parse_existing_hooks(text)
+        return any(
+            _TRUEMEMORY_MARKER in h.get("command", "").lower()
+            for h in hooks
+        )
+
+    def _has_hook_entries(self) -> bool:
+        if not _CONFIG_PATH.exists():
+            return False
+        try:
+            text = _CONFIG_PATH.read_text(encoding="utf-8")
+            return self._has_hook_entries_in_text(text)
+        except OSError:
+            return False
+
+    @staticmethod
+    def _remove_mcp_section(text: str) -> str:
+        lines = text.splitlines(keepends=True)
+        cleaned: list[str] = []
+        skip = False
+
+        for line in lines:
+            stripped = line.strip()
+            if stripped == "[mcp_servers.truememory]":
+                skip = True
+                continue
+            if skip:
+                if stripped.startswith("[") and stripped != "[mcp_servers.truememory]":
+                    skip = False
+                    cleaned.append(line)
+                elif not stripped or "=" in stripped:
+                    continue
+                else:
+                    skip = False
+                    cleaned.append(line)
+            else:
+                cleaned.append(line)
+
+        return "".join(cleaned)
+
+    @staticmethod
+    def _remove_hook_blocks(text: str) -> str:
+        lines = text.splitlines(keepends=True)
+        cleaned: list[str] = []
+
+        i = 0
+        while i < len(lines):
+            stripped = lines[i].strip()
+
+            if stripped == "[[hooks]]":
+                block_lines = [lines[i]]
+                i += 1
+                while (
+                    i < len(lines)
+                    and lines[i].strip()
+                    and not lines[i].strip().startswith("[[")
+                    and not lines[i].strip().startswith("[")
+                ):
+                    block_lines.append(lines[i])
+                    i += 1
+
+                block_text = "".join(block_lines)
+                if _TRUEMEMORY_MARKER not in block_text.lower():
+                    cleaned.extend(block_lines)
+                continue
+
+            cleaned.append(lines[i])
+            i += 1
+
+        return "".join(cleaned)

--- a/truememory/hooks/registry.py
+++ b/truememory/hooks/registry.py
@@ -20,10 +20,11 @@ STATE_FILE = Path.home() / ".truememory" / "integrations.json"
 def _get_all_adapters() -> list[CLIAdapter]:
     """Return instances of all known CLI adapters."""
     from truememory.hooks.adapters.claude import ClaudeAdapter
+    from truememory.hooks.adapters.codex import CodexAdapter
     from truememory.hooks.adapters.kimi import KimiAdapter
     from truememory.hooks.adapters.hermes import HermesAdapter
     from truememory.hooks.adapters.openclaw import OpenClawAdapter
-    return [ClaudeAdapter(), KimiAdapter(), HermesAdapter(), OpenClawAdapter()]
+    return [ClaudeAdapter(), CodexAdapter(), KimiAdapter(), HermesAdapter(), OpenClawAdapter()]
 
 
 def detect_installed() -> list[CLIAdapter]:

--- a/truememory/hooks/templates/codex/config.toml
+++ b/truememory/hooks/templates/codex/config.toml
@@ -1,0 +1,24 @@
+# TrueMemory MCP server registration for Codex CLI
+# See: https://github.com/buildingjoshbetter/TrueMemory
+
+[mcp_servers.truememory]
+command = "/path/to/python"
+args = ["-m", "truememory.mcp_server"]
+
+# TrueMemory lifecycle hooks
+# These scripts use the same JSON stdin/stdout protocol as Claude Code.
+
+[[hooks]]
+event = "SessionStart"
+command = "/path/to/python /path/to/truememory/ingest/hooks/session_start.py"
+timeout = 10000
+
+[[hooks]]
+event = "Stop"
+command = "/path/to/python /path/to/truememory/ingest/hooks/stop.py"
+timeout = 5000
+
+[[hooks]]
+event = "UserPromptSubmit"
+command = "/path/to/python /path/to/truememory/ingest/hooks/user_prompt_submit.py"
+timeout = 5000


### PR DESCRIPTION
Closes #182

## Summary
- **CodexAdapter** (`truememory/hooks/adapters/codex.py`): Full CLIAdapter implementation for Codex CLI with detection, TOML-based MCP registration (`[mcp_servers.truememory]`), and hook registration (`[[hooks]]` entries)
- **Three hook events**: SessionStart (10s), Stop (5s), UserPromptSubmit (5s) — same scripts as Claude Code, different config format
- **AGENTS.md support**: System prompt path and content adapted from CLAUDE_TEMPLATE.md
- **Additive config merges**: MCP + hooks both in `~/.codex/config.toml`, existing entries preserved

## Test plan
- [ ] All new tests pass (`tests/test_codex_adapter.py`)
- [ ] All existing tests still pass
- [ ] `uvx ruff check` passes — no lint errors
- [ ] Import chain verified — no circular imports
- [ ] Interface compliance: all 11 CLIAdapter abstract methods implemented
- [ ] Idempotent install: running twice produces identical config
- [ ] Uninstall removes only TrueMemory entries
- [ ] Python 3.10 compatible (no bare `import tomllib`)