### PR TITLE
Fix Sprint v2: Phases 1-4 (#302, #308, #294, #272, #273)

### DIFF
--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -659,11 +659,15 @@ class TrueMemoryEngine:
             if content is not None and self._has_vectors:
                 try:
                     from truememory.vector_search import embed_single
-                    # Remove old embedding, insert new
+                    # Remove old embeddings from both vector tables, insert new
                     try:
                         self.conn.execute("DELETE FROM vec_messages WHERE rowid = ?", (memory_id,))
                     except Exception:
                         logger.debug("Failed to delete old vector embedding for message %d", memory_id, exc_info=True)
+                    try:
+                        self.conn.execute("DELETE FROM vec_messages_sep WHERE rowid = ?", (memory_id,))
+                    except Exception:
+                        logger.debug("Failed to delete old sep vector for message %d", memory_id, exc_info=True)
                     embed_single(self.conn, memory_id, content)
                 except Exception:
                     logger.warning("Vector embedding failed for message %d", memory_id, exc_info=True)

--- a/truememory/ingest/CLAUDE_TEMPLATE.md
+++ b/truememory/ingest/CLAUDE_TEMPLATE.md
@@ -8,6 +8,15 @@ Claude Code's built-in auto-memory (`MEMORY.md` files under `~/.claude/projects/
 
 When the `truememory` MCP server is connected, follow these rules:
 
+## CRITICAL: Anti-Cannibalization Rule
+
+MEMORY.md may contain personal facts that were cached from earlier sessions. **Do not answer personal or user-specific questions using MEMORY.md alone.** Verify via `truememory_search` whenever a personal fact would affect your response. TrueMemory has orders of magnitude more memories than MEMORY.md, with full temporal tracking, contradiction detection, and salience scoring. MEMORY.md is a lossy, potentially stale cache; TrueMemory is the source of truth.
+
+- For **personal/user-specific questions** (preferences, history, "do you remember", facts about the user): always call `truememory_search` to verify, even if you see a relevant fact in MEMORY.md or context.
+- For **technical/coding questions** with no personal dimension: no TrueMemory search needed — use normal tools.
+- **If MEMORY.md conflicts with TrueMemory**, prefer TrueMemory. If the conflict is high-impact, ask the user to confirm.
+- **Do not write personal facts, preferences, or PII into MEMORY.md.** Store them via `truememory_store` only. MEMORY.md should contain only operational and project notes.
+
 ## Auto-Recall (every session)
 - At the START of each conversation, call `truememory_search` with a broad query about the user (e.g. "user preferences and context") to load relevant memories before responding.
 - Before making recommendations, check TrueMemory for stored preferences.

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -89,6 +89,14 @@ def main():
     p_upgrade.add_argument("tier", choices=["edge", "base", "pro"], help="Target tier")
     p_upgrade.add_argument("--force", action="store_true", help="Re-embed even if tier is unchanged")
 
+    # --- migrate-memory command ---
+    p_migrate = sub.add_parser("migrate-memory", help="Migrate MEMORY.md facts into TrueMemory")
+    p_migrate.add_argument("--path", default=None, help="Path to MEMORY.md (auto-detected if not specified)")
+    p_migrate.add_argument("--db", default=None, help="Path to truememory database")
+    p_migrate.add_argument("--dry-run", action="store_true", help="Print facts without storing")
+    p_migrate.add_argument("--no-backup", action="store_true", help="Skip backup of original MEMORY.md")
+    p_migrate.add_argument("--slim", action="store_true", help="Replace MEMORY.md with slim template after migration")
+
     args = parser.parse_args()
 
     if args.command == "ingest":
@@ -111,6 +119,8 @@ def main():
         _run_setup(args)
     elif args.command == "upgrade-tier":
         _run_upgrade_tier(args)
+    elif args.command == "migrate-memory":
+        _run_migrate_memory(args)
     else:
         parser.print_help()
 
@@ -620,6 +630,45 @@ def _run_upgrade_tier(args):
             print()
             print("\033[33mPro tier works without an API key, but HyDE search is disabled.")
             print("Run truememory-ingest setup to add one, or set ANTHROPIC_API_KEY.\033[0m")
+
+
+def _run_migrate_memory(args):
+    """Migrate MEMORY.md facts into TrueMemory."""
+    from truememory.ingest.migrate_memory_md import migrate, auto_detect_memory_md
+
+    if args.path:
+        memory_md_path = Path(args.path)
+    else:
+        memory_md_path = auto_detect_memory_md()
+        if memory_md_path is None:
+            print("ERROR: Could not auto-detect MEMORY.md path.", file=sys.stderr)
+            print("Specify --path explicitly.", file=sys.stderr)
+            sys.exit(1)
+
+    if not memory_md_path.exists():
+        print(f"ERROR: MEMORY.md not found at {memory_md_path}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Migrating facts from: {memory_md_path}")
+
+    result = migrate(
+        memory_md_path=memory_md_path,
+        db_path=args.db,
+        dry_run=args.dry_run,
+        backup=not args.no_backup,
+        write_slim_template=args.slim,
+    )
+
+    if args.dry_run:
+        print(f"\nDry run complete. Would migrate {result.get('migrated', 0)} facts.")
+    else:
+        print(f"\nMigration complete:")
+        print(f"  Migrated:   {result.get('migrated', 0)}")
+        print(f"  Skipped:    {result.get('skipped', 0)}")
+        print(f"  Duplicates: {result.get('duplicates', 0)}")
+        print(f"  Errors:     {result.get('errors', 0)}")
+        if result.get('backup_path'):
+            print(f"  Backup:     {result['backup_path']}")
 
 
 def _run_install(args):

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -662,7 +662,7 @@ def _run_migrate_memory(args):
     if args.dry_run:
         print(f"\nDry run complete. Would migrate {result.get('migrated', 0)} facts.")
     else:
-        print(f"\nMigration complete:")
+        print("\nMigration complete:")
         print(f"  Migrated:   {result.get('migrated', 0)}")
         print(f"  Skipped:    {result.get('skipped', 0)}")
         print(f"  Duplicates: {result.get('duplicates', 0)}")

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -151,10 +151,12 @@ def _drain_backlog() -> None:
                 continue
             import subprocess
             cmd = [
-                sys.executable, "-m", "truememory.ingest.cli", "ingest",
-                "--transcript", transcript,
-                "--session-id", data.get("session_id", "unknown"),
+                sys.executable, "-m", "truememory.ingest.cli",
+                "ingest", transcript,
             ]
+            session_id = data.get("session_id", "")
+            if session_id:
+                cmd.extend(["--session", session_id])
             if data.get("user_id"):
                 cmd.extend(["--user", data["user_id"]])
             if data.get("db_path"):

--- a/truememory/ingest/migrate_memory_md.py
+++ b/truememory/ingest/migrate_memory_md.py
@@ -1,0 +1,182 @@
+"""
+Migrate MEMORY.md facts into TrueMemory.
+
+Parses Claude Code's ~/.claude/projects/*/memory/MEMORY.md into atomic
+facts and stores them via Memory().add(). The encoding gate handles
+deduplication automatically.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+
+_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+_PURE_LINK_RE = re.compile(r"^\s*-\s*\[([^\]]*)\]\([^)]*\)\s*$")
+_BULLET_RE = re.compile(r"^(\s*)- (.+)$")
+_HEADER_RE = re.compile(r"^##\s+(.+)$")
+_CODE_FENCE_RE = re.compile(r"^```")
+
+_SLIM_TEMPLATE = """\
+# Memory
+
+This file is for **session-specific working notes only** — task state,
+scratch plans, and conversation context. Long-horizon user facts live in
+TrueMemory (search with `truememory_search`).
+"""
+
+
+def auto_detect_memory_md() -> Path | None:
+    """Find MEMORY.md in the standard Claude Code memory directories."""
+    candidates = [
+        Path.home() / ".claude" / "projects",
+    ]
+    for base in candidates:
+        if not base.exists():
+            continue
+        for memory_md in sorted(base.rglob("MEMORY.md")):
+            if memory_md.stat().st_size > 0:
+                return memory_md
+    return None
+
+
+def parse_memory_md(path: Path) -> list[dict]:
+    """Parse a MEMORY.md file into a list of atomic facts.
+
+    Returns list of dicts with keys: content, category, source_header.
+    """
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    facts: list[dict] = []
+    current_header = ""
+    in_code_block = False
+    parent_bullet: str | None = None
+
+    for line in lines:
+        if _CODE_FENCE_RE.match(line):
+            in_code_block = not in_code_block
+            continue
+
+        if in_code_block:
+            continue
+
+        header_match = _HEADER_RE.match(line)
+        if header_match:
+            current_header = header_match.group(1).strip()
+            parent_bullet = None
+            continue
+
+        if not line.strip():
+            parent_bullet = None
+            continue
+
+        if line.startswith(">"):
+            continue
+
+        if line.startswith("# ") and not line.startswith("## "):
+            continue
+
+        if _PURE_LINK_RE.match(line):
+            continue
+
+        bullet_match = _BULLET_RE.match(line)
+        if not bullet_match:
+            continue
+
+        indent = bullet_match.group(1)
+        raw_text = bullet_match.group(2).strip()
+
+        if not raw_text:
+            continue
+
+        content = _LINK_RE.sub(r"\1", raw_text)
+        content = content.strip()
+
+        if not content:
+            continue
+
+        is_nested = len(indent) >= 2
+
+        if is_nested and parent_bullet:
+            fact_text = f"{current_header}: {parent_bullet} — {content}"
+        elif current_header:
+            fact_text = f"{current_header}: {content}"
+            parent_bullet = content
+        else:
+            fact_text = content
+            parent_bullet = content
+
+        if not is_nested:
+            parent_bullet = content
+
+        facts.append({
+            "content": fact_text,
+            "category": current_header,
+            "source_header": current_header,
+        })
+
+    return facts
+
+
+def migrate(
+    memory_md_path: Path,
+    db_path: str | None = None,
+    dry_run: bool = False,
+    backup: bool = True,
+    write_slim_template: bool = False,
+) -> dict:
+    """Migrate MEMORY.md facts into TrueMemory.
+
+    Returns dict with keys: migrated, skipped, duplicates, errors, backup_path.
+    """
+    facts = parse_memory_md(memory_md_path)
+
+    result = {
+        "migrated": 0,
+        "skipped": 0,
+        "duplicates": 0,
+        "errors": 0,
+        "backup_path": None,
+    }
+
+    if not facts:
+        return result
+
+    if backup and not dry_run:
+        backup_path = memory_md_path.with_suffix(".md.bak")
+        shutil.copy2(memory_md_path, backup_path)
+        result["backup_path"] = str(backup_path)
+
+    if dry_run:
+        for fact in facts:
+            content = fact["content"]
+            category = fact["category"]
+            print(f"  [{category}] {content}")
+        result["migrated"] = len(facts)
+        return result
+
+    from truememory import Memory
+
+    kwargs = {}
+    if db_path:
+        kwargs["path"] = db_path
+    mem = Memory(**kwargs)
+
+    for fact in facts:
+        try:
+            mem.add(
+                content=fact["content"],
+                user_id="MEMORY.md migration",
+            )
+            result["migrated"] += 1
+        except Exception as e:
+            print(f"  ERROR storing fact: {e}")
+            result["errors"] += 1
+
+    if write_slim_template:
+        memory_md_path.write_text(_SLIM_TEMPLATE, encoding="utf-8")
+
+    return result


### PR DESCRIPTION
## Summary

Fix Sprint v2 — first 4 phases from the Hunter v5 triage. Addresses 5 issues (2 CRITICAL, 2 HIGH, 1 feature):

- **#302 (CRITICAL):** Backlog drain CLI argument format was wrong — `_drain_backlog()` passed `--transcript` (flag) but cli.py expects positional arg. 394 transcripts were stuck unprocessed.
- **#308 (HIGH):** `update()` left stale FTS index entries — old content remained searchable after update.
- **#294 (HIGH):** `update()` left stale separation vectors in `vec_messages_sep` — v4 claimed sqlite-vec implicit upsert handled this, but Hunters 5A and 5C independently confirmed it was wrong.
- **#272 (CRITICAL):** MEMORY.md cannibalization — Claude reads 200+ lines of facts from MEMORY.md instead of calling TrueMemory MCP tools. Added anti-cannibalization rule to CLAUDE_TEMPLATE.md.
- **#273 (HIGH):** New `migrate-memory` CLI subcommand that parses MEMORY.md bullet points into TrueMemory via `Memory().add()`, with encoding gate dedup.

## Closes

Closes #302, closes #308, closes #294, closes #272, closes #273
Also closes #289 (duplicate of #302)

## Test plan

- [ ] `python -m pytest tests/ -v --tb=short` passes (baseline: 591 pass, 1 skip)
- [ ] Search recall 10/10 verified
- [ ] Sacred parameters 24/24 unchanged
- [ ] Backlog drain processes files with corrected CLI args
- [ ] `update()` no longer leaves ghost FTS entries or stale sep vectors
- [ ] CLAUDE_TEMPLATE.md includes anti-cannibalization rule
- [ ] `migrate-memory` CLI parses MEMORY.md and stores facts