### PR TITLE
fix: storage hardening — deprecate open(), add pragmas/indexes, validate content, add tests

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,173 @@
+"""Tests for truememory.storage — schema creation, CRUD, FTS sync, indexes."""
+
+import sqlite3
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+from truememory.storage import (
+    create_db,
+    insert_message,
+    delete_message,
+    get_message,
+    get_message_count,
+    bulk_replace_messages,
+    DEFAULT_BUSY_TIMEOUT_MS,
+)
+
+
+@pytest.fixture
+def db():
+    path = tempfile.mktemp(suffix=".db")
+    conn = create_db(path)
+    yield conn
+    conn.close()
+    Path(path).unlink(missing_ok=True)
+
+
+class TestCreateDb:
+    def test_creates_messages_table(self, db):
+        tables = {r[0] for r in db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()}
+        assert "messages" in tables
+
+    def test_creates_fts_table(self, db):
+        tables = {r[0] for r in db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()}
+        assert "messages_fts" in tables
+
+    def test_creates_entity_tables(self, db):
+        tables = {r[0] for r in db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()}
+        for t in ("entity_profiles", "fact_timeline", "summaries", "episodes"):
+            assert t in tables, f"Missing table: {t}"
+
+    def test_wal_mode_enabled(self, db):
+        mode = db.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "wal"
+
+    def test_busy_timeout_set(self, db):
+        timeout = db.execute("PRAGMA busy_timeout").fetchone()[0]
+        assert timeout == DEFAULT_BUSY_TIMEOUT_MS
+
+    def test_synchronous_normal(self, db):
+        val = db.execute("PRAGMA synchronous").fetchone()[0]
+        assert val == 1  # NORMAL = 1
+
+    def test_cache_size(self, db):
+        val = db.execute("PRAGMA cache_size").fetchone()[0]
+        assert val == -64000
+
+    def test_mmap_size(self, db):
+        val = db.execute("PRAGMA mmap_size").fetchone()[0]
+        assert val == 268435456
+
+    def test_indexes_created(self, db):
+        indexes = {r[1] for r in db.execute("PRAGMA index_list('messages')").fetchall()}
+        assert "idx_messages_sender" in indexes
+        assert "idx_messages_timestamp" in indexes
+
+
+class TestInsertMessage:
+    def test_basic_insert_and_retrieve(self, db):
+        msg = {"content": "hello world", "sender": "alice"}
+        new_id = insert_message(db, msg)
+        db.commit()
+        assert new_id > 0
+        row = get_message(db, new_id)
+        assert row is not None
+        assert row["content"] == "hello world"
+        assert row["sender"] == "alice"
+
+    def test_empty_content_rejected(self, db):
+        with pytest.raises(ValueError, match="content cannot be empty"):
+            insert_message(db, {"content": ""})
+
+    def test_whitespace_content_rejected(self, db):
+        with pytest.raises(ValueError, match="content cannot be empty"):
+            insert_message(db, {"content": "   "})
+
+    def test_fts_sync_on_insert(self, db):
+        insert_message(db, {"content": "unique_canary_token_xyz"})
+        db.commit()
+        rows = db.execute(
+            "SELECT rowid FROM messages_fts WHERE messages_fts MATCH ?",
+            ("unique_canary_token_xyz",),
+        ).fetchall()
+        assert len(rows) == 1
+
+    def test_sql_injection_safe(self, db):
+        msg = {"content": "Robert'); DROP TABLE messages;--"}
+        new_id = insert_message(db, msg)
+        db.commit()
+        row = get_message(db, new_id)
+        assert row["content"] == "Robert'); DROP TABLE messages;--"
+        assert get_message_count(db) >= 1
+
+
+class TestDeleteMessage:
+    def test_delete_existing(self, db):
+        new_id = insert_message(db, {"content": "to delete"})
+        db.commit()
+        assert delete_message(db, new_id) is True
+        assert get_message(db, new_id) is None
+
+    def test_delete_nonexistent(self, db):
+        assert delete_message(db, 999999) is False
+
+    def test_fts_cleaned_on_delete(self, db):
+        new_id = insert_message(db, {"content": "fts_delete_test_token"})
+        db.commit()
+        delete_message(db, new_id)
+        db.commit()
+        rows = db.execute(
+            "SELECT rowid FROM messages_fts WHERE messages_fts MATCH ?",
+            ("fts_delete_test_token",),
+        ).fetchall()
+        assert len(rows) == 0
+
+
+class TestBulkReplace:
+    def test_replaces_all(self, db):
+        insert_message(db, {"content": "old message"})
+        db.commit()
+        messages = [
+            {"content": "new msg 1", "sender": "a"},
+            {"content": "new msg 2", "sender": "b"},
+        ]
+        count = bulk_replace_messages(db, messages)
+        assert count == 2
+        assert get_message_count(db) == 2
+
+    def test_fts_synced_after_replace(self, db):
+        messages = [{"content": "bulk_unique_token_abc"}]
+        bulk_replace_messages(db, messages)
+        rows = db.execute(
+            "SELECT rowid FROM messages_fts WHERE messages_fts MATCH ?",
+            ("bulk_unique_token_abc",),
+        ).fetchall()
+        assert len(rows) == 1
+
+
+class TestConcurrentAccess:
+    def test_two_connections_read_write(self):
+        path = tempfile.mktemp(suffix=".db")
+        conn1 = create_db(path)
+        conn2 = sqlite3.connect(path, check_same_thread=False)
+        conn2.execute("PRAGMA journal_mode=WAL")
+        conn2.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
+
+        insert_message(conn1, {"content": "from conn1"})
+        conn1.commit()
+
+        row = conn2.execute("SELECT content FROM messages WHERE id = 1").fetchone()
+        assert row[0] == "from conn1"
+
+        conn1.close()
+        conn2.close()
+        Path(path).unlink(missing_ok=True)

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -27,6 +27,7 @@ import logging
 import os
 import re
 import threading
+import warnings
 import time
 import sqlite3
 from pathlib import Path
@@ -717,6 +718,12 @@ class TrueMemoryEngine:
 
         Returns self for chaining: ``engine = TrueMemoryEngine(path).open()``
         """
+        warnings.warn(
+            "open() is deprecated — production code uses _ensure_connection()/create_db()",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if not self.db_path.exists():
             raise FileNotFoundError(f"Database not found: {self.db_path}")
 
@@ -724,6 +731,9 @@ class TrueMemoryEngine:
         self.conn.row_factory = None  # Use default tuple rows
         self.conn.execute("PRAGMA journal_mode=WAL")
         self.conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
+        self.conn.execute("PRAGMA synchronous=NORMAL")
+        self.conn.execute("PRAGMA cache_size=-64000")
+        self.conn.execute("PRAGMA mmap_size=268435456")
 
         # Detect available tables
         tables = {

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -160,6 +160,13 @@ CREATE TABLE IF NOT EXISTS metadata (
 
 CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender);
 CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages(timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_episode_id ON messages(episode_id);
+CREATE INDEX IF NOT EXISTS idx_messages_category ON messages(category);
+CREATE INDEX IF NOT EXISTS idx_fact_timeline_subject ON fact_timeline(subject);
+CREATE INDEX IF NOT EXISTS idx_summaries_entity ON summaries(entity);
+CREATE INDEX IF NOT EXISTS idx_summaries_period ON summaries(period);
+CREATE INDEX IF NOT EXISTS idx_entity_relationships_a ON entity_relationships(entity_a);
+CREATE INDEX IF NOT EXISTS idx_landmark_events_timestamp ON landmark_events(timestamp);
 """
 
 
@@ -435,6 +442,9 @@ def insert_message(conn: sqlite3.Connection, msg: dict) -> int:
     Returns:
         The new row's integer ID.
     """
+    content = msg.get("content", "")
+    if not content or not content.strip():
+        raise ValueError("content cannot be empty or whitespace-only")
     cursor = conn.execute(
         """INSERT INTO messages
            (content, sender, recipient, timestamp, category, modality)


### PR DESCRIPTION
## Summary
- **#237**: Add DeprecationWarning to `engine.open()` — production uses `_ensure_connection()`/`create_db()`
- **#239**: Add 3 missing performance pragmas to `open()` matching `create_db()`: synchronous=NORMAL, cache_size=-64000, mmap_size=268435456
- **#240**: Add 7 performance indexes for queried columns (episode_id, category, fact_timeline.subject, summaries.entity/period, entity_relationships.entity_a, landmark_events.timestamp)
- **#241**: Add empty/whitespace content validation in `insert_message()` — raises ValueError
- **#238**: Create `tests/test_storage.py` with 20 tests covering schema, pragmas, CRUD, FTS sync, SQL injection, empty rejection, concurrent access

## Test Results
- Full suite: **591 passed, 1 skipped, 0 failures** (20 new tests)
- 34 DeprecationWarnings from test files calling open() — expected and desired

## Multi-Model Consensus
| Model | Verdict |
|-------|---------|
| Gemini 2.5 Pro | APPROVE |
| GPT-5.2 Pro | APPROVE (noted sync=NORMAL tradeoff — already default in create_db) |
| Grok 4.1 Fast | APPROVE |
| DeepSeek R1 | Inconclusive |

Pipeline parameters verified: busy_timeout=10000, synchronous=NORMAL, cache_size=-64000, mmap_size=268435456

Fixes #237, #238, #239, #240, #241