### PR TITLE
fix: resolve ruff lint errors breaking CI

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2,7 +2,6 @@
 
 import sqlite3
 import tempfile
-import threading
 from pathlib import Path
 
 import pytest

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -24,6 +24,7 @@ Output: None (silent hook, no additionalContext)
 import argparse
 import json
 import os
+import re
 import sys
 import time
 from datetime import datetime, timezone
@@ -64,8 +65,6 @@ def _parse_args() -> argparse.Namespace:
     args, _ = p.parse_known_args()
     return args
 
-
-import re
 
 _EMAIL_RE = re.compile(r'[\w.+-]+@[\w-]+\.[\w.-]+')
 


### PR DESCRIPTION
## Summary
- Remove unused `threading` import in `tests/test_storage.py` (ruff F401)
- Move `import re` to top of file in `truememory/ingest/hooks/user_prompt_submit.py` (ruff E402)

These two lint errors have been failing CI on every recent push to main.

## Test plan
- [ ] CI passes (ruff check + pytest)