### PR TITLE
fix: hooks + platform — backlog drain, email capture, version race, Windows installer, auto-recall

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -28,7 +28,22 @@ function Ok($msg)   { Write-Host "[truememory] $msg" -ForegroundColor Green }
 function Warn($msg) { Write-Host "[truememory] $msg" -ForegroundColor Red }
 function Die($msg)  { Warn "error: $msg"; exit 1 }
 
+# ---------- execution policy check ----------
+$policy = Get-ExecutionPolicy -Scope CurrentUser
+if ($policy -eq "Restricted" -or $policy -eq "Undefined") {
+    $machinePolicy = Get-ExecutionPolicy -Scope LocalMachine
+    if ($machinePolicy -eq "Restricted" -or $machinePolicy -eq "Undefined") {
+        Warn "PowerShell execution policy is '$policy'. Scripts may be blocked."
+        Warn "Run this to fix: Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned"
+        Warn "Then re-run the installer."
+        exit 1
+    }
+}
+
 # ---------- main ----------
+$stepsDone = 0
+function Step-Done { $script:stepsDone++ }
+
 $TRUEMEMORY_PY = if ($env:TRUEMEMORY_PY) { $env:TRUEMEMORY_PY } else { "3.12" }
 $TRUEMEMORY_SOURCE = if ($env:TRUEMEMORY_SOURCE) { $env:TRUEMEMORY_SOURCE } else { "" }
 

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -31,6 +31,8 @@ log = logging.getLogger(__name__)
 
 MEMORY_LIMIT = int(os.environ.get("TRUEMEMORY_RECALL_LIMIT", "25"))
 ONBOARDED_MARKER = Path.home() / ".truememory" / ".onboarded"
+BACKLOG_DIR = Path.home() / ".truememory" / "backlog"
+_DRAIN_CAP = 3
 
 BANNER = r"""
 ████████╗██████╗ ██╗   ██╗███████╗    ███╗   ███╗███████╗███╗   ███╗ ██████╗ ██████╗ ██╗   ██╗
@@ -88,9 +90,16 @@ def _check_for_update() -> str:
         if not update_path.exists():
             return ""
         data = json.loads(update_path.read_text(encoding="utf-8"))
-        # Delete the file so we only show the notice once
-        update_path.unlink(missing_ok=True)
+        if data.get("shown"):
+            return ""
         if data.get("update_available"):
+            data["shown"] = True
+            try:
+                tmp = update_path.with_suffix(".tmp")
+                tmp.write_text(json.dumps(data), encoding="utf-8")
+                tmp.rename(update_path)
+            except Exception:
+                pass
             return (
                 "<truememory-update>\n"
                 f"A new version of TrueMemory is available: v{data.get('latest_version', '?')}. "
@@ -125,8 +134,47 @@ def _check_email_needed() -> str:
     return ""
 
 
+def _drain_backlog() -> None:
+    """Process queued sessions from the backlog directory."""
+    if not BACKLOG_DIR.exists():
+        return
+    try:
+        markers = sorted(BACKLOG_DIR.glob("*.json"))[:_DRAIN_CAP]
+    except Exception:
+        return
+    for marker_path in markers:
+        try:
+            data = json.loads(marker_path.read_text(encoding="utf-8"))
+            transcript = data.get("transcript_path", "")
+            if not transcript or not Path(transcript).exists():
+                marker_path.unlink(missing_ok=True)
+                continue
+            import subprocess
+            cmd = [
+                sys.executable, "-m", "truememory.ingest.cli", "ingest",
+                "--transcript", transcript,
+                "--session-id", data.get("session_id", "unknown"),
+            ]
+            if data.get("user_id"):
+                cmd.extend(["--user", data["user_id"]])
+            if data.get("db_path"):
+                cmd.extend(["--db", data["db_path"]])
+            subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            marker_path.unlink(missing_ok=True)
+            log.info("Drained backlog session: %s", data.get("session_id", "?"))
+        except Exception as e:
+            log.debug("Failed to drain backlog entry %s: %s", marker_path.name, e)
+
+
 def main():
     args = _parse_args()
+
+    _drain_backlog()
 
     try:
         input_data = json.load(sys.stdin)

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -65,6 +65,86 @@ def _parse_args() -> argparse.Namespace:
     return args
 
 
+import re
+
+_EMAIL_RE = re.compile(r'[\w.+-]+@[\w-]+\.[\w.-]+')
+
+_RECALL_RE = re.compile(
+    r'\b(?:what(?:\'s|\s+is|\s+was|\s+are|\s+were|\s+did|\s+do)\b'
+    r'|who\s+(?:is|was|did)\b'
+    r'|when\s+(?:is|was|did)\b'
+    r'|where\s+(?:is|was|did|does)\b'
+    r'|do\s+you\s+remember\b'
+    r'|did\s+(?:we|i|you)\b'
+    r'|what\'s\s+my\b'
+    r'|what\s+do\s+I\b'
+    r'|remind\s+me\b'
+    r'|have\s+(?:we|i)\s+(?:ever|already)\b'
+    r'|my\s+(?:favorite|preferred|usual)\b)',
+    re.IGNORECASE,
+)
+
+_CODE_RE = re.compile(
+    r'\b(?:function|class|def|import|const|let|var|return|console\.log|print\(|TypeError|SyntaxError)\b'
+    r'|```'
+    r'|(?:what\s+does\s+(?:this|the)\s+(?:function|code|class|method)\b)',
+    re.IGNORECASE,
+)
+
+
+def _detect_recall(prompt: str) -> bool:
+    if len(prompt) < 10 or len(prompt) > 500:
+        return False
+    if _CODE_RE.search(prompt):
+        return False
+    return bool(_RECALL_RE.search(prompt))
+
+
+def _try_auto_recall(prompt: str, user_id: str, db_path: str) -> str | None:
+    """Search TrueMemory if prompt looks like a recall question."""
+    if not _detect_recall(prompt):
+        return None
+    try:
+        from truememory.client import Memory
+        m = Memory(path=db_path or None)
+        results = m.search(prompt, user_id=user_id or None, limit=5)
+        if not results:
+            return None
+        lines = []
+        for r in results[:5]:
+            content = r.get("content", "")[:200]
+            lines.append(f"- {content}")
+        return (
+            "<truememory-recall>\n"
+            "Relevant memories for this question:\n"
+            + "\n".join(lines)
+            + "\n</truememory-recall>"
+        )
+    except Exception:
+        return None
+
+
+def _try_capture_email(prompt: str) -> None:
+    """If the user typed an email and config has no email, save it."""
+    try:
+        config_path = Path.home() / ".truememory" / "config.json"
+        if not config_path.exists():
+            return
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        if config.get("email"):
+            return
+        match = _EMAIL_RE.search(prompt)
+        if not match:
+            return
+        email = match.group(0)
+        config["email"] = email
+        tmp = config_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(config, indent=2), encoding="utf-8")
+        tmp.rename(config_path)
+    except Exception:
+        pass
+
+
 def main():
     args = _parse_args()
 
@@ -85,6 +165,8 @@ def main():
         _prune_old_buffers()
     except Exception:
         pass  # Never crash the hook
+
+    _try_capture_email(prompt)
 
     # Incremental extraction: if enough time has passed since the last
     # extraction, trigger background ingestion of the transcript so far.
@@ -109,6 +191,10 @@ def main():
                     mark_extracted()
         except Exception:
             pass  # Never crash the hook
+
+    recall_context = _try_auto_recall(prompt, args.user, args.db)
+    if recall_context:
+        print(json.dumps({"additionalContext": recall_context}))
 
 
 def buffer_message(session_id: str, prompt: str):

--- a/truememory/telemetry.py
+++ b/truememory/telemetry.py
@@ -78,7 +78,9 @@ def init(config: dict) -> dict | None:
         if info and info.get("update_available"):
             try:
                 _p = Path.home() / ".truememory" / ".update_available"
-                _p.write_text(json.dumps(info), encoding="utf-8")
+                _tmp = _p.with_suffix(".tmp")
+                _tmp.write_text(json.dumps(info), encoding="utf-8")
+                _tmp.rename(_p)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- **#246 CRITICAL**: Implement backlog drain in session_start.py — processes up to 3 queued sessions at startup
- **#249 MEDIUM**: Add regex email capture fallback in user_prompt_submit.py — extracts email from messages when config has none
- **#250 MEDIUM**: Fix version notification race — atomic writes + "shown" flag instead of one-shot deletion
- **#251 MEDIUM**: Add execution policy check to install.ps1 — prevents silent failure on fresh Windows 11
- **#231 ENHANCEMENT**: Implement UserPromptSubmit auto-recall — detects recall-shaped prompts, searches TrueMemory, injects results as additionalContext. Negative filter for code questions.

## Pipeline Parameters
No search pipeline code touched. All fixes are in hooks/platform layer.

Fixes #246, #249, #250, #251, #231