### PR TITLE
feat: Cursor integration — MCP server config + lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - **93.0% on LoCoMo, 92.0% on LongMemEval, SOTA on BEAM-1M.** Beats every live-retrieval memory system across three major benchmarks. Independently reproducible.
 - **Runs locally on a single SQLite file.** Zero cloud, zero API keys for Edge and Base tiers. Your memories never leave your machine.
 - **Neuroscience-inspired architecture.** Six retrieval layers plus an encoding gate that filters noise from signal before anything gets stored.
-- **Works with Claude Code, Codex CLI, and Claude Desktop.** Lifecycle hooks capture conversations automatically. No manual work needed.
+- **Works with Claude Code, Codex CLI, Cursor, and Claude Desktop.** Lifecycle hooks capture conversations automatically. No manual work needed.
 
 ---
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,17 +4,17 @@ TrueMemory integrates with multiple AI CLI tools. Each CLI has different config 
 
 ## Feature Support
 
-| Feature | Claude Code | Codex CLI | Kimi CLI | Hermes Agent | OpenClaw |
-|---------|:-----------:|:---------:|:--------:|:------------:|:--------:|
-| MCP server | JSON | TOML | JSON | YAML | JSON |
-| Auto-recall at session start | Yes | Yes | Yes | Yes | Yes |
-| Auto-extract at session end | Yes | Yes | Yes | Yes | Yes |
-| Mid-session extraction (PreCompact) | Yes | No | Yes | No | No |
-| Message buffering (UserPromptSubmit) | Yes | Yes | No | No | No |
-| System prompt injection | Yes | Yes | No | No | No |
-| Hook protocol | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JS plugin API |
-| Config format | JSON | TOML | TOML + JSON | YAML | JSON5 + JS |
-| Non-interactive install | `--cli claude` | `--cli codex` | `--cli kimi` | `--cli hermes` | `--cli openclaw` |
+| Feature | Claude Code | Codex CLI | Cursor | Kimi CLI | Hermes Agent | OpenClaw |
+|---------|:-----------:|:---------:|:------:|:--------:|:------------:|:--------:|
+| MCP server | JSON | TOML | JSON | JSON | YAML | JSON |
+| Auto-recall at session start | Yes | Yes | Yes | Yes | Yes | Yes |
+| Auto-extract at session end | Yes | Yes | Yes | Yes | Yes | Yes |
+| Mid-session extraction (PreCompact) | Yes | No | Yes | Yes | No | No |
+| Message buffering (UserPromptSubmit) | Yes | Yes | No | No | No | No |
+| System prompt injection | Yes | Yes | Yes | No | No | No |
+| Hook protocol | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JSON stdin/stdout | JS plugin API |
+| Config format | JSON | TOML | JSON (2 files) | TOML + JSON | YAML | JSON5 + JS |
+| Non-interactive install | `--cli claude` | `--cli codex` | `--cli cursor` | `--cli kimi` | `--cli hermes` | `--cli openclaw` |
 
 ## Config Locations
 
@@ -22,18 +22,19 @@ TrueMemory integrates with multiple AI CLI tools. Each CLI has different config 
 |-----|-----------|------------|----------------|
 | Claude Code | `~/.claude/settings.json` | `~/.claude/settings.json` | `~/.claude/` |
 | Codex CLI | `~/.codex/config.toml` | `~/.codex/config.toml` | `~/.codex/` |
+| Cursor | `~/.cursor/mcp.json` | `~/.cursor/hooks.json` | `~/.cursor/` |
 | Kimi CLI | `~/.kimi/mcp.json` | `~/.kimi/config.toml` | `~/.kimi/` |
 | Hermes Agent | `~/.hermes/config.yaml` | `~/.hermes/cli-config.yaml` | `~/.hermes/` |
 | OpenClaw | `~/.openclaw/openclaw.json` | `~/.openclaw/plugins/truememory/` | `~/.openclaw/` |
 
 ## Hook Events
 
-| Event | Claude Code | Codex CLI | Kimi CLI | Hermes Agent | OpenClaw |
-|-------|------------|-----------|----------|-------------|----------|
-| Session start | `SessionStart` | `SessionStart` | `SessionStart` | `on_session_start` | `before_agent_run` |
-| Session end | `Stop` | `Stop` | `Stop` | `on_session_end` | `agent_end` |
-| Pre-compact | `PreCompact` | — | `PreCompact` | — | — |
-| User message | `UserPromptSubmit` | `UserPromptSubmit` | — | — | — |
+| Event | Claude Code | Codex CLI | Cursor | Kimi CLI | Hermes Agent | OpenClaw |
+|-------|------------|-----------|--------|----------|-------------|----------|
+| Session start | `SessionStart` | `SessionStart` | `sessionStart` | `SessionStart` | `on_session_start` | `before_agent_run` |
+| Session end | `Stop` | `Stop` | `stop` | `Stop` | `on_session_end` | `agent_end` |
+| Pre-compact | `PreCompact` | — | `preCompact` | `PreCompact` | — | — |
+| User message | `UserPromptSubmit` | `UserPromptSubmit` | — | — | — | — |
 
 ## Shared Memory
 
@@ -42,6 +43,7 @@ All CLIs share the same TrueMemory database (`~/.truememory/memories.db`). Memor
 ## Known Limitations
 
 - **Codex CLI**: MCP and hooks share a single `config.toml`. TrueMemory uses additive merges to avoid overwriting other settings.
+- **Cursor**: MCP (`mcp.json`) and hooks (`hooks.json`) are separate files. Event names are camelCase. `hooks.json` requires `"version": 1` top-level key.
 - **Kimi CLI**: Hooks are in beta. Event availability may change.
 - **Hermes Agent**: Gateway hooks (Telegram/Discord/etc.) require separate `handler.py` setup.
 - **OpenClaw**: Uses a JS plugin system — requires Node.js at runtime for the plugin.

--- a/docs/setup-cursor.md
+++ b/docs/setup-cursor.md
@@ -1,0 +1,95 @@
+# Cursor Setup
+
+## Prerequisites
+
+- Cursor installed (`~/.cursor/` exists)
+- TrueMemory installed: `uv tool install truememory`
+- Python 3.10+
+
+## Automatic Setup
+
+```bash
+truememory-ingest setup --cli cursor
+```
+
+Or during the interactive setup wizard:
+
+```bash
+truememory-ingest setup
+# Select Cursor when prompted
+```
+
+## Manual Setup
+
+### 1. MCP Server
+
+Add to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "truememory": {
+      "command": "/path/to/python",
+      "args": ["-m", "truememory.mcp_server"]
+    }
+  }
+}
+```
+
+### 2. Lifecycle Hooks
+
+Add to `~/.cursor/hooks.json`:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "/path/to/python /path/to/truememory/ingest/hooks/session_start.py",
+        "timeout": 10000
+      }
+    ],
+    "stop": [
+      {
+        "command": "/path/to/python /path/to/truememory/ingest/hooks/stop.py",
+        "timeout": 5000
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "/path/to/python /path/to/truememory/ingest/hooks/compact.py",
+        "timeout": 5000
+      }
+    ]
+  }
+}
+```
+
+Find your Python path: `python3 -c "import sys; print(sys.executable)"`
+
+Find hook paths: `python3 -c "from pathlib import Path; import truememory; print(Path(truememory.__file__).parent / 'ingest' / 'hooks')"`
+
+### 3. .cursorrules (Optional)
+
+For auto-recall/auto-store instructions, run:
+
+```bash
+truememory-ingest setup --cli cursor
+```
+
+This creates `~/.cursor/.cursorrules` with TrueMemory system prompt instructions.
+
+## Verification
+
+```bash
+truememory-ingest status
+```
+
+## Troubleshooting
+
+- **MCP not connecting**: Verify the Python path in `mcp.json` points to the environment with TrueMemory installed.
+- **Existing config**: TrueMemory uses additive merges — your existing Cursor config is preserved.
+- **Hooks not firing**: Check that event names are camelCase (`sessionStart`, `stop`, `preCompact`). PascalCase will silently fail.
+- **Two config files**: MCP lives in `~/.cursor/mcp.json`, hooks live in `~/.cursor/hooks.json`. They are separate files.
+- **Version key**: `hooks.json` requires `"version": 1` at the top level.

--- a/tests/test_cursor_adapter.py
+++ b/tests/test_cursor_adapter.py
@@ -1,0 +1,363 @@
+"""Tests for the Cursor adapter (#234).
+
+Validates MCP config (mcp.json), hook config (hooks.json with version key),
+detection, dual-file merge safety, and uninstall across both files.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+
+# -- Import tests --
+
+def test_import_cursor_adapter():
+    from truememory.hooks.adapters.cursor import CursorAdapter  # noqa: F401
+
+
+def test_cursor_in_registry():
+    from truememory.hooks.registry import get_adapter
+    adapter = get_adapter("cursor")
+    assert adapter is not None
+    assert adapter.cli_id == "cursor"
+
+
+# -- Instantiation --
+
+def test_cursor_adapter_properties():
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    assert adapter.name == "Cursor"
+    assert adapter.cli_id == "cursor"
+    assert isinstance(adapter.config_path, Path)
+    assert adapter.config_path.name == "mcp.json"
+
+
+def test_cursor_implements_all_abstract_methods():
+    from truememory.hooks.adapters.base import CLIAdapter
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    abstract_methods = {
+        name for name, _ in inspect.getmembers(CLIAdapter)
+        if getattr(getattr(CLIAdapter, name, None), "__isabstractmethod__", False)
+    }
+    adapter = CursorAdapter()
+    for method_name in abstract_methods:
+        assert hasattr(adapter, method_name), f"Missing: {method_name}"
+
+
+# -- Detection --
+
+def test_detect_false_no_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    monkeypatch.setattr(cursor_mod, "_CURSOR_DIR", tmp_path / "nonexistent")
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    assert not adapter.detect()
+
+
+def test_detect_true_with_dir(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    cursor_dir = tmp_path / ".cursor"
+    cursor_dir.mkdir()
+    monkeypatch.setattr(cursor_mod, "_CURSOR_DIR", cursor_dir)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    assert adapter.detect()
+
+
+# -- MCP config (mcp.json) --
+
+def test_install_mcp_creates_config(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    mcp_path = tmp_path / "mcp.json"
+    monkeypatch.setattr(cursor_mod, "_MCP_CONFIG", mcp_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+
+    data = json.loads(mcp_path.read_text(encoding="utf-8"))
+    assert "truememory" in data["mcpServers"]
+    assert data["mcpServers"]["truememory"]["command"] == "/usr/bin/python3"
+    assert data["mcpServers"]["truememory"]["args"] == ["-m", "truememory.mcp_server"]
+
+
+def test_install_mcp_preserves_existing(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    mcp_path = tmp_path / "mcp.json"
+    mcp_path.write_text(json.dumps({
+        "mcpServers": {
+            "other-server": {"command": "other", "args": ["arg"]}
+        }
+    }), encoding="utf-8")
+    monkeypatch.setattr(cursor_mod, "_MCP_CONFIG", mcp_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+
+    data = json.loads(mcp_path.read_text(encoding="utf-8"))
+    assert "truememory" in data["mcpServers"]
+    assert "other-server" in data["mcpServers"]
+
+
+def test_install_mcp_idempotent(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    mcp_path = tmp_path / "mcp.json"
+    monkeypatch.setattr(cursor_mod, "_MCP_CONFIG", mcp_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    first = mcp_path.read_text(encoding="utf-8")
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    second = mcp_path.read_text(encoding="utf-8")
+    assert first == second
+
+
+# -- Hook config (hooks.json) --
+
+def test_install_hooks_creates_entries(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(hook_path.read_text(encoding="utf-8"))
+    assert data["version"] == 1
+    hooks = data["hooks"]
+    assert "sessionStart" in hooks
+    assert "stop" in hooks
+    assert "preCompact" in hooks
+    assert len(hooks["sessionStart"]) == 1
+    assert "truememory" in hooks["sessionStart"][0]["command"].lower()
+
+
+def test_install_hooks_has_version_key(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(hook_path.read_text(encoding="utf-8"))
+    assert "version" in data
+    assert data["version"] == 1
+
+
+def test_install_hooks_preserves_existing(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    hook_path.write_text(json.dumps({
+        "version": 1,
+        "hooks": {
+            "sessionStart": [
+                {"command": "my-custom-hook", "timeout": 5000}
+            ]
+        },
+    }), encoding="utf-8")
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(hook_path.read_text(encoding="utf-8"))
+    assert data["version"] == 1
+    assert len(data["hooks"]["sessionStart"]) == 2
+    assert data["hooks"]["sessionStart"][0]["command"] == "my-custom-hook"
+
+
+def test_install_hooks_preserves_existing_version(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    hook_path.write_text(json.dumps({
+        "version": 1,
+        "customSetting": "keep-me",
+    }), encoding="utf-8")
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(hook_path.read_text(encoding="utf-8"))
+    assert data["version"] == 1
+    assert data["customSetting"] == "keep-me"
+
+
+def test_install_hooks_idempotent(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    first = hook_path.read_text(encoding="utf-8")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    second = hook_path.read_text(encoding="utf-8")
+    assert first == second
+
+
+# -- Uninstall (must clean BOTH files) --
+
+def test_uninstall_removes_from_both_files(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    mcp_path = tmp_path / "mcp.json"
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_MCP_CONFIG", mcp_path)
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    assert adapter.is_configured()
+
+    adapter.uninstall()
+
+    mcp_data = json.loads(mcp_path.read_text(encoding="utf-8"))
+    assert "truememory" not in mcp_data.get("mcpServers", {})
+
+    hook_data = json.loads(hook_path.read_text(encoding="utf-8"))
+    hooks = hook_data.get("hooks", {})
+    for entries in hooks.values():
+        for h in entries:
+            assert "truememory" not in h.get("command", "").lower()
+
+
+def test_uninstall_preserves_other_entries(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    mcp_path = tmp_path / "mcp.json"
+    hook_path = tmp_path / "hooks.json"
+
+    mcp_path.write_text(json.dumps({
+        "mcpServers": {
+            "other-server": {"command": "other"},
+            "truememory": {"command": "python", "args": ["-m", "truememory.mcp_server"]},
+        }
+    }), encoding="utf-8")
+
+    hook_path.write_text(json.dumps({
+        "version": 1,
+        "hooks": {
+            "sessionStart": [
+                {"command": "my-hook", "timeout": 5000},
+                {"command": "/path/to/truememory/hooks/session_start.py", "timeout": 10000},
+            ]
+        },
+    }), encoding="utf-8")
+
+    monkeypatch.setattr(cursor_mod, "_MCP_CONFIG", mcp_path)
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.uninstall()
+
+    mcp_data = json.loads(mcp_path.read_text(encoding="utf-8"))
+    assert "other-server" in mcp_data["mcpServers"]
+    assert "truememory" not in mcp_data["mcpServers"]
+
+    hook_data = json.loads(hook_path.read_text(encoding="utf-8"))
+    assert hook_data["version"] == 1
+    assert len(hook_data["hooks"]["sessionStart"]) == 1
+    assert hook_data["hooks"]["sessionStart"][0]["command"] == "my-hook"
+
+
+# -- is_configured (checks BOTH files) --
+
+def test_is_configured_false_clean(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    monkeypatch.setattr(cursor_mod, "_MCP_CONFIG", tmp_path / "mcp.json")
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", tmp_path / "hooks.json")
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    assert not CursorAdapter().is_configured()
+
+
+def test_is_configured_true_with_mcp_only(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    mcp_path = tmp_path / "mcp.json"
+    monkeypatch.setattr(cursor_mod, "_MCP_CONFIG", mcp_path)
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", tmp_path / "hooks.json")
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    assert adapter.is_configured()
+
+
+def test_is_configured_true_with_hooks_only(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_MCP_CONFIG", tmp_path / "mcp.json")
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    assert adapter.is_configured()
+
+
+# -- verify (requires BOTH) --
+
+def test_verify_requires_both(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    mcp_path = tmp_path / "mcp.json"
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_MCP_CONFIG", mcp_path)
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    assert not adapter.verify()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+    assert adapter.verify()
+
+
+# -- System prompt --
+
+def test_system_prompt_path():
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    path = adapter.get_system_prompt_path()
+    assert path is not None
+    assert path.name == ".cursorrules"
+
+
+def test_system_prompt_content():
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    content = adapter.get_system_prompt_content()
+    assert "TrueMemory" in content
+    assert "truememory_search" in content
+
+
+# -- Build command --
+
+def test_build_command_with_user_and_db():
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    cmd = CursorAdapter._build_command(
+        "/usr/bin/python3",
+        Path("/path/to/session_start.py"),
+        user_id="alice",
+        db_path="/data/mem.db",
+    )
+    assert "/usr/bin/python3" in cmd
+    assert "session_start.py" in cmd
+    assert "--user" in cmd
+    assert "alice" in cmd
+    assert "--db" in cmd
+
+
+# -- Event names are camelCase --
+
+def test_hook_events_are_camelcase(tmp_path, monkeypatch):
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(hook_path.read_text(encoding="utf-8"))
+    event_names = list(data["hooks"].keys())
+    for name in event_names:
+        assert name[0].islower(), f"Event {name!r} should be camelCase, not PascalCase"

--- a/truememory/hooks/adapters/cursor.py
+++ b/truememory/hooks/adapters/cursor.py
@@ -1,0 +1,283 @@
+"""Cursor adapter — MCP config + JSON lifecycle hooks.
+
+Cursor uses TWO separate config files:
+- ~/.cursor/mcp.json for MCP server registration
+- ~/.cursor/hooks.json for hook registration (with "version": 1 top-level key)
+- camelCase event names: sessionStart, stop, preCompact
+"""
+from __future__ import annotations
+
+import json
+import shlex
+import shutil
+import sys
+from pathlib import Path
+
+from truememory.hooks.adapters.base import CLIAdapter
+
+_CURSOR_DIR = Path.home() / ".cursor"
+_MCP_CONFIG = _CURSOR_DIR / "mcp.json"
+_HOOK_CONFIG = _CURSOR_DIR / "hooks.json"
+
+_HOOK_EVENTS = {
+    "sessionStart": {
+        "script": "session_start.py",
+        "timeout": 10000,
+    },
+    "stop": {
+        "script": "stop.py",
+        "timeout": 5000,
+    },
+    "preCompact": {
+        "script": "compact.py",
+        "timeout": 5000,
+    },
+}
+
+_TRUEMEMORY_MARKER = "truememory"
+
+_SYSTEM_PROMPT_TEMPLATE = """\
+# TrueMemory — Persistent Memory
+
+TrueMemory is the **primary long-horizon memory** for this user. \
+It persists facts, preferences, decisions, and corrections across \
+sessions, projects, and machines.
+
+When the `truememory` MCP server is connected, follow these rules:
+
+## Auto-Recall (every session)
+- At the START of each conversation, call `truememory_search` with a \
+broad query about the user to load relevant memories before responding.
+- Before making recommendations, check TrueMemory for stored preferences.
+- When the user asks anything about past conversations or personal \
+facts — search TrueMemory first.
+
+## Auto-Store (during conversation)
+- When the user shares a personal preference, store it immediately \
+via `truememory_store`. Do not ask permission.
+- When an important decision is made, store it.
+- When the user corrects you, store the correction.
+- Write each memory as a clear, atomic statement.
+- Do NOT store full conversations, large code blocks, or transient \
+debugging context.
+
+## Background Processing
+- Memories are also extracted automatically from conversations via \
+background processing.
+- The stop hook captures the full transcript and runs deep extraction \
+after sessions end.
+- You do NOT need to store everything manually — focus on \
+in-conversation corrections and explicit preferences.
+"""
+
+
+class CursorAdapter(CLIAdapter):
+    """Adapter for Cursor IDE."""
+
+    @property
+    def name(self) -> str:
+        return "Cursor"
+
+    @property
+    def cli_id(self) -> str:
+        return "cursor"
+
+    @property
+    def config_path(self) -> Path:
+        return _MCP_CONFIG
+
+    def detect(self) -> bool:
+        return _CURSOR_DIR.is_dir() or shutil.which("cursor") is not None
+
+    def is_configured(self) -> bool:
+        return self._has_mcp_entry() or self._has_hook_entries()
+
+    def install_mcp(self, python_path: str | None = None) -> None:
+        py = python_path or sys.executable
+        _MCP_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+
+        existing: dict = {}
+        if _MCP_CONFIG.exists():
+            try:
+                existing = json.loads(_MCP_CONFIG.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                existing = {}
+
+        if not isinstance(existing, dict):
+            existing = {}
+
+        servers = existing.setdefault("mcpServers", {})
+        if not isinstance(servers, dict):
+            servers = {}
+            existing["mcpServers"] = servers
+
+        servers["truememory"] = {
+            "command": py,
+            "args": ["-m", "truememory.mcp_server"],
+        }
+
+        _MCP_CONFIG.write_text(
+            json.dumps(existing, indent=2),
+            encoding="utf-8",
+        )
+
+    def install_hooks(
+        self,
+        python_path: str | None = None,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> None:
+        py = python_path or sys.executable
+        hooks_dir = Path(__file__).parent.parent.parent / "ingest" / "hooks"
+
+        _HOOK_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+
+        existing: dict = {}
+        if _HOOK_CONFIG.exists():
+            try:
+                existing = json.loads(_HOOK_CONFIG.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                existing = {}
+
+        if not isinstance(existing, dict):
+            existing = {}
+
+        existing.setdefault("version", 1)
+
+        hooks = existing.setdefault("hooks", {})
+        if not isinstance(hooks, dict):
+            hooks = {}
+            existing["hooks"] = hooks
+
+        for event, info in _HOOK_EVENTS.items():
+            event_list = hooks.setdefault(event, [])
+            if not isinstance(event_list, list):
+                event_list = []
+                hooks[event] = event_list
+
+            if self._event_has_truememory(event_list):
+                continue
+
+            script_path = hooks_dir / info["script"]
+            cmd = self._build_command(py, script_path, user_id, db_path)
+            event_list.append({
+                "command": cmd,
+                "timeout": info["timeout"],
+            })
+
+        _HOOK_CONFIG.write_text(
+            json.dumps(existing, indent=2),
+            encoding="utf-8",
+        )
+
+    def uninstall(self) -> None:
+        self._remove_mcp_entry()
+        self._remove_hook_entries()
+
+    def verify(self) -> bool:
+        return self._has_mcp_entry() and self._has_hook_entries()
+
+    def get_system_prompt_path(self) -> Path | None:
+        return _CURSOR_DIR / ".cursorrules"
+
+    def get_system_prompt_content(self) -> str:
+        return _SYSTEM_PROMPT_TEMPLATE.strip()
+
+    # -- Private helpers --
+
+    @staticmethod
+    def _build_command(
+        python_path: str,
+        script_path: Path,
+        user_id: str = "",
+        db_path: str = "",
+    ) -> str:
+        parts: list[str] = [python_path, str(script_path)]
+        if user_id:
+            parts.extend(["--user", user_id])
+        if db_path:
+            parts.extend(["--db", db_path])
+        if sys.platform == "win32":
+            import subprocess as _sp
+            return _sp.list2cmdline(parts)
+        return " ".join(shlex.quote(p) for p in parts)
+
+    def _has_mcp_entry(self) -> bool:
+        if not _MCP_CONFIG.exists():
+            return False
+        try:
+            data = json.loads(_MCP_CONFIG.read_text(encoding="utf-8"))
+            return "truememory" in data.get("mcpServers", {})
+        except (json.JSONDecodeError, OSError):
+            return False
+
+    def _has_hook_entries(self) -> bool:
+        if not _HOOK_CONFIG.exists():
+            return False
+        try:
+            data = json.loads(_HOOK_CONFIG.read_text(encoding="utf-8"))
+            hooks = data.get("hooks", {})
+            if not isinstance(hooks, dict):
+                return False
+            for entries in hooks.values():
+                if not isinstance(entries, list):
+                    continue
+                if self._event_has_truememory(entries):
+                    return True
+        except (json.JSONDecodeError, OSError):
+            pass
+        return False
+
+    @staticmethod
+    def _event_has_truememory(entries: list) -> bool:
+        return any(
+            isinstance(h, dict)
+            and _TRUEMEMORY_MARKER in h.get("command", "").lower()
+            for h in entries
+        )
+
+    def _remove_mcp_entry(self) -> None:
+        if not _MCP_CONFIG.exists():
+            return
+        try:
+            data = json.loads(_MCP_CONFIG.read_text(encoding="utf-8"))
+            servers = data.get("mcpServers", {})
+            if isinstance(servers, dict) and "truememory" in servers:
+                del servers["truememory"]
+                _MCP_CONFIG.write_text(
+                    json.dumps(data, indent=2), encoding="utf-8",
+                )
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    def _remove_hook_entries(self) -> None:
+        if not _HOOK_CONFIG.exists():
+            return
+        try:
+            data = json.loads(_HOOK_CONFIG.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return
+
+        hooks = data.get("hooks", {})
+        if not isinstance(hooks, dict):
+            return
+
+        for event in list(hooks.keys()):
+            entries = hooks[event]
+            if not isinstance(entries, list):
+                continue
+            cleaned = [
+                h for h in entries
+                if not (
+                    isinstance(h, dict)
+                    and _TRUEMEMORY_MARKER in h.get("command", "").lower()
+                )
+            ]
+            if cleaned:
+                hooks[event] = cleaned
+            else:
+                del hooks[event]
+
+        _HOOK_CONFIG.write_text(
+            json.dumps(data, indent=2), encoding="utf-8",
+        )

--- a/truememory/hooks/registry.py
+++ b/truememory/hooks/registry.py
@@ -21,10 +21,11 @@ def _get_all_adapters() -> list[CLIAdapter]:
     """Return instances of all known CLI adapters."""
     from truememory.hooks.adapters.claude import ClaudeAdapter
     from truememory.hooks.adapters.codex import CodexAdapter
+    from truememory.hooks.adapters.cursor import CursorAdapter
     from truememory.hooks.adapters.kimi import KimiAdapter
     from truememory.hooks.adapters.hermes import HermesAdapter
     from truememory.hooks.adapters.openclaw import OpenClawAdapter
-    return [ClaudeAdapter(), CodexAdapter(), KimiAdapter(), HermesAdapter(), OpenClawAdapter()]
+    return [ClaudeAdapter(), CodexAdapter(), CursorAdapter(), KimiAdapter(), HermesAdapter(), OpenClawAdapter()]
 
 
 def detect_installed() -> list[CLIAdapter]:


### PR DESCRIPTION
Closes #234

## Summary
- Adds `CursorAdapter` in `truememory/hooks/adapters/cursor.py` — dual-file JSON adapter with MCP at `~/.cursor/mcp.json` and hooks at `~/.cursor/hooks.json` (with `"version": 1` top-level key)
- 25 new tests covering both config files, version key, camelCase event names, idempotency, additive merge, dual-file uninstall, and interface compliance
- Quickstart guide at `docs/setup-cursor.md`, compatibility matrix updated with Cursor column

## Test plan
- [x] All 25 new tests pass
- [x] All 59 existing adapter tests still pass (zero regressions)
- [x] `uvx ruff check` passes — no lint errors
- [x] Import chain verified — no circular imports
- [x] Interface compliance: all 11 CLIAdapter abstract methods implemented
- [x] Idempotent install: running twice produces identical config (both files)
- [x] Uninstall removes TrueMemory entries from BOTH mcp.json and hooks.json
- [x] Standalone hooks (`python -m truememory.ingest.hooks.session_start`) still importable
- [x] All 6 existing adapters (Claude, Codex, Kimi, Hermes, OpenClaw) still load in registry
- [x] Event names verified camelCase: sessionStart, stop, preCompact
- [x] hooks.json includes required `"version": 1` key