### PR TITLE
fix: dynamic spawn cap v2 — 9-bug fix with time-gated ramp-up

### DIFF
--- a/tests/test_spawn_gate.py
+++ b/tests/test_spawn_gate.py
@@ -11,6 +11,15 @@ import os
 import subprocess
 from contextlib import contextmanager
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_ramp_cooldown(monkeypatch):
+    """Disable the 120s ramp-up cooldown in all tests so ramp-up is instant."""
+    from truememory.hooks import core
+    monkeypatch.setattr(core, "_RAMP_UP_COOLDOWN_SECONDS", 0)
+
 
 # ---------------------------------------------------------------------------
 # Spawn gate tests
@@ -344,6 +353,29 @@ def test_single_warn_does_not_reduce(tmp_path, monkeypatch):
     cap = core._get_spawn_cap()
     state = _json_load(tmp_path / ".state")
     assert state["warn_count"] == 0, "Warn count should reset"
+
+
+def test_ramp_up_cooldown_prevents_rapid_ramp(tmp_path, monkeypatch):
+    """With cooldown enabled, rapid cascade calls should NOT ramp up every tick."""
+    from truememory.hooks import core
+
+    monkeypatch.delenv("TRUEMEMORY_SPAWN_CAP", raising=False)
+    monkeypatch.delenv("TRUEMEMORY_INGEST_SPAWN_CAP", raising=False)
+    monkeypatch.setattr(core, "_get_current_tier", lambda: "edge")
+    monkeypatch.setattr(core, "_get_physical_cores", lambda: 10)
+    monkeypatch.setattr(core, "_get_memory_free_pct", lambda: 90)
+    monkeypatch.setattr(core, "_get_swap_used_gb", lambda: 0.0)
+    monkeypatch.setattr(core, "_SPAWN_CAP_STATE_PATH", tmp_path / ".state")
+    monkeypatch.setattr(core, "_RAMP_UP_COOLDOWN_SECONDS", 120)
+
+    caps = []
+    for _ in range(10):
+        caps.append(core._get_spawn_cap())
+
+    # First call: state empty → floor(1), ramps to 2 (last_ramp_time=0 is old)
+    # Subsequent calls: cooldown not elapsed → stays at 2
+    assert caps[0] == 2, f"First call should ramp from floor to 2, got {caps[0]}"
+    assert max(caps) == 2, f"With 120s cooldown, rapid calls should stay at 2, got max {max(caps)}"
 
 
 def _json_load(path):

--- a/truememory/hooks/core.py
+++ b/truememory/hooks/core.py
@@ -43,6 +43,7 @@ _GPU_PROCESS_COST_GB = {"base": 1.0, "pro": 1.2}
 
 _HARD_FLOOR = 1
 _WARN_CONSECUTIVE_THRESHOLD = 2
+_RAMP_UP_COOLDOWN_SECONDS = 120
 
 # State file for persisting cap + swap readings across cascade processes
 _SPAWN_CAP_STATE_PATH = Path.home() / ".truememory" / ".spawn_cap_state"
@@ -156,7 +157,10 @@ def _load_cap_state() -> dict:
         return {}
 
 
-def _save_cap_state(cap: int, warn_count: int, swap_gb: float) -> None:
+def _save_cap_state(
+    cap: int, warn_count: int, swap_gb: float,
+    last_ramp_time: float | None = None,
+) -> None:
     """Persist spawn cap state to disk atomically.
 
     Must be called while holding the spawn flock.
@@ -165,12 +169,15 @@ def _save_cap_state(cap: int, warn_count: int, swap_gb: float) -> None:
         import json as _json
         _SPAWN_CAP_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
         tmp = _SPAWN_CAP_STATE_PATH.with_suffix(".tmp")
-        tmp.write_text(_json.dumps({
+        data = {
             "cap": cap,
             "warn_count": warn_count,
             "last_swap_gb": swap_gb,
             "timestamp": time.time(),
-        }), encoding="utf-8")
+        }
+        if last_ramp_time is not None:
+            data["last_ramp_time"] = last_ramp_time
+        tmp.write_text(_json.dumps(data), encoding="utf-8")
         tmp.rename(_SPAWN_CAP_STATE_PATH)
     except Exception:
         pass
@@ -231,6 +238,7 @@ def _get_spawn_cap() -> int:
     current_cap = state.get("cap", _HARD_FLOOR)
     warn_count = state.get("warn_count", 0)
     last_swap_gb = state.get("last_swap_gb", 0.0)
+    last_ramp_time = state.get("last_ramp_time", 0.0)
 
     # Bug 1 fix: parse actual free percentage from memory_pressure
     free_pct = _get_memory_free_pct()
@@ -249,7 +257,7 @@ def _get_spawn_cap() -> int:
             "delta=%.1fGB) → cap=%d",
             free_pct, pressure, swap_gb, swap_gb - last_swap_gb, _HARD_FLOOR,
         )
-        _save_cap_state(current_cap, warn_count, swap_gb)
+        _save_cap_state(current_cap, warn_count, swap_gb, 0.0)
         return _HARD_FLOOR
 
     # Sustained warn: halve after 2+ consecutive readings (hysteresis)
@@ -261,18 +269,20 @@ def _get_spawn_cap() -> int:
                 "Spawn cap: WARN sustained (%d checks, free=%d%%) → cap=%d",
                 warn_count, free_pct, current_cap,
             )
-            _save_cap_state(current_cap, warn_count, swap_gb)
+            _save_cap_state(current_cap, warn_count, swap_gb, 0.0)
             return current_cap
     else:
         warn_count = 0
 
-    # Healthy: ramp up by 1 toward ceiling
-    if current_cap < ceiling:
+    # Healthy: ramp up by 1 toward ceiling, but only every _RAMP_UP_COOLDOWN_SECONDS
+    now = time.time()
+    if current_cap < ceiling and (now - last_ramp_time) >= _RAMP_UP_COOLDOWN_SECONDS:
         current_cap += 1
+        last_ramp_time = now
         log.info("Spawn cap: ramp-up → cap=%d (ceiling=%d, free=%d%%)",
                  current_cap, ceiling, free_pct)
 
-    _save_cap_state(current_cap, warn_count, swap_gb)
+    _save_cap_state(current_cap, warn_count, swap_gb, last_ramp_time)
     return current_cap
 
 


### PR DESCRIPTION
## Summary

Fixes 9 bugs in the dynamic spawn cap, including a critical rapid-ramp issue that caused 7 processes to spawn in 4 minutes (load avg 78).

### Bugs fixed

| # | Bug | Severity |
|---|-----|----------|
| 1 | `memory_pressure` parsing broken — never detected warn/critical | CRITICAL |
| 2 | Ramp-up state reset per cascade process — never ramped | CRITICAL |
| 3 | Env var override read at module load | MEDIUM |
| 4 | Swap check triggered on historical swap | LOW |
| 5 | State file race condition | CRITICAL |
| 6-8 | State expiry, swap delta, hysteresis | LOW |
| 9 | Ramp-up was tick-gated — cascade rapid-ramp caused 7 procs in 4 min | CRITICAL |

### Key changes

- **Edge tier**: caps by CPU cores (not RAM). `min(physical_cores - 1, 8)`
- **Base/Pro**: caps by unified memory (not CPU). `min((memory - 2GB) / model_cost, 6)`
- **120s ramp-up cooldown**: prevents cascade from ramping 1→7 in 4 minutes
- **Memory pressure**: parses actual "free percentage: XX%" from `memory_pressure` command
- **Swap growth**: tracks delta (>0.5GB growth = emergency), not absolute value
- **State persistence**: atomic writes, expires after 5 min, protected by flock

### Validation

- 10-model architectural review + 3-model cooldown review (3/3 APPROVE)
- 16 tests, lint clean

## Test plan

- [x] 16 spawn gate tests
- [x] Full suite passes, lint clean
- [ ] Live test after merge