### PR TITLE
fix: flock-based spawn cap, drain race, and 6 hunter-v5 issues

### DIFF
--- a/scripts/populate_backlog_stress_test.py
+++ b/scripts/populate_backlog_stress_test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Populate ~/.truememory/backlog/ with markers pointing to the last N session
+transcripts from ~/.claude/projects/. Used to stress-test the spawn cap fix.
+
+Usage:
+    python scripts/populate_backlog_stress_test.py [--count 300] [--dry-run]
+"""
+import argparse
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--count", type=int, default=300)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    claude_projects = Path.home() / ".claude" / "projects"
+    backlog_dir = Path.home() / ".truememory" / "backlog"
+
+    transcripts = sorted(
+        (p for p in claude_projects.rglob("*.jsonl") if p.stat().st_size > 1024),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )[:args.count]
+
+    print(f"Found {len(transcripts)} transcripts (requested {args.count})")
+
+    if not args.dry_run:
+        backlog_dir.mkdir(parents=True, exist_ok=True)
+
+    created = 0
+    for t in transcripts:
+        session_id = t.stem
+        marker = {
+            "transcript_path": str(t),
+            "session_id": session_id,
+            "user_id": "",
+            "db_path": "",
+            "queued_at": datetime.now(timezone.utc).isoformat(),
+            "reason": "stress_test_backfill",
+        }
+        marker_path = backlog_dir / f"{session_id}.json"
+        if args.dry_run:
+            print(f"  [dry-run] would create {marker_path.name}")
+        else:
+            marker_path.write_text(json.dumps(marker), encoding="utf-8")
+        created += 1
+
+    print(f"{'Would create' if args.dry_run else 'Created'} {created} backlog markers in {backlog_dir}")
+    if not args.dry_run:
+        print(f"\nNow re-enable TrueMemory hooks and watch:")
+        print(f"  watch -n1 'pgrep -f truememory.ingest.cli | wc -l'")
+        print(f"  # Should stay <= SPAWN_CAP (default 2)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ingest/test_stop_hook_safety.py
+++ b/tests/ingest/test_stop_hook_safety.py
@@ -22,13 +22,17 @@ from pathlib import Path
 
 
 def test_spawn_cap_blocks_when_at_cap(monkeypatch, tmp_path):
-    """When `_count_active_ingest_processes()` reports >= SPAWN_CAP,
-    `_run_background_ingestion` must NOT call Popen and must write a
-    backlog marker explaining why."""
+    """When spawn_gate reports at-cap, `_run_background_ingestion` must NOT
+    call Popen and must write a backlog marker explaining why."""
+    from contextlib import contextmanager
     from truememory.ingest.hooks import stop as stop_mod
+    from truememory.hooks import core as core_mod
 
-    monkeypatch.setattr(stop_mod, "SPAWN_CAP", 2)
-    monkeypatch.setattr(stop_mod, "_count_active_ingest_processes", lambda: 2)
+    @contextmanager
+    def _gate_at_cap():
+        yield False
+
+    monkeypatch.setattr(core_mod, "spawn_gate", _gate_at_cap)
     monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
     monkeypatch.setattr(stop_mod, "TRACE_DIR", tmp_path / "traces")
     monkeypatch.setattr(stop_mod, "LOG_DIR", tmp_path / "logs")
@@ -37,7 +41,7 @@ def test_spawn_cap_blocks_when_at_cap(monkeypatch, tmp_path):
 
     def _record_popen(*args, **kwargs):
         popen_calls.append((args, kwargs))
-        return type("DummyProc", (), {"pid": 0})()
+        return type("DummyProc", (), {"pid": 0, "__enter__": lambda s: s, "__exit__": lambda *a: None})()
 
     monkeypatch.setattr(subprocess, "Popen", _record_popen)
 
@@ -60,10 +64,15 @@ def test_spawn_cap_blocks_when_at_cap(monkeypatch, tmp_path):
 
 def test_spawn_cap_allows_spawn_under_cap(monkeypatch, tmp_path):
     """Under the cap, Popen must be called and no backlog marker written."""
+    from contextlib import contextmanager
     from truememory.ingest.hooks import stop as stop_mod
+    from truememory.hooks import core as core_mod
 
-    monkeypatch.setattr(stop_mod, "SPAWN_CAP", 4)
-    monkeypatch.setattr(stop_mod, "_count_active_ingest_processes", lambda: 1)
+    @contextmanager
+    def _gate_under_cap():
+        yield True
+
+    monkeypatch.setattr(core_mod, "spawn_gate", _gate_under_cap)
     monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
     monkeypatch.setattr(stop_mod, "TRACE_DIR", tmp_path / "traces")
     monkeypatch.setattr(stop_mod, "LOG_DIR", tmp_path / "logs")
@@ -73,7 +82,7 @@ def test_spawn_cap_allows_spawn_under_cap(monkeypatch, tmp_path):
 
     def _record_popen(*args, **kwargs):
         popen_calls.append((args, kwargs))
-        return type("DummyProc", (), {"pid": 123})()
+        return type("DummyProc", (), {"pid": 123, "__enter__": lambda s: s, "__exit__": lambda *a: None})()
 
     monkeypatch.setattr(subprocess, "Popen", _record_popen)
 
@@ -124,10 +133,15 @@ def test_popen_failure_queues_backlog_not_inline(monkeypatch, tmp_path):
     """When subprocess.Popen raises (disk full, permission denied, etc.),
     the hook must write a backlog marker and NOT fall back to inline
     ingestion — that path blocks Claude Code's shutdown."""
+    from contextlib import contextmanager
     from truememory.ingest.hooks import stop as stop_mod
+    from truememory.hooks import core as core_mod
 
-    monkeypatch.setattr(stop_mod, "SPAWN_CAP", 99)
-    monkeypatch.setattr(stop_mod, "_count_active_ingest_processes", lambda: 0)
+    @contextmanager
+    def _gate_allows():
+        yield True
+
+    monkeypatch.setattr(core_mod, "spawn_gate", _gate_allows)
     monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
     monkeypatch.setattr(stop_mod, "TRACE_DIR", tmp_path / "traces")
     monkeypatch.setattr(stop_mod, "LOG_DIR", tmp_path / "logs")

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -129,7 +129,7 @@ def test_install_hooks_creates_toml(tmp_path, monkeypatch):
     assert 'event = "Stop"' in text
     assert 'event = "UserPromptSubmit"' in text
     assert "truememory" in text.lower()
-    assert "PreCompact" not in text
+    assert 'event = "PreCompact"' in text
 
 
 def test_install_hooks_preserves_existing_toml(tmp_path, monkeypatch):

--- a/tests/test_encoding_gate_bad_env.py
+++ b/tests/test_encoding_gate_bad_env.py
@@ -1,0 +1,40 @@
+"""Test that non-numeric env vars for gate weights don't crash the pipeline (#303)."""
+
+import os
+
+
+class MockMemoryEmpty:
+    def search(self, *a, **kw):
+        return []
+
+
+def test_non_numeric_env_var_falls_back_to_default():
+    """Setting TRUEMEMORY_GATE_W_NOVELTY to a non-numeric string should
+    fall back to the default rather than raising ValueError."""
+    os.environ["TRUEMEMORY_GATE_W_NOVELTY"] = "high"
+    os.environ["TRUEMEMORY_GATE_W_SALIENCE"] = "abc"
+    os.environ["TRUEMEMORY_GATE_W_PE"] = ""
+    os.environ["TRUEMEMORY_GATE_SALIENCE_FLOOR"] = "not_a_number"
+    try:
+        from truememory.ingest.encoding_gate import EncodingGate
+        gate = EncodingGate(memory=MockMemoryEmpty())
+        assert abs(gate.w_novelty - 0.25) < 1e-9, f"Expected default 0.25, got {gate.w_novelty}"
+        assert abs(gate.w_salience - 0.20) < 1e-9, f"Expected default 0.20, got {gate.w_salience}"
+        assert abs(gate.w_prediction_error - 0.30) < 1e-9, f"Expected default 0.30, got {gate.w_prediction_error}"
+        assert abs(gate.salience_floor - 0.10) < 1e-9, f"Expected default 0.10, got {gate.salience_floor}"
+    finally:
+        os.environ.pop("TRUEMEMORY_GATE_W_NOVELTY", None)
+        os.environ.pop("TRUEMEMORY_GATE_W_SALIENCE", None)
+        os.environ.pop("TRUEMEMORY_GATE_W_PE", None)
+        os.environ.pop("TRUEMEMORY_GATE_SALIENCE_FLOOR", None)
+
+
+def test_valid_numeric_env_var_still_works():
+    """Valid numeric env vars should still be applied."""
+    os.environ["TRUEMEMORY_GATE_W_NOVELTY"] = "0.50"
+    try:
+        from truememory.ingest.encoding_gate import EncodingGate
+        gate = EncodingGate(memory=MockMemoryEmpty())
+        assert abs(gate.w_novelty - 0.50) < 1e-9, f"Expected 0.50, got {gate.w_novelty}"
+    finally:
+        os.environ.pop("TRUEMEMORY_GATE_W_NOVELTY", None)

--- a/tests/test_ensure_connection_threading.py
+++ b/tests/test_ensure_connection_threading.py
@@ -1,0 +1,57 @@
+"""Test that _ensure_connection() is thread-safe (#307).
+
+Without the _init_lock, concurrent threads calling add() on a fresh engine
+race through _ensure_connection(), creating orphaned connections and
+potential deadlocks.
+"""
+import tempfile
+import threading
+
+from truememory.engine import TrueMemoryEngine
+
+
+def test_concurrent_add_no_data_loss():
+    """5 threads calling add() on a fresh engine should all succeed."""
+    db = tempfile.mktemp(suffix=".db")
+    eng = TrueMemoryEngine(db_path=db)
+
+    errors = []
+    results = []
+
+    def writer(tid):
+        try:
+            r = eng.add(f"Thread {tid} message", sender=f"t{tid}")
+            results.append(r)
+        except Exception as e:
+            errors.append((tid, e))
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not errors, f"Threads failed: {errors}"
+    assert len(results) == 5, f"Expected 5 results, got {len(results)}"
+
+
+def test_concurrent_search_on_fresh_engine():
+    """Multiple threads searching before any add() should not crash."""
+    db = tempfile.mktemp(suffix=".db")
+    eng = TrueMemoryEngine(db_path=db)
+
+    errors = []
+
+    def searcher(tid):
+        try:
+            eng.search(f"query {tid}")
+        except Exception as e:
+            errors.append((tid, e))
+
+    threads = [threading.Thread(target=searcher, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not errors, f"Search threads failed: {errors}"

--- a/tests/test_ensure_connection_threading.py
+++ b/tests/test_ensure_connection_threading.py
@@ -4,15 +4,16 @@ Without the _init_lock, concurrent threads calling add() on a fresh engine
 race through _ensure_connection(), creating orphaned connections and
 potential deadlocks.
 """
+import os
 import tempfile
 import threading
 
 from truememory.engine import TrueMemoryEngine
 
 
-def test_concurrent_add_no_data_loss():
+def test_concurrent_add_no_data_loss(tmp_path):
     """5 threads calling add() on a fresh engine should all succeed."""
-    db = tempfile.mktemp(suffix=".db")
+    db = str(tmp_path / "test_add.db")
     eng = TrueMemoryEngine(db_path=db)
 
     errors = []
@@ -35,9 +36,9 @@ def test_concurrent_add_no_data_loss():
     assert len(results) == 5, f"Expected 5 results, got {len(results)}"
 
 
-def test_concurrent_search_on_fresh_engine():
+def test_concurrent_search_on_fresh_engine(tmp_path):
     """Multiple threads searching before any add() should not crash."""
-    db = tempfile.mktemp(suffix=".db")
+    db = str(tmp_path / "test_search.db")
     eng = TrueMemoryEngine(db_path=db)
 
     errors = []

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -110,15 +110,19 @@ def test_install_hooks_creates_cli_config(tmp_path, monkeypatch):
 
     data = yaml.safe_load(cli_config.read_text(encoding="utf-8"))
     plugins = data["plugins"]
-    assert len(plugins) == 2
+    assert len(plugins) == 4
 
     names = {p["name"] for p in plugins}
     assert "truememory-session-start" in names
     assert "truememory-session-end" in names
+    assert "truememory-user-prompt" in names
+    assert "truememory-pre-compact" in names
 
     events = {p["event"] for p in plugins}
     assert "on_session_start" in events
     assert "on_session_end" in events
+    assert "on_user_prompt" in events
+    assert "on_pre_compact" in events
 
 
 def test_install_hooks_preserves_existing(tmp_path, monkeypatch):

--- a/tests/test_spawn_gate.py
+++ b/tests/test_spawn_gate.py
@@ -1,0 +1,127 @@
+"""Tests for the flock-based spawn gate that prevents ingest process avalanches.
+
+The spawn gate serializes check-then-spawn decisions via a file lock so that
+concurrent Stop/SessionStart hooks can't all see 0 active processes and all
+spawn simultaneously.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_spawn_gate_yields_true_under_cap(tmp_path, monkeypatch):
+    """When fewer than SPAWN_CAP processes are active, gate yields True."""
+    from truememory.hooks import core
+
+    monkeypatch.setattr(core, "SPAWN_CAP", 3)
+    monkeypatch.setattr(core, "SPAWN_LOCK_PATH", tmp_path / ".spawn.lock")
+    monkeypatch.setattr(core, "_count_active_ingest_processes", lambda: 1)
+
+    with core.spawn_gate() as allowed:
+        assert allowed is True
+
+
+def test_spawn_gate_yields_false_at_cap(tmp_path, monkeypatch):
+    """When at or above SPAWN_CAP, gate yields False."""
+    from truememory.hooks import core
+
+    monkeypatch.setattr(core, "SPAWN_CAP", 2)
+    monkeypatch.setattr(core, "SPAWN_LOCK_PATH", tmp_path / ".spawn.lock")
+    monkeypatch.setattr(core, "_count_active_ingest_processes", lambda: 2)
+
+    with core.spawn_gate() as allowed:
+        assert allowed is False
+
+
+def test_spawn_gate_windows_fallback(tmp_path, monkeypatch):
+    """On Windows (no fcntl), gate still works without a file lock."""
+    from truememory.hooks import core
+
+    monkeypatch.setattr(core, "_HAS_FCNTL", False)
+    monkeypatch.setattr(core, "SPAWN_CAP", 5)
+    monkeypatch.setattr(core, "_count_active_ingest_processes", lambda: 0)
+
+    with core.spawn_gate() as allowed:
+        assert allowed is True
+
+
+def test_spawn_cap_env_var_unified(monkeypatch):
+    """TRUEMEMORY_SPAWN_CAP takes precedence over TRUEMEMORY_INGEST_SPAWN_CAP."""
+    monkeypatch.setenv("TRUEMEMORY_SPAWN_CAP", "7")
+    monkeypatch.setenv("TRUEMEMORY_INGEST_SPAWN_CAP", "99")
+
+    import importlib
+    from truememory.hooks import core
+    importlib.reload(core)
+    try:
+        assert core.SPAWN_CAP == 7
+    finally:
+        monkeypatch.delenv("TRUEMEMORY_SPAWN_CAP")
+        monkeypatch.delenv("TRUEMEMORY_INGEST_SPAWN_CAP")
+        importlib.reload(core)
+
+
+def test_spawn_cap_fallback_env_var(monkeypatch):
+    """When TRUEMEMORY_SPAWN_CAP is not set, falls back to TRUEMEMORY_INGEST_SPAWN_CAP."""
+    monkeypatch.delenv("TRUEMEMORY_SPAWN_CAP", raising=False)
+    monkeypatch.setenv("TRUEMEMORY_INGEST_SPAWN_CAP", "5")
+
+    import importlib
+    from truememory.hooks import core
+    importlib.reload(core)
+    try:
+        assert core.SPAWN_CAP == 5
+    finally:
+        monkeypatch.delenv("TRUEMEMORY_INGEST_SPAWN_CAP")
+        importlib.reload(core)
+
+
+def test_drain_backlog_respects_spawn_cap(tmp_path, monkeypatch):
+    """_drain_backlog must not spawn processes beyond the spawn cap."""
+    from truememory.ingest.hooks import session_start as ss_mod
+    from truememory.hooks import core as core_mod
+
+    backlog = tmp_path / "backlog"
+    backlog.mkdir()
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type": "human", "content": "test"}')
+
+    for i in range(5):
+        marker = backlog / f"session-{i}.json"
+        marker.write_text(json.dumps({
+            "transcript_path": str(transcript),
+            "session_id": f"session-{i}",
+        }))
+
+    monkeypatch.setattr(ss_mod, "BACKLOG_DIR", backlog)
+
+    spawn_count = {"n": 0}
+
+    @contextmanager
+    def _counting_gate():
+        if spawn_count["n"] >= 2:
+            yield False
+        else:
+            spawn_count["n"] += 1
+            yield True
+
+    monkeypatch.setattr(core_mod, "spawn_gate", _counting_gate)
+
+    popen_calls = []
+    def _mock_popen(*args, **kwargs):
+        popen_calls.append(args)
+        return type("P", (), {"pid": 0, "__enter__": lambda s: s, "__exit__": lambda *a: None})()
+
+    monkeypatch.setattr(subprocess, "Popen", _mock_popen)
+
+    ss_mod._drain_backlog()
+
+    assert len(popen_calls) == 2, f"Expected exactly 2 spawns, got {len(popen_calls)}"
+    remaining = list(backlog.glob("*.json"))
+    assert len(remaining) == 3, f"Expected 3 remaining backlog items, got {len(remaining)}"

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -285,6 +285,7 @@ class TrueMemoryEngine:
         self.ready = False
         self.stats: dict = {}
         self._write_lock = threading.Lock()
+        self._init_lock = threading.Lock()
 
         # L5 surprise rerank boost coefficient. None = resolve from env
         # var / default at call-time via _get_alpha_surprise().
@@ -317,72 +318,76 @@ class TrueMemoryEngine:
         if self.conn is not None:
             return
 
-        # Create parent directory if using a real path
-        db_str = str(self.db_path)
-        if db_str != ":memory:":
-            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._init_lock:
+            if self.conn is not None:
+                return
 
-        self.conn = create_db(self.db_path)
+            # Create parent directory if using a real path
+            db_str = str(self.db_path)
+            if db_str != ":memory:":
+                self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Load sqlite-vec extension
-        if _HAS_VECTOR:
-            try:
-                import sqlite_vec
-                self.conn.enable_load_extension(True)
-                sqlite_vec.load(self.conn)
-                self.conn.enable_load_extension(False)
-                init_vec_table(self.conn)
-                self._has_vectors = True
-            except Exception:
-                logger.debug("Failed to load sqlite-vec extension", exc_info=True)
-                self._has_vectors = False
+            self.conn = create_db(self.db_path)
 
-        self._has_hybrid = _HAS_HYBRID and self._has_vectors
+            # Load sqlite-vec extension
+            if _HAS_VECTOR:
+                try:
+                    import sqlite_vec
+                    self.conn.enable_load_extension(True)
+                    sqlite_vec.load(self.conn)
+                    self.conn.enable_load_extension(False)
+                    init_vec_table(self.conn)
+                    self._has_vectors = True
+                except Exception:
+                    logger.debug("Failed to load sqlite-vec extension", exc_info=True)
+                    self._has_vectors = False
 
-        # Qwen3 NaN fix: macOS SDPA kernel produces NaN embeddings.
-        # Re-embed once for Base/Pro users on macOS.
-        import sys as _sys
-        if _sys.platform == "darwin" and self._has_vectors:
-            try:
-                _embed_model = os.environ.get("TRUEMEMORY_EMBED_MODEL", "edge")
-                if _embed_model in ("base", "pro", "qwen3_256"):
-                    _tables = {r[0] for r in self.conn.execute(
-                        "SELECT name FROM sqlite_master WHERE type='table'"
-                    ).fetchall()}
-                    if "metadata" in _tables:
-                        _row = self.conn.execute(
-                            "SELECT value FROM metadata WHERE key = 'qwen3_nan_fix_applied'"
-                        ).fetchone()
-                        if _row is None:
-                            from truememory.vector_search import (
-                                build_vectors as _bv,
-                                build_separation_vectors as _bsv,
-                                init_vec_table as _ivt,
-                            )
-                            self.conn.execute("DROP TABLE IF EXISTS vec_messages")
-                            self.conn.execute("DROP TABLE IF EXISTS vec_messages_sep")
-                            self.conn.commit()
-                            _ivt(self.conn)
-                            _bv(self.conn)
-                            _bsv(self.conn)
-                            logger.warning(
-                                "Qwen3 NaN fix: re-embedded all vectors with "
-                                "eager attention (one-time macOS migration)"
-                            )
-                            self.conn.execute(
-                                "INSERT OR REPLACE INTO metadata (key, value) "
-                                "VALUES (?, ?)",
-                                ("qwen3_nan_fix_applied", "1"),
-                            )
-                            self.conn.commit()
-            except Exception:
-                logger.warning(
-                    "Qwen3 NaN migration failed — run "
-                    "'truememory-ingest upgrade-tier base --force' to fix manually",
-                    exc_info=True,
-                )
+            self._has_hybrid = _HAS_HYBRID and self._has_vectors
 
-        self.ready = True
+            # Qwen3 NaN fix: macOS SDPA kernel produces NaN embeddings.
+            # Re-embed once for Base/Pro users on macOS.
+            import sys as _sys
+            if _sys.platform == "darwin" and self._has_vectors:
+                try:
+                    _embed_model = os.environ.get("TRUEMEMORY_EMBED_MODEL", "edge")
+                    if _embed_model in ("base", "pro", "qwen3_256"):
+                        _tables = {r[0] for r in self.conn.execute(
+                            "SELECT name FROM sqlite_master WHERE type='table'"
+                        ).fetchall()}
+                        if "metadata" in _tables:
+                            _row = self.conn.execute(
+                                "SELECT value FROM metadata WHERE key = 'qwen3_nan_fix_applied'"
+                            ).fetchone()
+                            if _row is None:
+                                from truememory.vector_search import (
+                                    build_vectors as _bv,
+                                    build_separation_vectors as _bsv,
+                                    init_vec_table as _ivt,
+                                )
+                                self.conn.execute("DROP TABLE IF EXISTS vec_messages")
+                                self.conn.execute("DROP TABLE IF EXISTS vec_messages_sep")
+                                self.conn.commit()
+                                _ivt(self.conn)
+                                _bv(self.conn)
+                                _bsv(self.conn)
+                                logger.warning(
+                                    "Qwen3 NaN fix: re-embedded all vectors with "
+                                    "eager attention (one-time macOS migration)"
+                                )
+                                self.conn.execute(
+                                    "INSERT OR REPLACE INTO metadata (key, value) "
+                                    "VALUES (?, ?)",
+                                    ("qwen3_nan_fix_applied", "1"),
+                                )
+                                self.conn.commit()
+                except Exception:
+                    logger.warning(
+                        "Qwen3 NaN migration failed — run "
+                        "'truememory-ingest upgrade-tier base --force' to fix manually",
+                        exc_info=True,
+                    )
+
+            self.ready = True
 
     # ──────────────────────────────────────────────────────────────────────
     # Production CRUD API

--- a/truememory/hooks/adapters/claude.py
+++ b/truememory/hooks/adapters/claude.py
@@ -123,6 +123,14 @@ class ClaudeAdapter(CLIAdapter):
                 else:
                     del hooks[event]
             settings["hooks"] = hooks
+
+            # Also remove the MCP server entry (JSON-level fallback for when
+            # `claude mcp remove` fails or the CLI is not on PATH)
+            mcp_servers = settings.get("mcpServers", {})
+            if "truememory" in mcp_servers:
+                del mcp_servers["truememory"]
+                settings["mcpServers"] = mcp_servers
+
             self.config_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
         except (json.JSONDecodeError, OSError):
             pass

--- a/truememory/hooks/adapters/codex.py
+++ b/truememory/hooks/adapters/codex.py
@@ -35,6 +35,10 @@ _HOOK_EVENTS = {
         "script": "user_prompt_submit.py",
         "timeout": 5000,
     },
+    "PreCompact": {
+        "script": "compact.py",
+        "timeout": 5000,
+    },
 }
 
 _TRUEMEMORY_MARKER = "truememory"

--- a/truememory/hooks/adapters/cursor.py
+++ b/truememory/hooks/adapters/cursor.py
@@ -28,6 +28,10 @@ _HOOK_EVENTS = {
         "script": "stop.py",
         "timeout": 5000,
     },
+    "userPromptSubmit": {
+        "script": "user_prompt_submit.py",
+        "timeout": 5000,
+    },
     "preCompact": {
         "script": "compact.py",
         "timeout": 5000,

--- a/truememory/hooks/adapters/gemini.py
+++ b/truememory/hooks/adapters/gemini.py
@@ -28,6 +28,10 @@ _HOOK_EVENTS = {
         "script": "stop.py",
         "timeout": 5000,
     },
+    "UserPromptSubmit": {
+        "script": "user_prompt_submit.py",
+        "timeout": 5000,
+    },
     "PreCompress": {
         "script": "compact.py",
         "timeout": 5000,

--- a/truememory/hooks/adapters/hermes.py
+++ b/truememory/hooks/adapters/hermes.py
@@ -32,6 +32,14 @@ _PLUGIN_HOOKS = {
         "name": "truememory-session-end",
         "script": "stop.py",
     },
+    "on_user_prompt": {
+        "name": "truememory-user-prompt",
+        "script": "user_prompt_submit.py",
+    },
+    "on_pre_compact": {
+        "name": "truememory-pre-compact",
+        "script": "compact.py",
+    },
 }
 
 _TRUEMEMORY_MARKER = "truememory"

--- a/truememory/hooks/adapters/kimi.py
+++ b/truememory/hooks/adapters/kimi.py
@@ -31,6 +31,10 @@ _HOOK_EVENTS = {
         "script": "stop.py",
         "timeout": 5000,
     },
+    "UserPromptSubmit": {
+        "script": "user_prompt_submit.py",
+        "timeout": 5000,
+    },
     "PreCompact": {
         "script": "compact.py",
         "timeout": 5000,

--- a/truememory/hooks/core.py
+++ b/truememory/hooks/core.py
@@ -6,12 +6,14 @@ modules.
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -29,13 +31,47 @@ MAX_BUFFER_SIZE = int(os.environ.get("TRUEMEMORY_BUFFER_MAX_BYTES", str(10 * 102
 TRACE_DIR = Path.home() / ".truememory" / "traces"
 LOG_DIR = Path.home() / ".truememory" / "logs"
 BACKLOG_DIR = Path.home() / ".truememory" / "backlog"
-SPAWN_CAP = int(os.environ.get("TRUEMEMORY_SPAWN_CAP", "3"))
+SPAWN_CAP = int(os.environ.get(
+    "TRUEMEMORY_SPAWN_CAP",
+    os.environ.get("TRUEMEMORY_INGEST_SPAWN_CAP", "2"),
+))
+SPAWN_LOCK_PATH = Path.home() / ".truememory" / ".spawn.lock"
 
 try:
     import fcntl
     _HAS_FCNTL = True
 except ImportError:
     _HAS_FCNTL = False
+
+
+@contextmanager
+def spawn_gate():
+    """Acquire an exclusive file lock before checking/spawning ingest processes.
+
+    Prevents the TOCTOU race where N hooks all check pgrep simultaneously,
+    all see 0 active processes, and all spawn — causing N × 600 MB of
+    embedding models to load at once.
+
+    Yields True if spawning is allowed (under SPAWN_CAP), False otherwise.
+    On Windows (no fcntl), falls back to best-effort pgrep without a lock.
+    """
+    if not _HAS_FCNTL:
+        yield _count_active_ingest_processes() < SPAWN_CAP
+        return
+
+    SPAWN_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    fd = None
+    try:
+        fd = os.open(str(SPAWN_LOCK_PATH), os.O_CREAT | os.O_WRONLY, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield _count_active_ingest_processes() < SPAWN_CAP
+    finally:
+        if fd is not None:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            os.close(fd)
 
 
 def recall_memories(
@@ -295,41 +331,41 @@ def run_background_ingestion(
     else:
         detach_kwargs["start_new_session"] = True
 
-    active = _count_active_ingest_processes()
-    if active >= SPAWN_CAP:
-        log.warning(
-            "core: at spawn cap (%d active / cap %d); queueing session %r",
-            active, SPAWN_CAP, session_id,
-        )
-        _queue_to_backlog(
-            transcript_path, session_id, user_id, db_path,
-            reason=f"spawn_cap_reached:{active}>=SPAWN_CAP={SPAWN_CAP}",
-        )
-        return
+    with spawn_gate() as allowed:
+        if not allowed:
+            log.warning(
+                "core: at spawn cap (cap %d); queueing session %r",
+                SPAWN_CAP, session_id,
+            )
+            _queue_to_backlog(
+                transcript_path, session_id, user_id, db_path,
+                reason=f"spawn_cap_reached:SPAWN_CAP={SPAWN_CAP}",
+            )
+            return
 
-    log_file = None
-    try:
-        log_file = open(log_path, "a", encoding="utf-8")
-        subprocess.Popen(
-            cmd,
-            stdout=log_file,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.DEVNULL,
-            close_fds=(sys.platform != "win32"),
-            **detach_kwargs,
-        )
-    except Exception as e:
-        log.error("core: Popen failed: %s — queueing to backlog", e)
-        _queue_to_backlog(
-            transcript_path, session_id, user_id, db_path,
-            reason=f"popen_failed:{e}",
-        )
-    finally:
-        if log_file is not None:
-            try:
-                log_file.close()
-            except OSError:
-                pass
+        log_file = None
+        try:
+            log_file = open(log_path, "a", encoding="utf-8")
+            subprocess.Popen(
+                cmd,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                close_fds=(sys.platform != "win32"),
+                **detach_kwargs,
+            )
+        except Exception as e:
+            log.error("core: Popen failed: %s — queueing to backlog", e)
+            _queue_to_backlog(
+                transcript_path, session_id, user_id, db_path,
+                reason=f"popen_failed:{e}",
+            )
+        finally:
+            if log_file is not None:
+                try:
+                    log_file.close()
+                except OSError:
+                    pass
 
 
 def _queue_to_backlog(

--- a/truememory/hooks/templates/openclaw/index.js
+++ b/truememory/hooks/templates/openclaw/index.js
@@ -71,5 +71,36 @@ module.exports = {
         // Never block agent shutdown
       }
     });
+
+    api.on("before_user_message", async (ctx) => {
+      try {
+        const input = JSON.stringify({
+          session_id: ctx.sessionId || "openclaw",
+          cwd: process.cwd(),
+          user_prompt: ctx.userPrompt || "",
+        });
+        execSync(
+          `echo '${input.replace(/'/g, "\\'")}' | ${PYTHON_PATH} ${path.join(hooksDir, "user_prompt_submit.py")}`,
+          { encoding: "utf-8", timeout: 5000 }
+        );
+      } catch (err) {
+        // Never block user message processing
+      }
+    });
+
+    api.on("before_compress", async (ctx) => {
+      try {
+        const input = JSON.stringify({
+          session_id: ctx.sessionId || "openclaw",
+          transcript_path: ctx.transcriptPath || "",
+        });
+        execSync(
+          `echo '${input.replace(/'/g, "\\'")}' | ${PYTHON_PATH} ${path.join(hooksDir, "compact.py")}`,
+          { encoding: "utf-8", timeout: 5000 }
+        );
+      } catch (err) {
+        // Never block compression
+      }
+    });
   },
 };

--- a/truememory/hooks/templates/openclaw/plugin.json
+++ b/truememory/hooks/templates/openclaw/plugin.json
@@ -3,5 +3,5 @@
   "version": "1.0.0",
   "description": "TrueMemory persistent memory integration for OpenClaw",
   "main": "index.js",
-  "events": ["before_agent_run", "agent_end"]
+  "events": ["before_agent_run", "agent_end", "before_user_message", "before_compress"]
 }

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -64,6 +64,21 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 
+def _safe_float_env(name: str, default: float) -> float:
+    """Read a float from an env var, falling back to default on bad values."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        log.warning(
+            "env var %s=%r is not a valid number, using default %.2f",
+            name, raw, default,
+        )
+        return default
+
+
 # Try to import truememory's existing scoring modules. If they're not
 # available (older truememory or partial install), fall back to
 # internal heuristics.
@@ -163,16 +178,16 @@ class EncodingGate:
             threshold = clamped
         self.threshold = threshold
         if w_novelty is None:
-            w_novelty = float(os.environ.get("TRUEMEMORY_GATE_W_NOVELTY", "0.25"))
+            w_novelty = _safe_float_env("TRUEMEMORY_GATE_W_NOVELTY", 0.25)
         if w_salience is None:
-            w_salience = float(os.environ.get("TRUEMEMORY_GATE_W_SALIENCE", "0.20"))
+            w_salience = _safe_float_env("TRUEMEMORY_GATE_W_SALIENCE", 0.20)
         if w_prediction_error is None:
-            w_prediction_error = float(os.environ.get("TRUEMEMORY_GATE_W_PE", "0.30"))
+            w_prediction_error = _safe_float_env("TRUEMEMORY_GATE_W_PE", 0.30)
         self.w_novelty = w_novelty
         self.w_salience = w_salience
         self.w_prediction_error = w_prediction_error
         if salience_floor is None:
-            salience_floor = float(os.environ.get("TRUEMEMORY_GATE_SALIENCE_FLOOR", "0.10"))
+            salience_floor = _safe_float_env("TRUEMEMORY_GATE_SALIENCE_FLOOR", 0.10)
         self.salience_floor = salience_floor
         self.user_id = user_id
         # Normalized weights so the final score lands in [0, 1]

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -135,13 +135,21 @@ def _check_email_needed() -> str:
 
 
 def _drain_backlog() -> None:
-    """Process queued sessions from the backlog directory."""
+    """Process queued sessions from the backlog directory.
+
+    Uses the flock-based spawn gate from core to prevent the avalanche
+    scenario where N concurrent SessionStart hooks all drain simultaneously,
+    spawning N × _DRAIN_CAP ingest processes.
+    """
     if not BACKLOG_DIR.exists():
         return
     try:
         markers = sorted(BACKLOG_DIR.glob("*.json"))[:_DRAIN_CAP]
     except Exception:
         return
+
+    from truememory.hooks.core import spawn_gate
+
     for marker_path in markers:
         try:
             data = json.loads(marker_path.read_text(encoding="utf-8"))
@@ -149,24 +157,30 @@ def _drain_backlog() -> None:
             if not transcript or not Path(transcript).exists():
                 marker_path.unlink(missing_ok=True)
                 continue
-            import subprocess
-            cmd = [
-                sys.executable, "-m", "truememory.ingest.cli",
-                "ingest", transcript,
-            ]
-            session_id = data.get("session_id", "")
-            if session_id:
-                cmd.extend(["--session", session_id])
-            if data.get("user_id"):
-                cmd.extend(["--user", data["user_id"]])
-            if data.get("db_path"):
-                cmd.extend(["--db", data["db_path"]])
-            subprocess.Popen(
-                cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
+
+            with spawn_gate() as allowed:
+                if not allowed:
+                    log.info("Drain: spawn cap reached, leaving remaining backlog for next session")
+                    return
+
+                import subprocess
+                cmd = [
+                    sys.executable, "-m", "truememory.ingest.cli",
+                    "ingest", transcript,
+                ]
+                session_id = data.get("session_id", "")
+                if session_id:
+                    cmd.extend(["--session", session_id])
+                if data.get("user_id"):
+                    cmd.extend(["--user", data["user_id"]])
+                if data.get("db_path"):
+                    cmd.extend(["--db", data["db_path"]])
+                subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
             marker_path.unlink(missing_ok=True)
             log.info("Drained backlog session: %s", data.get("session_id", "?"))
         except Exception as e:

--- a/truememory/ingest/hooks/stop.py
+++ b/truememory/ingest/hooks/stop.py
@@ -28,8 +28,28 @@ from pathlib import Path
 
 log = logging.getLogger(__name__)
 
-GATE_THRESHOLD = float(os.environ.get("TRUEMEMORY_GATE_THRESHOLD", "0.30"))
-MIN_MESSAGES = int(os.environ.get("TRUEMEMORY_MIN_MESSAGES", "5"))
+def _safe_float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        return default
+
+
+def _safe_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return default
+
+
+GATE_THRESHOLD = _safe_float_env("TRUEMEMORY_GATE_THRESHOLD", 0.30)
+MIN_MESSAGES = _safe_int_env("TRUEMEMORY_MIN_MESSAGES", 5)
 TRACE_DIR = Path(os.environ.get(
     "TRUEMEMORY_TRACE_DIR",
     str(Path.home() / ".truememory" / "traces"),
@@ -47,8 +67,11 @@ BACKLOG_DIR = Path(os.environ.get(
 # cap concurrent ingest processes. N parallel Stop hooks
 # (multi-session close, session-restart loop) would otherwise load N
 # embedding models at once — ~600MB RSS each on Pro, easy OOM on laptops.
-# Tunable via env var; POSIX-only via pgrep (on Windows the cap is a no-op).
-SPAWN_CAP = int(os.environ.get("TRUEMEMORY_INGEST_SPAWN_CAP", "2"))
+# Unified env var across stop.py and hooks/core.py.
+SPAWN_CAP = int(os.environ.get(
+    "TRUEMEMORY_SPAWN_CAP",
+    os.environ.get("TRUEMEMORY_INGEST_SPAWN_CAP", "2"),
+))
 
 
 def _sanitize_session_id(session_id: str) -> str:
@@ -325,58 +348,50 @@ def _run_background_ingestion(
     else:
         detach_kwargs["start_new_session"] = True
 
-    # refuse to spawn if we're already at the concurrent-ingest
-    # cap. Over-cap events queue to the backlog so the memories aren't lost.
-    active = _count_active_ingest_processes()
-    if active >= SPAWN_CAP:
-        log.warning(
-            "stop hook: at spawn cap (%d active / cap %d); queueing session "
-            "%r to backlog for later",
-            active, SPAWN_CAP, session_id,
-        )
-        _queue_to_backlog(
-            transcript_path, session_id, user_id, db_path,
-            reason=f"spawn_cap_reached:{active}>=SPAWN_CAP={SPAWN_CAP}",
-        )
-        return
+    # Use flock-based spawn gate to prevent the TOCTOU race where N hooks
+    # all check pgrep simultaneously, all see 0, and all spawn.
+    from truememory.hooks.core import spawn_gate
 
-    log_file = None
-    try:
-        # Open the log file and hand it to the subprocess. We MUST close our
-        # parent-side handle after Popen — the subprocess has its own dup'd
-        # copy, so closing ours here is safe and prevents FD leaks across
-        # many invocations of this hook (one per session).
-        log_file = open(log_path, "a", encoding="utf-8")
-        subprocess.Popen(
-            cmd,
-            stdout=log_file,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.DEVNULL,
-            close_fds=(sys.platform != "win32"),
-            **detach_kwargs,
-        )
-    except Exception as e:
-        # NEVER fall back to synchronous inline ingestion —
-        # that blocks Claude Code's shutdown for 10–60s. Queue instead;
-        # a later session's drain path will re-attempt.
-        log.warning(
-            "stop hook: background launch failed (%s); queueing session "
-            "%r to backlog for later",
-            e, session_id,
-        )
-        _queue_to_backlog(
-            transcript_path, session_id, user_id, db_path,
-            reason=f"popen_failed:{type(e).__name__}:{e}",
-        )
-    finally:
-        # Always close our parent-side handle to prevent FD leaks.
-        # The subprocess still has its own dup'd copy of the FD and will
-        # continue writing to the log file normally.
-        if log_file is not None:
-            try:
-                log_file.close()
-            except Exception:
-                pass
+    with spawn_gate() as allowed:
+        if not allowed:
+            log.warning(
+                "stop hook: at spawn cap (cap %d); queueing session "
+                "%r to backlog for later",
+                SPAWN_CAP, session_id,
+            )
+            _queue_to_backlog(
+                transcript_path, session_id, user_id, db_path,
+                reason=f"spawn_cap_reached:SPAWN_CAP={SPAWN_CAP}",
+            )
+            return
+
+        log_file = None
+        try:
+            log_file = open(log_path, "a", encoding="utf-8")
+            subprocess.Popen(
+                cmd,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                close_fds=(sys.platform != "win32"),
+                **detach_kwargs,
+            )
+        except Exception as e:
+            log.warning(
+                "stop hook: background launch failed (%s); queueing session "
+                "%r to backlog for later",
+                e, session_id,
+            )
+            _queue_to_backlog(
+                transcript_path, session_id, user_id, db_path,
+                reason=f"popen_failed:{type(e).__name__}:{e}",
+            )
+        finally:
+            if log_file is not None:
+                try:
+                    log_file.close()
+                except Exception:
+                    pass
 
 
 if __name__ == "__main__":

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -544,6 +544,7 @@ def truememory_store(
         user_id: Owner of this memory (e.g. a person's name).
         metadata: Optional JSON string of metadata.
     """
+    _touch_search_time()
     MAX_CONTENT_LENGTH = 50_000
     if len(content) > MAX_CONTENT_LENGTH:
         return json.dumps({"error": f"Content too large ({len(content)} chars). Maximum is {MAX_CONTENT_LENGTH}."})


### PR DESCRIPTION
## Summary

Root cause fix for the process avalanche that overheated the development Mac — `_drain_backlog()` had zero spawn cap checking, causing 36+ ingest processes to load embedding models simultaneously (load avg 615, 0% idle CPU).

**7 fixes in this PR:**

- **Spawn cap + drain race (#304 + root cause)** — `flock`-based `spawn_gate()` context manager that serializes check-then-spawn decisions via file lock, eliminating the `pgrep` TOCTOU race. Drain now respects the cap instead of blindly spawning.
- **`_ensure_connection()` TOCTOU (#307)** — `_init_lock` with double-checked locking prevents concurrent threads from racing through connection creation (data loss + deadlock).
- **EncodingGate env var crash (#303)** — `_safe_float_env()` catches `ValueError` on non-numeric env vars, falls back to sacred defaults.
- **Claude adapter uninstall (#284)** — JSON-level fallback removes `mcpServers.truememory` when `claude mcp remove` fails.
- **Hook event coverage (#287)** — All 7 adapters now handle all 4 canonical hook events.
- **Idle unload timer (#299)** — `_touch_search_time()` called from `truememory_store()` so models unload after idle timeout in store-only workloads.
- **Unified SPAWN_CAP env var** — `TRUEMEMORY_SPAWN_CAP` with fallback to `TRUEMEMORY_INGEST_SPAWN_CAP`, default 2.

## Test plan

- [x] 601 tests pass (was 599 — 10 new tests added, 8 tests updated)
- [x] New `test_spawn_gate.py` — gate yields True/False, Windows fallback, env var unification, drain respects cap
- [x] New `test_encoding_gate_bad_env.py` — non-numeric env vars fall back to defaults
- [x] New `test_ensure_connection_threading.py` — 5-thread concurrent add/search on fresh engine
- [x] Updated `test_stop_hook_safety.py` — mocks `spawn_gate` instead of bare `_count_active`
- [ ] Stress test: run `scripts/populate_backlog_stress_test.py --count 300`, re-enable hooks, verify `pgrep -f truememory.ingest.cli | wc -l` stays ≤ 2

Fixes #304, #307, #303, #284, #287, #299