### PR TITLE
fix: ingestion pipeline — ghost recursion, double-ingest, backlog races

### DIFF
--- a/truememory/hooks/core.py
+++ b/truememory/hooks/core.py
@@ -644,15 +644,17 @@ def run_background_ingestion(
     else:
         detach_kwargs["start_new_session"] = True
 
+    effective_cap = _load_cap_state().get("cap", SPAWN_CAP)
+
     with spawn_gate() as allowed:
         if not allowed:
             log.warning(
                 "core: at spawn cap (cap %d); queueing session %r",
-                SPAWN_CAP, session_id,
+                effective_cap, session_id,
             )
             _queue_to_backlog(
                 transcript_path, session_id, user_id, db_path,
-                reason=f"spawn_cap_reached:SPAWN_CAP={SPAWN_CAP}",
+                reason=f"spawn_cap_reached:SPAWN_CAP={effective_cap}",
             )
             return
 

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -285,8 +285,8 @@ def _cascade_next() -> None:
                     start_new_session=True,
                 )
                 register_spawned_pid(proc.pid)
+                marker_path.unlink(missing_ok=True)
 
-            marker_path.unlink(missing_ok=True)
             logging.getLogger(__name__).info(
                 "Cascade: spawned next ingest for session %s (PID %d)",
                 data.get("session_id", "?"), proc.pid,

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -218,6 +218,12 @@ def _run_ingest(args):
     if args.trace:
         save_trace(result, args.trace)
 
+    try:
+        from truememory.ingest.hooks._shared import mark_session_extracted
+        mark_session_extracted(args.session, args.transcript)
+    except Exception:
+        pass
+
     _cascade_next()
 
 

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -1,10 +1,14 @@
 """Shared utilities for TrueMemory hooks."""
 
 from pathlib import Path
+import json
+import os
 import time
 
 MARKER_PATH = Path.home() / ".truememory" / "last_incremental_extraction"
 DEFAULT_INTERVAL = 14400  # 4 hours in seconds
+
+EXTRACTED_DIR = Path.home() / ".truememory" / "extracted"
 
 
 def should_extract(interval: int = DEFAULT_INTERVAL) -> bool:
@@ -22,5 +26,64 @@ def mark_extracted():
     try:
         MARKER_PATH.parent.mkdir(parents=True, exist_ok=True)
         MARKER_PATH.write_text(str(time.time()), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def should_extract_session(session_id: str, transcript_path: str) -> bool:
+    """Check if a session's transcript has new content since last extraction.
+
+    Compares the current transcript file size against the size recorded
+    at last extraction. Only returns True if the file grew by >1KB
+    (enough for at least a few new messages, avoids re-extracting for
+    minor metadata appends).
+
+    Returns True if:
+    - No prior extraction marker exists (first time)
+    - Transcript grew by >1024 bytes since last extraction
+    - Marker is corrupted/unreadable (extract to be safe)
+    """
+    if not session_id or session_id == "unknown":
+        return True
+
+    EXTRACTED_DIR.mkdir(parents=True, exist_ok=True)
+    marker = EXTRACTED_DIR / session_id
+
+    if not marker.exists():
+        return True
+
+    try:
+        current_size = Path(transcript_path).stat().st_size
+    except OSError:
+        return True
+
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+        last_size = data.get("size", 0)
+    except (json.JSONDecodeError, OSError, ValueError):
+        return True
+
+    return (current_size - last_size) > 1024
+
+
+def mark_session_extracted(session_id: str, transcript_path: str) -> None:
+    """Record that a session's transcript was extracted at its current size.
+
+    Written by the ingest CLI on successful completion, and also by
+    triggers before spawning (optimistic) to prevent concurrent duplicates.
+    The CLI write is authoritative; the trigger write is best-effort.
+    """
+    if not session_id or session_id == "unknown":
+        return
+
+    try:
+        EXTRACTED_DIR.mkdir(parents=True, exist_ok=True)
+        current_size = Path(transcript_path).stat().st_size
+        marker = EXTRACTED_DIR / session_id
+        marker.write_text(json.dumps({
+            "size": current_size,
+            "timestamp": time.time(),
+            "pid": os.getpid(),
+        }), encoding="utf-8")
     except OSError:
         pass

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -5,34 +5,12 @@ import json
 import os
 import time
 
-MARKER_PATH = Path.home() / ".truememory" / "last_incremental_extraction"
-DEFAULT_INTERVAL = 14400  # 4 hours in seconds
-
 EXTRACTED_DIR = Path.home() / ".truememory" / "extracted"
 
 
 def _safe_session_id(session_id: str) -> str:
     """Sanitize session_id to prevent path traversal."""
     return "".join(c for c in session_id if c.isalnum() or c in "-_")[:64]
-
-
-def should_extract(interval: int = DEFAULT_INTERVAL) -> bool:
-    """Check if enough time has elapsed since the last incremental extraction."""
-    if not MARKER_PATH.exists():
-        return True
-    try:
-        return (time.time() - MARKER_PATH.stat().st_mtime) >= interval
-    except OSError:
-        return True
-
-
-def mark_extracted():
-    """Update the timestamp marker after a successful extraction trigger."""
-    try:
-        MARKER_PATH.parent.mkdir(parents=True, exist_ok=True)
-        MARKER_PATH.write_text(str(time.time()), encoding="utf-8")
-    except OSError:
-        pass
 
 
 def should_extract_session(session_id: str, transcript_path: str) -> bool:
@@ -74,6 +52,8 @@ def should_extract_session(session_id: str, transcript_path: str) -> bool:
     except (json.JSONDecodeError, OSError, ValueError):
         return True
 
+    if current_size < last_size:
+        return True
     return (current_size - last_size) > 1024
 
 

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -11,6 +11,11 @@ DEFAULT_INTERVAL = 14400  # 4 hours in seconds
 EXTRACTED_DIR = Path.home() / ".truememory" / "extracted"
 
 
+def _safe_session_id(session_id: str) -> str:
+    """Sanitize session_id to prevent path traversal."""
+    return "".join(c for c in session_id if c.isalnum() or c in "-_")[:64]
+
+
 def should_extract(interval: int = DEFAULT_INTERVAL) -> bool:
     """Check if enough time has elapsed since the last incremental extraction."""
     if not MARKER_PATH.exists():
@@ -45,9 +50,15 @@ def should_extract_session(session_id: str, transcript_path: str) -> bool:
     """
     if not session_id or session_id == "unknown":
         return True
+    if not transcript_path or not transcript_path.strip():
+        return True
+
+    safe_id = _safe_session_id(session_id)
+    if not safe_id:
+        return True
 
     EXTRACTED_DIR.mkdir(parents=True, exist_ok=True)
-    marker = EXTRACTED_DIR / session_id
+    marker = EXTRACTED_DIR / safe_id
 
     if not marker.exists():
         return True
@@ -75,11 +86,17 @@ def mark_session_extracted(session_id: str, transcript_path: str) -> None:
     """
     if not session_id or session_id == "unknown":
         return
+    if not transcript_path or not transcript_path.strip():
+        return
+
+    safe_id = _safe_session_id(session_id)
+    if not safe_id:
+        return
 
     try:
         EXTRACTED_DIR.mkdir(parents=True, exist_ok=True)
         current_size = Path(transcript_path).stat().st_size
-        marker = EXTRACTED_DIR / session_id
+        marker = EXTRACTED_DIR / safe_id
         marker.write_text(json.dumps({
             "size": current_size,
             "timestamp": time.time(),

--- a/truememory/ingest/hooks/compact.py
+++ b/truememory/ingest/hooks/compact.py
@@ -70,14 +70,9 @@ def main():
     except Exception as e:
         log.error("Compact hook failed: %s", e)
 
-    # Background extraction: context is about to be compressed, so run
-    # the full extraction pipeline on the transcript before it's lost.
-    # The snapshot above is a lightweight breadcrumb; this does deep
-    # LLM-based fact extraction. Uses the shared timestamp marker to
-    # coordinate with the UserPromptSubmit incremental trigger.
     try:
-        from truememory.ingest.hooks._shared import should_extract, mark_extracted
-        if should_extract(interval=0):
+        from truememory.ingest.hooks._shared import should_extract_session, mark_session_extracted
+        if should_extract_session(session_id, transcript_path):
             from truememory.ingest.hooks.stop import (
                 _has_enough_messages, _run_background_ingestion,
                 TRACE_DIR, LOG_DIR,
@@ -89,7 +84,7 @@ def main():
                     transcript_path, session_id,
                     user_id=args.user, db_path=args.db,
                 )
-                mark_extracted()
+                mark_session_extracted(session_id, transcript_path)
     except Exception as e:
         log.error("Compact background extraction failed: %s", e)
 

--- a/truememory/ingest/hooks/compact.py
+++ b/truememory/ingest/hooks/compact.py
@@ -43,6 +43,9 @@ def _parse_args() -> argparse.Namespace:
 
 
 def main():
+    if os.environ.get("TRUEMEMORY_EXTRACTION"):
+        return
+
     args = _parse_args()
 
     try:

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -189,6 +189,9 @@ def _drain_backlog() -> None:
 
 
 def main():
+    if os.environ.get("TRUEMEMORY_EXTRACTION"):
+        return
+
     args = _parse_args()
 
     _drain_backlog()

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -175,12 +175,20 @@ def _drain_backlog() -> None:
                     cmd.extend(["--user", data["user_id"]])
                 if data.get("db_path"):
                     cmd.extend(["--db", data["db_path"]])
+                _log_dir = Path.home() / ".truememory" / "logs"
+                _log_dir.mkdir(parents=True, exist_ok=True)
+                _log_file = open(
+                    _log_dir / f"{data.get('session_id', 'unknown')}.log",
+                    "a", encoding="utf-8",
+                )
                 proc = subprocess.Popen(
                     cmd,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
+                    stdout=_log_file,
+                    stderr=subprocess.STDOUT,
+                    stdin=subprocess.DEVNULL,
                     start_new_session=True,
                 )
+                _log_file.close()
                 register_spawned_pid(proc.pid)
                 marker_path.unlink(missing_ok=True)
             log.info("Drained backlog session: %s", data.get("session_id", "?"))

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -182,7 +182,7 @@ def _drain_backlog() -> None:
                     start_new_session=True,
                 )
                 register_spawned_pid(proc.pid)
-            marker_path.unlink(missing_ok=True)
+                marker_path.unlink(missing_ok=True)
             log.info("Drained backlog session: %s", data.get("session_id", "?"))
         except Exception as e:
             log.debug("Failed to drain backlog entry %s: %s", marker_path.name, e)

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -175,10 +175,12 @@ def _drain_backlog() -> None:
                     cmd.extend(["--user", data["user_id"]])
                 if data.get("db_path"):
                     cmd.extend(["--db", data["db_path"]])
+                from truememory.ingest.hooks._shared import _safe_session_id
                 _log_dir = Path.home() / ".truememory" / "logs"
                 _log_dir.mkdir(parents=True, exist_ok=True)
+                _safe_sid = _safe_session_id(data.get('session_id', 'unknown')) or 'unknown'
                 _log_file = open(
-                    _log_dir / f"{data.get('session_id', 'unknown')}.log",
+                    _log_dir / f"{_safe_sid}.log",
                     "a", encoding="utf-8",
                 )
                 proc = subprocess.Popen(

--- a/truememory/ingest/hooks/stop.py
+++ b/truememory/ingest/hooks/stop.py
@@ -362,18 +362,20 @@ def _run_background_ingestion(
 
     # Use flock-based spawn gate to prevent the TOCTOU race where N hooks
     # all check pgrep simultaneously, all see 0, and all spawn.
-    from truememory.hooks.core import spawn_gate, register_spawned_pid
+    from truememory.hooks.core import spawn_gate, register_spawned_pid, _load_cap_state
+
+    effective_cap = _load_cap_state().get("cap", SPAWN_CAP)
 
     with spawn_gate() as allowed:
         if not allowed:
             log.warning(
                 "stop hook: at spawn cap (cap %d); queueing session "
                 "%r to backlog for later",
-                SPAWN_CAP, session_id,
+                effective_cap, session_id,
             )
             _queue_to_backlog(
                 transcript_path, session_id, user_id, db_path,
-                reason=f"spawn_cap_reached:SPAWN_CAP={SPAWN_CAP}",
+                reason=f"spawn_cap_reached:SPAWN_CAP={effective_cap}",
             )
             return
 

--- a/truememory/ingest/hooks/stop.py
+++ b/truememory/ingest/hooks/stop.py
@@ -110,6 +110,9 @@ def _parse_args() -> argparse.Namespace:
 
 
 def main():
+    if os.environ.get("TRUEMEMORY_EXTRACTION"):
+        return
+
     args = _parse_args()
 
     try:

--- a/truememory/ingest/hooks/stop.py
+++ b/truememory/ingest/hooks/stop.py
@@ -137,8 +137,17 @@ def main():
     if not _has_enough_messages(transcript_path, MIN_MESSAGES):
         return
 
-    # Run ingestion in the background so we don't block Claude Code
+    from truememory.ingest.hooks._shared import should_extract_session, mark_session_extracted
+    if not should_extract_session(session_id, transcript_path):
+        log.info("stop hook: session %s already extracted at this size, skipping", session_id)
+        return
+
     _run_background_ingestion(transcript_path, session_id, args.user, args.db)
+
+    try:
+        mark_session_extracted(session_id, transcript_path)
+    except Exception:
+        pass
 
 
 def _writable_dirs_ok() -> bool:

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -145,6 +145,9 @@ def _try_capture_email(prompt: str) -> None:
 
 
 def main():
+    if os.environ.get("TRUEMEMORY_EXTRACTION"):
+        return
+
     args = _parse_args()
 
     try:

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -157,7 +157,6 @@ def main():
 
     prompt = input_data.get("prompt", "").strip()
     session_id = input_data.get("session_id", "unknown")
-    transcript_path = input_data.get("transcript_path", "")
 
     if not prompt or len(prompt) < 3:
         return
@@ -170,29 +169,9 @@ def main():
 
     _try_capture_email(prompt)
 
-    # Incremental extraction: if enough time has passed since the last
-    # extraction, trigger background ingestion of the transcript so far.
-    # This captures memories during long-running sessions without waiting
-    # for the Stop hook. The encoding gate + dedup pipeline handles
-    # overlap with the Stop hook's extraction gracefully.
-    if transcript_path and Path(transcript_path).exists():
-        try:
-            interval = int(os.environ.get("TRUEMEMORY_INCREMENTAL_INTERVAL", "14400"))
-            from truememory.ingest.hooks._shared import should_extract, mark_extracted
-            if should_extract(interval):
-                from truememory.ingest.hooks.stop import (
-                    _has_enough_messages, _run_background_ingestion,
-                    TRACE_DIR, LOG_DIR,
-                )
-                TRACE_DIR.mkdir(parents=True, exist_ok=True)
-                LOG_DIR.mkdir(parents=True, exist_ok=True)
-                if _has_enough_messages(transcript_path, 5):
-                    _run_background_ingestion(
-                        transcript_path, session_id, args.user, args.db,
-                    )
-                    mark_extracted()
-        except Exception:
-            pass  # Never crash the hook
+    # Incremental extraction disabled (Fix Sprint v3): extraction now
+    # happens only on session close (Stop) and context compression
+    # (Compact), both gated by per-session transcript-size idempotency.
 
     recall_context = _try_auto_recall(prompt, args.user, args.db)
     if recall_context:

--- a/truememory/ingest/models.py
+++ b/truememory/ingest/models.py
@@ -399,6 +399,7 @@ def _complete_claude_cli(config: LLMConfig, prompt: str, system: str) -> str:
     # Strip ANTHROPIC_API_KEY so the CLI uses OAuth/keychain auth rather
     # than a potentially stale key from the parent environment.
     env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+    env["TRUEMEMORY_EXTRACTION"] = "1"
 
     try:
         proc = subprocess.run(

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1132,12 +1132,20 @@ def _drain_batch_from_backlog(markers: list[Path]) -> None:
                     cmd.extend(["--user", data["user_id"]])
                 if data.get("db_path"):
                     cmd.extend(["--db", data["db_path"]])
+                _log_dir = Path.home() / ".truememory" / "logs"
+                _log_dir.mkdir(parents=True, exist_ok=True)
+                _log_file = open(
+                    _log_dir / f"{data.get('session_id', 'unknown')}.log",
+                    "a", encoding="utf-8",
+                )
                 proc = _subprocess.Popen(
                     cmd,
-                    stdout=_subprocess.DEVNULL,
-                    stderr=_subprocess.DEVNULL,
+                    stdout=_log_file,
+                    stderr=_subprocess.STDOUT,
+                    stdin=_subprocess.DEVNULL,
                     start_new_session=True,
                 )
+                _log_file.close()
                 register_spawned_pid(proc.pid)
                 marker_path.unlink(missing_ok=True)
 

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1139,8 +1139,8 @@ def _drain_batch_from_backlog(markers: list[Path]) -> None:
                     start_new_session=True,
                 )
                 register_spawned_pid(proc.pid)
+                marker_path.unlink(missing_ok=True)
 
-            marker_path.unlink(missing_ok=True)
             log.info("Backlog drainer: processed session %s", data.get("session_id", "?"))
         except Exception:
             pass

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1148,6 +1148,8 @@ def _drain_batch_from_backlog(markers: list[Path]) -> None:
 
 def _start_backlog_drainer() -> None:
     """Launch the background backlog drainer thread."""
+    if os.environ.get("TRUEMEMORY_EXTRACTION"):
+        return
     if _BACKLOG_DRAIN_INTERVAL_NORMAL <= 0:
         log.info("Backlog drainer disabled (TRUEMEMORY_DRAIN_INTERVAL_SEC=0)")
         return

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1132,10 +1132,12 @@ def _drain_batch_from_backlog(markers: list[Path]) -> None:
                     cmd.extend(["--user", data["user_id"]])
                 if data.get("db_path"):
                     cmd.extend(["--db", data["db_path"]])
+                from truememory.ingest.hooks._shared import _safe_session_id
                 _log_dir = Path.home() / ".truememory" / "logs"
                 _log_dir.mkdir(parents=True, exist_ok=True)
+                _safe_sid = _safe_session_id(data.get('session_id', 'unknown')) or 'unknown'
                 _log_file = open(
-                    _log_dir / f"{data.get('session_id', 'unknown')}.log",
+                    _log_dir / f"{_safe_sid}.log",
                     "a", encoding="utf-8",
                 )
                 proc = _subprocess.Popen(


### PR DESCRIPTION
## Summary

Fixes critical ingestion pipeline bugs that caused:
- **Ghost session recursion**: `claude -p` extraction calls created infinite feedback loops, burning 56% of a Claude 20x Max subscription in <2 hours
- **Double/triple ingestion**: Same transcript extracted 2-3x by Stop + Compact + UserPromptSubmit triggers
- **Backlog race conditions**: Three drainers could process the same marker simultaneously
- **Silent crash data loss**: Stderr went to /dev/null in drain paths

### Changes

1. **TRUEMEMORY_EXTRACTION env var** — Set in `models.py` for `claude -p` calls; all hooks + MCP drainer bail on it
2. **Transcript-size idempotency** — Per-session markers in `~/.truememory/extracted/` track file size at last extraction; skip if unchanged
3. **Disable UserPromptSubmit extraction** — Violated one-session-one-ingest rule; had 3 bugs (global marker, missing marker loop, TOCTOU race)
4. **Marker deletion inside flock** — Moved `unlink()` inside `spawn_gate()` in 3 drain paths
5. **Stderr to log files** — Drain paths now log to `~/.truememory/logs/` instead of DEVNULL
6. **Dynamic cap in log messages** — Use `_load_cap_state()` instead of static `SPAWN_CAP=2`
7. **Path traversal defense** — Sanitize session_id + guard empty transcript_path in `_shared.py`

### Test plan

- [x] Full pytest suite passes (611 passed, 0 failed)
- [x] Ruff lint passes (0 errors)
- [x] Spawn gate intact in all 5 Popen files
- [x] Ghost recursion: `TRUEMEMORY_EXTRACTION` checked in all hooks + MCP drainer
- [x] Idempotency: `should_extract_session` checked in Stop + Compact
- [x] No `interval=0` in compact.py
- [x] No `_run_background_ingestion` in user_prompt_submit.py
- [x] `marker_path.unlink` at same indent as `register_spawned_pid` in 3 drain files
- [x] 4-model OpenRouter consensus: 3/4 APPROVE (Codex non-responsive)