### PR TITLE
feat: Gemini CLI integration — MCP server config + lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - **93.0% on LoCoMo, 92.0% on LongMemEval, SOTA on BEAM-1M.** Beats every live-retrieval memory system across three major benchmarks. Independently reproducible.
 - **Runs locally on a single SQLite file.** Zero cloud, zero API keys for Edge and Base tiers. Your memories never leave your machine.
 - **Neuroscience-inspired architecture.** Six retrieval layers plus an encoding gate that filters noise from signal before anything gets stored.
-- **Works with Claude Code, Codex CLI, and Claude Desktop.** Lifecycle hooks capture conversations automatically. No manual work needed.
+- **Works with Claude Code, Codex CLI, Gemini CLI, and Claude Desktop.** Lifecycle hooks capture conversations automatically. No manual work needed.
 
 ---
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,17 +4,17 @@ TrueMemory integrates with multiple AI CLI tools. Each CLI has different config 
 
 ## Feature Support
 
-| Feature | Claude Code | Codex CLI | Kimi CLI | Hermes Agent | OpenClaw |
-|---------|:-----------:|:---------:|:--------:|:------------:|:--------:|
-| MCP server | JSON | TOML | JSON | YAML | JSON |
-| Auto-recall at session start | Yes | Yes | Yes | Yes | Yes |
-| Auto-extract at session end | Yes | Yes | Yes | Yes | Yes |
-| Mid-session extraction (PreCompact) | Yes | No | Yes | No | No |
-| Message buffering (UserPromptSubmit) | Yes | Yes | No | No | No |
-| System prompt injection | Yes | Yes | No | No | No |
-| Hook protocol | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JS plugin API |
-| Config format | JSON | TOML | TOML + JSON | YAML | JSON5 + JS |
-| Non-interactive install | `--cli claude` | `--cli codex` | `--cli kimi` | `--cli hermes` | `--cli openclaw` |
+| Feature | Claude Code | Codex CLI | Gemini CLI | Kimi CLI | Hermes Agent | OpenClaw |
+|---------|:-----------:|:---------:|:----------:|:--------:|:------------:|:--------:|
+| MCP server | JSON | TOML | JSON | JSON | YAML | JSON |
+| Auto-recall at session start | Yes | Yes | Yes | Yes | Yes | Yes |
+| Auto-extract at session end | Yes | Yes | Yes | Yes | Yes | Yes |
+| Mid-session extraction (PreCompact) | Yes | No | Yes | Yes | No | No |
+| Message buffering (UserPromptSubmit) | Yes | Yes | No | No | No | No |
+| System prompt injection | Yes | Yes | Yes | No | No | No |
+| Hook protocol | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JS plugin API |
+| Config format | JSON | TOML | JSON | TOML + JSON | YAML | JSON5 + JS |
+| Non-interactive install | `--cli claude` | `--cli codex` | `--cli gemini` | `--cli kimi` | `--cli hermes` | `--cli openclaw` |
 
 ## Config Locations
 
@@ -22,18 +22,19 @@ TrueMemory integrates with multiple AI CLI tools. Each CLI has different config 
 |-----|-----------|------------|----------------|
 | Claude Code | `~/.claude/settings.json` | `~/.claude/settings.json` | `~/.claude/` |
 | Codex CLI | `~/.codex/config.toml` | `~/.codex/config.toml` | `~/.codex/` |
+| Gemini CLI | `~/.gemini/settings.json` | `~/.gemini/settings.json` | `~/.gemini/` |
 | Kimi CLI | `~/.kimi/mcp.json` | `~/.kimi/config.toml` | `~/.kimi/` |
 | Hermes Agent | `~/.hermes/config.yaml` | `~/.hermes/cli-config.yaml` | `~/.hermes/` |
 | OpenClaw | `~/.openclaw/openclaw.json` | `~/.openclaw/plugins/truememory/` | `~/.openclaw/` |
 
 ## Hook Events
 
-| Event | Claude Code | Codex CLI | Kimi CLI | Hermes Agent | OpenClaw |
-|-------|------------|-----------|----------|-------------|----------|
-| Session start | `SessionStart` | `SessionStart` | `SessionStart` | `on_session_start` | `before_agent_run` |
-| Session end | `Stop` | `Stop` | `Stop` | `on_session_end` | `agent_end` |
-| Pre-compact | `PreCompact` | — | `PreCompact` | — | — |
-| User message | `UserPromptSubmit` | `UserPromptSubmit` | — | — | — |
+| Event | Claude Code | Codex CLI | Gemini CLI | Kimi CLI | Hermes Agent | OpenClaw |
+|-------|------------|-----------|------------|----------|-------------|----------|
+| Session start | `SessionStart` | `SessionStart` | `SessionStart` | `SessionStart` | `on_session_start` | `before_agent_run` |
+| Session end | `Stop` | `Stop` | `SessionEnd` | `Stop` | `on_session_end` | `agent_end` |
+| Pre-compact | `PreCompact` | — | `PreCompress` | `PreCompact` | — | — |
+| User message | `UserPromptSubmit` | `UserPromptSubmit` | — | — | — | — |
 
 ## Shared Memory
 
@@ -42,6 +43,7 @@ All CLIs share the same TrueMemory database (`~/.truememory/memories.db`). Memor
 ## Known Limitations
 
 - **Codex CLI**: MCP and hooks share a single `config.toml`. TrueMemory uses additive merges to avoid overwriting other settings.
+- **Gemini CLI**: MCP and hooks share a single `settings.json`. Uses different event names than Claude Code (`SessionEnd` instead of `Stop`, `PreCompress` instead of `PreCompact`).
 - **Kimi CLI**: Hooks are in beta. Event availability may change.
 - **Hermes Agent**: Gateway hooks (Telegram/Discord/etc.) require separate `handler.py` setup.
 - **OpenClaw**: Uses a JS plugin system — requires Node.js at runtime for the plugin.

--- a/docs/setup-gemini.md
+++ b/docs/setup-gemini.md
@@ -1,0 +1,83 @@
+# Gemini CLI Setup
+
+## Prerequisites
+
+- Gemini CLI installed (`~/.gemini/` exists)
+- TrueMemory installed: `uv tool install truememory`
+- Python 3.10+
+
+## Automatic Setup
+
+```bash
+truememory-ingest setup --cli gemini
+```
+
+Or during the interactive setup wizard:
+
+```bash
+truememory-ingest setup
+# Select Gemini CLI when prompted
+```
+
+## Manual Setup
+
+### 1. MCP Server + Lifecycle Hooks
+
+Both MCP and hooks live in `~/.gemini/settings.json`. Add the following:
+
+```json
+{
+  "mcpServers": {
+    "truememory": {
+      "command": "/path/to/python",
+      "args": ["-m", "truememory.mcp_server"]
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "command": "/path/to/python /path/to/truememory/ingest/hooks/session_start.py",
+        "timeout": 10000
+      }
+    ],
+    "SessionEnd": [
+      {
+        "command": "/path/to/python /path/to/truememory/ingest/hooks/stop.py",
+        "timeout": 5000
+      }
+    ],
+    "PreCompress": [
+      {
+        "command": "/path/to/python /path/to/truememory/ingest/hooks/compact.py",
+        "timeout": 5000
+      }
+    ]
+  }
+}
+```
+
+Find your Python path: `python3 -c "import sys; print(sys.executable)"`
+
+Find hook paths: `python3 -c "from pathlib import Path; import truememory; print(Path(truememory.__file__).parent / 'ingest' / 'hooks')"`
+
+### 2. GEMINI.md (Optional)
+
+For auto-recall/auto-store instructions, run:
+
+```bash
+truememory-ingest setup --cli gemini
+```
+
+This creates `~/.gemini/GEMINI.md` with TrueMemory system prompt instructions.
+
+## Verification
+
+```bash
+truememory-ingest status
+```
+
+## Troubleshooting
+
+- **MCP not connecting**: Verify the Python path in `settings.json` points to the environment with TrueMemory installed.
+- **Existing config**: TrueMemory uses additive merges — your existing Gemini config is preserved.
+- **Hooks not firing**: Check that the hook script paths are absolute and the Python executable is correct. Event names are PascalCase: `SessionStart`, `SessionEnd`, `PreCompress`.

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -1,0 +1,289 @@
+"""Tests for the Gemini CLI adapter (#233).
+
+Validates MCP config, JSON hook registration, detection, and
+config merge safety without network calls.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+
+# -- Import tests --
+
+def test_import_gemini_adapter():
+    from truememory.hooks.adapters.gemini import GeminiAdapter  # noqa: F401
+
+
+def test_gemini_in_registry():
+    from truememory.hooks.registry import get_adapter
+    adapter = get_adapter("gemini")
+    assert adapter is not None
+    assert adapter.cli_id == "gemini"
+
+
+# -- Instantiation --
+
+def test_gemini_adapter_properties():
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    assert adapter.name == "Gemini CLI"
+    assert adapter.cli_id == "gemini"
+    assert isinstance(adapter.config_path, Path)
+    assert adapter.config_path.name == "settings.json"
+
+
+def test_gemini_implements_all_abstract_methods():
+    from truememory.hooks.adapters.base import CLIAdapter
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    abstract_methods = {
+        name for name, _ in inspect.getmembers(CLIAdapter)
+        if getattr(getattr(CLIAdapter, name, None), "__isabstractmethod__", False)
+    }
+    adapter = GeminiAdapter()
+    for method_name in abstract_methods:
+        assert hasattr(adapter, method_name), f"Missing: {method_name}"
+
+
+# -- Detection --
+
+def test_detect_false_no_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    monkeypatch.setattr(gemini_mod, "_GEMINI_DIR", tmp_path / "nonexistent")
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    assert not adapter.detect()
+
+
+def test_detect_true_with_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    gemini_dir = tmp_path / ".gemini"
+    gemini_dir.mkdir()
+    monkeypatch.setattr(gemini_mod, "_GEMINI_DIR", gemini_dir)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    assert adapter.detect()
+
+
+# -- MCP config --
+
+def test_install_mcp_creates_config(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "truememory" in data["mcpServers"]
+    assert data["mcpServers"]["truememory"]["command"] == "/usr/bin/python3"
+    assert data["mcpServers"]["truememory"]["args"] == ["-m", "truememory.mcp_server"]
+
+
+def test_install_mcp_preserves_existing(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    config_path.write_text(json.dumps({
+        "mcpServers": {
+            "other-server": {"command": "other", "args": ["arg"]}
+        },
+        "theme": "dark",
+    }), encoding="utf-8")
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "truememory" in data["mcpServers"]
+    assert "other-server" in data["mcpServers"]
+    assert data["theme"] == "dark"
+
+
+def test_install_mcp_idempotent(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    first = config_path.read_text(encoding="utf-8")
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    second = config_path.read_text(encoding="utf-8")
+    assert first == second
+
+
+# -- Hook config --
+
+def test_install_hooks_creates_entries(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    hooks = data["hooks"]
+    assert "SessionStart" in hooks
+    assert "SessionEnd" in hooks
+    assert "PreCompress" in hooks
+    assert len(hooks["SessionStart"]) == 1
+    assert "truememory" in hooks["SessionStart"][0]["command"].lower()
+
+
+def test_install_hooks_preserves_existing(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    config_path.write_text(json.dumps({
+        "hooks": {
+            "SessionStart": [
+                {"command": "my-custom-hook", "timeout": 5000}
+            ]
+        },
+        "theme": "dark",
+    }), encoding="utf-8")
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["theme"] == "dark"
+    assert len(data["hooks"]["SessionStart"]) == 2
+    assert data["hooks"]["SessionStart"][0]["command"] == "my-custom-hook"
+
+
+def test_install_hooks_idempotent(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    first = config_path.read_text(encoding="utf-8")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    second = config_path.read_text(encoding="utf-8")
+    assert first == second
+
+
+# -- Uninstall --
+
+def test_uninstall_removes_entries(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    assert adapter.is_configured()
+
+    adapter.uninstall()
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "truememory" not in data.get("mcpServers", {})
+    hooks = data.get("hooks", {})
+    for entries in hooks.values():
+        for h in entries:
+            assert "truememory" not in h.get("command", "").lower()
+
+
+def test_uninstall_preserves_other_entries(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    config_path.write_text(json.dumps({
+        "mcpServers": {
+            "other-server": {"command": "other"},
+            "truememory": {"command": "python", "args": ["-m", "truememory.mcp_server"]},
+        },
+        "hooks": {
+            "SessionStart": [
+                {"command": "my-hook", "timeout": 5000},
+                {"command": "/path/to/truememory/hooks/session_start.py", "timeout": 10000},
+            ]
+        },
+        "theme": "dark",
+    }), encoding="utf-8")
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    adapter.uninstall()
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "other-server" in data["mcpServers"]
+    assert "truememory" not in data["mcpServers"]
+    assert data["theme"] == "dark"
+    assert len(data["hooks"]["SessionStart"]) == 1
+    assert data["hooks"]["SessionStart"][0]["command"] == "my-hook"
+
+
+# -- is_configured --
+
+def test_is_configured_false_clean(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", tmp_path / "settings.json")
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    assert not GeminiAdapter().is_configured()
+
+
+def test_is_configured_true_after_install(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    assert adapter.is_configured()
+
+
+# -- verify --
+
+def test_verify_requires_both(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    assert not adapter.verify()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    assert adapter.verify()
+
+
+# -- System prompt --
+
+def test_system_prompt_path():
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    path = adapter.get_system_prompt_path()
+    assert path is not None
+    assert path.name == "GEMINI.md"
+
+
+def test_system_prompt_content():
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    content = adapter.get_system_prompt_content()
+    assert "TrueMemory" in content
+    assert "truememory_search" in content
+
+
+# -- Build command --
+
+def test_build_command_with_user_and_db():
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    cmd = GeminiAdapter._build_command(
+        "/usr/bin/python3",
+        Path("/path/to/session_start.py"),
+        user_id="alice",
+        db_path="/data/mem.db",
+    )
+    assert "/usr/bin/python3" in cmd
+    assert "session_start.py" in cmd
+    assert "--user" in cmd
+    assert "alice" in cmd
+    assert "--db" in cmd

--- a/truememory/hooks/adapters/gemini.py
+++ b/truememory/hooks/adapters/gemini.py
@@ -1,0 +1,253 @@
+"""Gemini CLI adapter — MCP config + JSON lifecycle hooks.
+
+Gemini CLI uses:
+- ~/.gemini/settings.json for BOTH MCP server registration AND hook registration
+- MCP under mcpServers key (Claude Desktop-compatible format)
+- Hooks under hooks key with PascalCase event names
+- Same JSON stdin/stdout hook protocol as Claude Code
+"""
+from __future__ import annotations
+
+import json
+import shlex
+import shutil
+import sys
+from pathlib import Path
+
+from truememory.hooks.adapters.base import CLIAdapter
+
+_GEMINI_DIR = Path.home() / ".gemini"
+_CONFIG_PATH = _GEMINI_DIR / "settings.json"
+
+_HOOK_EVENTS = {
+    "SessionStart": {
+        "script": "session_start.py",
+        "timeout": 10000,
+    },
+    "SessionEnd": {
+        "script": "stop.py",
+        "timeout": 5000,
+    },
+    "PreCompress": {
+        "script": "compact.py",
+        "timeout": 5000,
+    },
+}
+
+_TRUEMEMORY_MARKER = "truememory"
+
+_SYSTEM_PROMPT_TEMPLATE = """\
+# TrueMemory — Persistent Memory
+
+TrueMemory is the **primary long-horizon memory** for this user. \
+It persists facts, preferences, decisions, and corrections across \
+sessions, projects, and machines.
+
+When the `truememory` MCP server is connected, follow these rules:
+
+## Auto-Recall (every session)
+- At the START of each conversation, call `truememory_search` with a \
+broad query about the user to load relevant memories before responding.
+- Before making recommendations, check TrueMemory for stored preferences.
+- When the user asks anything about past conversations or personal \
+facts — search TrueMemory first.
+
+## Auto-Store (during conversation)
+- When the user shares a personal preference, store it immediately \
+via `truememory_store`. Do not ask permission.
+- When an important decision is made, store it.
+- When the user corrects you, store the correction.
+- Write each memory as a clear, atomic statement.
+- Do NOT store full conversations, large code blocks, or transient \
+debugging context.
+
+## Background Processing
+- Memories are also extracted automatically from conversations via \
+background processing.
+- The SessionEnd hook captures the full transcript and runs deep extraction \
+after sessions end.
+- You do NOT need to store everything manually — focus on \
+in-conversation corrections and explicit preferences.
+"""
+
+
+class GeminiAdapter(CLIAdapter):
+    """Adapter for Google Gemini CLI."""
+
+    @property
+    def name(self) -> str:
+        return "Gemini CLI"
+
+    @property
+    def cli_id(self) -> str:
+        return "gemini"
+
+    @property
+    def config_path(self) -> Path:
+        return _CONFIG_PATH
+
+    def detect(self) -> bool:
+        return _GEMINI_DIR.is_dir() or shutil.which("gemini") is not None
+
+    def is_configured(self) -> bool:
+        return self._has_mcp_entry() or self._has_hook_entries()
+
+    def install_mcp(self, python_path: str | None = None) -> None:
+        py = python_path or sys.executable
+        settings = self._read_config()
+
+        servers = settings.setdefault("mcpServers", {})
+        if not isinstance(servers, dict):
+            servers = {}
+            settings["mcpServers"] = servers
+
+        servers["truememory"] = {
+            "command": py,
+            "args": ["-m", "truememory.mcp_server"],
+        }
+
+        self._write_config(settings)
+
+    def install_hooks(
+        self,
+        python_path: str | None = None,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> None:
+        py = python_path or sys.executable
+        hooks_dir = Path(__file__).parent.parent.parent / "ingest" / "hooks"
+
+        settings = self._read_config()
+        hooks = settings.setdefault("hooks", {})
+        if not isinstance(hooks, dict):
+            hooks = {}
+            settings["hooks"] = hooks
+
+        for event, info in _HOOK_EVENTS.items():
+            event_list = hooks.setdefault(event, [])
+            if not isinstance(event_list, list):
+                event_list = []
+                hooks[event] = event_list
+
+            if self._event_has_truememory(event_list):
+                continue
+
+            script_path = hooks_dir / info["script"]
+            cmd = self._build_command(py, script_path, user_id, db_path)
+            event_list.append({
+                "command": cmd,
+                "timeout": info["timeout"],
+            })
+
+        self._write_config(settings)
+
+    def uninstall(self) -> None:
+        if not _CONFIG_PATH.exists():
+            return
+        settings = self._read_config()
+
+        servers = settings.get("mcpServers", {})
+        if isinstance(servers, dict) and "truememory" in servers:
+            del servers["truememory"]
+
+        hooks = settings.get("hooks", {})
+        if isinstance(hooks, dict):
+            for event in list(hooks.keys()):
+                entries = hooks[event]
+                if not isinstance(entries, list):
+                    continue
+                cleaned = [
+                    h for h in entries
+                    if not (
+                        isinstance(h, dict)
+                        and _TRUEMEMORY_MARKER in h.get("command", "").lower()
+                    )
+                ]
+                if cleaned:
+                    hooks[event] = cleaned
+                else:
+                    del hooks[event]
+
+        self._write_config(settings)
+
+    def verify(self) -> bool:
+        if not _CONFIG_PATH.exists():
+            return False
+        return self._has_mcp_entry() and self._has_hook_entries()
+
+    def get_system_prompt_path(self) -> Path | None:
+        return _GEMINI_DIR / "GEMINI.md"
+
+    def get_system_prompt_content(self) -> str:
+        return _SYSTEM_PROMPT_TEMPLATE.strip()
+
+    # -- Private helpers --
+
+    @staticmethod
+    def _build_command(
+        python_path: str,
+        script_path: Path,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> str:
+        parts: list[str] = [python_path, str(script_path)]
+        if user_id:
+            parts.extend(["--user", user_id])
+        if db_path:
+            parts.extend(["--db", db_path])
+        if sys.platform == "win32":
+            import subprocess as _sp
+            return _sp.list2cmdline(parts)
+        return " ".join(shlex.quote(p) for p in parts)
+
+    def _read_config(self) -> dict:
+        _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        if _CONFIG_PATH.exists():
+            try:
+                data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    return data
+            except (json.JSONDecodeError, OSError):
+                pass
+        return {}
+
+    def _write_config(self, settings: dict) -> None:
+        _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _CONFIG_PATH.write_text(
+            json.dumps(settings, indent=2),
+            encoding="utf-8",
+        )
+
+    def _has_mcp_entry(self) -> bool:
+        if not _CONFIG_PATH.exists():
+            return False
+        try:
+            data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+            return "truememory" in data.get("mcpServers", {})
+        except (json.JSONDecodeError, OSError):
+            return False
+
+    def _has_hook_entries(self) -> bool:
+        if not _CONFIG_PATH.exists():
+            return False
+        try:
+            data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+            hooks = data.get("hooks", {})
+            if not isinstance(hooks, dict):
+                return False
+            for entries in hooks.values():
+                if not isinstance(entries, list):
+                    continue
+                if self._event_has_truememory(entries):
+                    return True
+        except (json.JSONDecodeError, OSError):
+            pass
+        return False
+
+    @staticmethod
+    def _event_has_truememory(entries: list) -> bool:
+        return any(
+            isinstance(h, dict)
+            and _TRUEMEMORY_MARKER in h.get("command", "").lower()
+            for h in entries
+        )

--- a/truememory/hooks/registry.py
+++ b/truememory/hooks/registry.py
@@ -21,10 +21,11 @@ def _get_all_adapters() -> list[CLIAdapter]:
     """Return instances of all known CLI adapters."""
     from truememory.hooks.adapters.claude import ClaudeAdapter
     from truememory.hooks.adapters.codex import CodexAdapter
+    from truememory.hooks.adapters.gemini import GeminiAdapter
     from truememory.hooks.adapters.kimi import KimiAdapter
     from truememory.hooks.adapters.hermes import HermesAdapter
     from truememory.hooks.adapters.openclaw import OpenClawAdapter
-    return [ClaudeAdapter(), CodexAdapter(), KimiAdapter(), HermesAdapter(), OpenClawAdapter()]
+    return [ClaudeAdapter(), CodexAdapter(), GeminiAdapter(), KimiAdapter(), HermesAdapter(), OpenClawAdapter()]
 
 
 def detect_installed() -> list[CLIAdapter]:


### PR DESCRIPTION
Closes #233

## Summary
- Adds `GeminiAdapter` in `truememory/hooks/adapters/gemini.py` — single-file JSON adapter for `~/.gemini/settings.json` with MCP server registration and lifecycle hooks (SessionStart, SessionEnd, PreCompress)
- 20 new tests covering import, detection, MCP install, hook install, idempotency, additive merge, uninstall, interface compliance, and system prompt
- Quickstart guide at `docs/setup-gemini.md`, compatibility matrix updated with Gemini column

## Test plan
- [x] All 20 new tests pass
- [x] All 55 existing adapter tests still pass (zero regressions)
- [x] `uvx ruff check` passes — no lint errors
- [x] Import chain verified — no circular imports
- [x] Interface compliance: all 11 CLIAdapter abstract methods implemented
- [x] Idempotent install: running twice produces identical config
- [x] Uninstall removes only TrueMemory entries, preserves other config
- [x] Standalone hooks (`python -m truememory.ingest.hooks.session_start`) still importable
- [x] All 6 existing adapters (Claude, Codex, Kimi, Hermes, OpenClaw) still load in registry