### PR TITLE
fix: adapter gaps — Claude uninstall, Hermes/Kimi prompts, OpenClaw JSON5 parser

### DIFF
--- a/truememory/hooks/adapters/base.py
+++ b/truememory/hooks/adapters/base.py
@@ -64,3 +64,23 @@ class CLIAdapter(ABC):
     @abstractmethod
     def get_system_prompt_content(self) -> str:
         """Return the TrueMemory system prompt content for this CLI."""
+
+
+def get_generic_system_prompt() -> str:
+    """Return the TrueMemory system prompt for non-Claude CLIs."""
+    template = Path(__file__).parent.parent.parent / "ingest" / "CLAUDE_TEMPLATE.md"
+    if template.exists():
+        try:
+            content = template.read_text(encoding="utf-8").strip()
+            content = content.replace("Claude Code's built-in auto-memory", "The host CLI's built-in memory")
+            content = content.replace("(`MEMORY.md` files under `~/.claude/projects/*/memory/`)", "")
+            return content
+        except OSError:
+            pass
+    return (
+        "# TrueMemory — Persistent Memory\n\n"
+        "You have access to TrueMemory MCP tools for persistent memory.\n"
+        "- Use `truememory_store` to save user facts, preferences, and decisions.\n"
+        "- Use `truememory_search` to recall stored memories before answering.\n"
+        "- Search TrueMemory FIRST on any 'do you remember' question.\n"
+    )

--- a/truememory/hooks/adapters/claude.py
+++ b/truememory/hooks/adapters/claude.py
@@ -84,6 +84,15 @@ class ClaudeAdapter(CLIAdapter):
         _run_install(args)
 
     def uninstall(self) -> None:
+        try:
+            import subprocess
+            subprocess.run(
+                ["claude", "mcp", "remove", "truememory"],
+                check=False,
+                capture_output=True,
+            )
+        except FileNotFoundError:
+            pass
         if not self.config_path.exists():
             return
         try:

--- a/truememory/hooks/adapters/hermes.py
+++ b/truememory/hooks/adapters/hermes.py
@@ -148,10 +148,11 @@ class HermesAdapter(CLIAdapter):
         return self._has_mcp_entry() and self._has_plugin_entries()
 
     def get_system_prompt_path(self) -> Path | None:
-        return None
+        return Path.home() / ".hermes" / "truememory_prompt.md"
 
     def get_system_prompt_content(self) -> str:
-        return ""
+        from truememory.hooks.adapters.base import get_generic_system_prompt
+        return get_generic_system_prompt()
 
     # -- Private helpers --
 

--- a/truememory/hooks/adapters/kimi.py
+++ b/truememory/hooks/adapters/kimi.py
@@ -138,10 +138,11 @@ class KimiAdapter(CLIAdapter):
         return self._has_mcp_entry() and self._has_hook_entries()
 
     def get_system_prompt_path(self) -> Path | None:
-        return None
+        return Path.home() / ".kimi" / "truememory_prompt.md"
 
     def get_system_prompt_content(self) -> str:
-        return ""
+        from truememory.hooks.adapters.base import get_generic_system_prompt
+        return get_generic_system_prompt()
 
     # -- Private helpers --
 

--- a/truememory/hooks/adapters/openclaw.py
+++ b/truememory/hooks/adapters/openclaw.py
@@ -47,9 +47,9 @@ def _read_json_config(path: Path) -> dict:
 def _strip_json5_comments(text: str) -> str:
     """Best-effort removal of single-line // comments and trailing commas.
 
-    Respects quoted strings — ``//`` inside ``"..."`` is preserved.
+    Uses a state-aware parser — ``//`` and trailing commas inside
+    ``"..."`` are preserved.
     """
-    import re
     result: list[str] = []
     i = 0
     while i < len(text):
@@ -68,12 +68,19 @@ def _strip_json5_comments(text: str) -> str:
         elif text[i:i+2] == '//':
             nl = text.find('\n', i)
             i = nl if nl != -1 else len(text)
+        elif text[i] == ',':
+            j = i + 1
+            while j < len(text) and text[j] in ' \t\n\r':
+                j += 1
+            if j < len(text) and text[j] in '}]':
+                i = j
+            else:
+                result.append(text[i])
+                i += 1
         else:
             result.append(text[i])
             i += 1
-    stripped = ''.join(result)
-    stripped = re.sub(r',(\s*[}\]])', r'\1', stripped)
-    return stripped
+    return ''.join(result)
 
 
 class OpenClawAdapter(CLIAdapter):

--- a/truememory/hooks/adapters/openclaw.py
+++ b/truememory/hooks/adapters/openclaw.py
@@ -45,12 +45,35 @@ def _read_json_config(path: Path) -> dict:
 
 
 def _strip_json5_comments(text: str) -> str:
-    """Best-effort removal of single-line // comments and trailing commas."""
+    """Best-effort removal of single-line // comments and trailing commas.
+
+    Respects quoted strings — ``//`` inside ``"..."`` is preserved.
+    """
     import re
-    text = re.sub(r'(?m)^\s*//.*$', '', text)
-    text = re.sub(r'//[^\n]*', '', text)
-    text = re.sub(r',(\s*[}\]])', r'\1', text)
-    return text
+    result: list[str] = []
+    i = 0
+    while i < len(text):
+        if text[i] == '"':
+            j = i + 1
+            while j < len(text):
+                if text[j] == '\\':
+                    j += 2
+                    continue
+                if text[j] == '"':
+                    j += 1
+                    break
+                j += 1
+            result.append(text[i:j])
+            i = j
+        elif text[i:i+2] == '//':
+            nl = text.find('\n', i)
+            i = nl if nl != -1 else len(text)
+        else:
+            result.append(text[i])
+            i += 1
+    stripped = ''.join(result)
+    stripped = re.sub(r',(\s*[}\]])', r'\1', stripped)
+    return stripped
 
 
 class OpenClawAdapter(CLIAdapter):


### PR DESCRIPTION
## Summary
- **#252**: Add `claude mcp remove truememory` to `ClaudeAdapter.uninstall()` so MCP server registration is cleaned up alongside hook removal
- **#253**: Add system prompts to Hermes and Kimi adapters via shared `get_generic_system_prompt()` in base.py — adapts CLAUDE_TEMPLATE.md with fallback
- **#254**: Rewrite `_strip_json5_comments()` in openclaw.py with a fully string-aware state machine parser — preserves URLs and `",}"` patterns inside quoted strings while stripping actual `//` comments and trailing commas

## Multi-Model Consensus
| Model | Verdict |
|-------|---------|
| Gemini 2.5 Pro | APPROVE |
| GPT-5.2 Pro | REJECT → fixed (trailing comma regex not string-aware) |
| Grok 4.1 Fast | Needs files |

Review feedback addressed: trailing comma removal moved into state machine (commit 2).

## Test Results
- URL preservation, comment removal, trailing comma, `",}"` inside strings all verified
- No pipeline code touched

Fixes #252, #253, #254