### PR TITLE
fix: search pipeline — limit clamping, RRF empty guard, separation vectors in embed_single

### DIFF
--- a/truememory/hybrid.py
+++ b/truememory/hybrid.py
@@ -74,11 +74,15 @@ def reciprocal_rank_fusion(
         - ``rrf_score`` -- the raw RRF score.
         - ``score`` -- alias for ``rrf_score`` (for API consistency).
     """
+    non_empty = [rl for rl in result_lists if rl]
+    if not non_empty:
+        return []
+
     # Accumulate scores and keep the best copy of each document.
     scores: dict[int, float] = defaultdict(float)
     best_doc: dict[int, dict] = {}
 
-    for result_list in result_lists:
+    for result_list in non_empty:
         for rank_0, doc in enumerate(result_list):
             doc_id = doc["id"]
             rank_1 = rank_0 + 1  # RRF uses 1-based ranks

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -690,7 +690,7 @@ def embed_single(conn: sqlite3.Connection, message_id: int, content: str) -> Non
                 (message_id, serialize_f32(sep_embedding)),
             )
     except Exception:
-        pass
+        logger.debug("Failed to create separation vector for message %d", message_id, exc_info=True)
     # Caller is responsible for committing
 
 

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -475,6 +475,8 @@ def search_vector(
         ``id``, ``content``, ``sender``, ``recipient``, ``timestamp``,
         ``category``, ``modality``, ``score``.
     """
+    limit = max(1, min(limit, 4096))
+
     if _query_blob is None:
         model = get_model()
         query_embedding = model.encode([query])[0]
@@ -623,13 +625,12 @@ def build_separation_vectors(
     for start in range(0, len(messages), _BATCH_SIZE):
         batch = messages[start : start + _BATCH_SIZE]
 
-        # Build separation texts with metadata
         texts = []
         ids = []
         for m in batch:
-            sep_text = (
-                f"{m.get('sender', '?')} to {m.get('recipient', '?')} "
-                f"on {m.get('timestamp', '?')[:10]}: {m['content']}"
+            sep_text = _build_sep_text(
+                m.get("sender", "?"), m.get("recipient", "?"),
+                m.get("timestamp", "?"), m["content"],
             )
             texts.append(sep_text)
             ids.append(m["id"])
@@ -648,9 +649,16 @@ def build_separation_vectors(
     return total
 
 
+def _build_sep_text(sender: str, recipient: str, timestamp: str, content: str) -> str:
+    return (
+        f"{sender or '?'} to {recipient or '?'} "
+        f"on {(timestamp or '?')[:10]}: {content}"
+    )
+
+
 def embed_single(conn: sqlite3.Connection, message_id: int, content: str) -> None:
     """
-    Embed a single message and insert it into ``vec_messages``.
+    Embed a single message and insert into ``vec_messages`` and ``vec_messages_sep``.
 
     This is the incremental counterpart to :func:`build_vectors` — it embeds
     one message at a time (~5ms with Model2Vec) for use with the production
@@ -668,6 +676,21 @@ def embed_single(conn: sqlite3.Connection, message_id: int, content: str) -> Non
         "INSERT INTO vec_messages(rowid, embedding) VALUES (?, ?)",
         (message_id, serialize_f32(embedding)),
     )
+
+    try:
+        row = conn.execute(
+            "SELECT sender, recipient, timestamp FROM messages WHERE id = ?",
+            (message_id,),
+        ).fetchone()
+        if row:
+            sep_text = _build_sep_text(row[0], row[1], row[2], content)
+            sep_embedding = model.encode([sep_text])[0]
+            conn.execute(
+                "INSERT INTO vec_messages_sep(rowid, embedding) VALUES (?, ?)",
+                (message_id, serialize_f32(sep_embedding)),
+            )
+    except Exception:
+        pass
     # Caller is responsible for committing
 
 
@@ -699,6 +722,8 @@ def search_vector_separation(
     Returns:
         List of result dicts sorted by descending similarity.
     """
+    limit = max(1, min(limit, 4096))
+
     if sender:
         model = get_model()
         query_text = f"{sender}: {query}"


### PR DESCRIPTION
## Summary
- **#261**: Clamp `search_vector()` and `search_vector_separation()` limit to [1, 4096] before sqlite-vec knn query — prevents OperationalError on negative/oversized limits
- **#262**: Filter empty lists in `reciprocal_rank_fusion()` before processing — prevents TypeError when one result source returns nothing
- **#244 (DANGER)**: Add separation vector embedding to `embed_single()` so incrementally-added messages get both completion and separation vectors (matching `build_vectors()` behavior). Centralized sep-text format in `_build_sep_text()` helper. Best-effort with debug logging on failure.

## DANGER Protocol (#244)
- 5-model pre-approval: **4/5 FIX** (Gemini, GPT-5.2, Grok, DeepSeek), 1 inconclusive (Codex)
- Post-fix recall test: **10/10 (100%)**
- Post-fix consensus: 2 APPROVE, 1 REJECT (bare pass → fixed to logging), 1 inconclusive
- All reviewer feedback addressed (logging added per Gemini)

## Test Results
- Full test suite: **571 passed, 1 skipped, 0 failures**
- Search recall: 10/10 after fix
- Pipeline parameters verified: k=60, _CANDIDATE_POOL=200, all models/dims unchanged

Fixes #261, #262, #244