### PR TITLE
fix(mcp): async tool handlers + pre-computed embeddings — parallel-store hang

### DIFF
--- a/tests/test_concurrent_store_hang.py
+++ b/tests/test_concurrent_store_hang.py
@@ -1,0 +1,159 @@
+"""Regression lock for the parallel-store hang.
+
+Symptom (before fix): when Claude Code issues 3+ `truememory_store` MCP
+calls in a single parallel tool batch, the harness UI hangs 10-15+ seconds
+before any response renders, even though each individual store completes
+server-side in ~60ms. Root cause was two-layer:
+
+1. MCP layer: all 8 `@mcp.tool()` handlers were sync `def`, causing
+   FastMCP to dispatch them via `return fn(**kwargs)` which blocks the
+   single asyncio event loop thread for the duration of each call. JSON-RPC
+   requests serialized at the transport layer.
+
+2. Engine layer: `TrueMemoryEngine.add()` acquired `_write_lock` BEFORE
+   calling `embed_single()` (~10-50ms of model.encode). Encoding is
+   thread-safe (PyTorch releases the GIL inside .encode()), so concurrent
+   stores could have overlapped on inference — but the lock prevented it.
+
+Fix:
+- MCP: tools changed to `async def`, engine calls wrapped in
+  `await asyncio.to_thread(...)`.
+- Engine: embeddings pre-computed OUTSIDE `_write_lock`; lock now only
+  guards the 3 INSERTs + commit.
+
+This test exercises the engine half — kicks 3 concurrent `engine.add()`
+calls from threads and asserts the total wall-clock is well under what
+serialized encodes would take. The MCP half is verified by a separate
+asyncio.gather-based test.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading
+import time
+
+import pytest
+
+from truememory.client import Memory
+
+
+@pytest.fixture
+def memory_db(tmp_path, monkeypatch):
+    """Fresh Memory instance with a per-test DB; force Edge tier for speed."""
+    db_path = tmp_path / "concurrent_store.db"
+    monkeypatch.setenv("TRUEMEMORY_DB", str(db_path))
+    monkeypatch.setenv("TRUEMEMORY_EMBED_MODEL", "edge")
+    m = Memory()
+    yield m
+
+
+def test_engine_add_releases_lock_during_embed(memory_db):
+    """Three threads each call m.add(); total wall-clock must be well under
+    3 × serialized-encode time. The fix moves embedding OUTSIDE the
+    write lock so encodes overlap. Edge embeddings are ~5-15ms each; with
+    parallel encoding, 3 concurrent stores should land near a single-store
+    cost + small lock-contention overhead.
+    """
+    contents = [
+        "concurrent store test fact A " + "x" * 400,
+        "concurrent store test fact B " + "y" * 400,
+        "concurrent store test fact C " + "z" * 400,
+    ]
+    results: list[dict] = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def worker(content: str) -> None:
+        try:
+            r = memory_db.add(content=content, user_id="test")
+            with lock:
+                results.append(r)
+        except BaseException as e:  # noqa: BLE001 — capture all
+            with lock:
+                errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(c,)) for c in contents]
+    t0 = time.perf_counter()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    elapsed = time.perf_counter() - t0
+
+    assert not errors, f"Concurrent add() raised: {errors!r}"
+    assert len(results) == 3, f"Expected 3 results, got {len(results)}"
+
+    # The hard requirement: all 3 stores complete in well under 30s. The
+    # original bug was 10-15s harness-perceived hang on 3 concurrent stores.
+    # After the fix, 3 concurrent Edge stores should finish in < 5s
+    # (typically 200-800ms, but allow generous headroom for CI variance).
+    assert elapsed < 5.0, (
+        f"3 concurrent stores took {elapsed:.2f}s — the lock-during-embed "
+        f"regression may have returned. Expected < 5s."
+    )
+
+    # Each row must be queryable + have its own ID
+    ids = {r["id"] for r in results}
+    assert len(ids) == 3, f"Expected 3 distinct ids, got {ids}"
+
+
+def test_mcp_handlers_are_async():
+    """The 6 hot-path MCP tool handlers must be coroutine functions.
+    Sync handlers serialize concurrent MCP requests at the FastMCP layer.
+
+    truememory_configure stays sync (called once at setup, has complex
+    mutable state — not on the hot path).
+    """
+    from truememory import mcp_server as ms
+
+    expected_async = [
+        "truememory_store",
+        "truememory_search",
+        "truememory_search_deep",
+        "truememory_get",
+        "truememory_forget",
+        "truememory_stats",
+        "truememory_entity_profile",
+    ]
+    for name in expected_async:
+        fn = getattr(ms, name)
+        assert inspect.iscoroutinefunction(fn), (
+            f"{name} must be `async def` so FastMCP doesn't block the "
+            f"event loop. If you change it back to sync, expect the "
+            f"parallel-store hang to return."
+        )
+
+    # Configure intentionally stays sync — assert that too so future refactors
+    # know it's deliberate.
+    assert not inspect.iscoroutinefunction(ms.truememory_configure), (
+        "truememory_configure is intentionally sync — heavy state mutation, "
+        "called once per session at setup, not on the hot path."
+    )
+
+
+def test_mcp_store_via_asyncio_gather(memory_db, monkeypatch):
+    """Three concurrent truememory_store coroutines via asyncio.gather must
+    all complete in well under 5s. Exercises the MCP-layer fix end-to-end.
+    """
+    from truememory import mcp_server as ms
+
+    monkeypatch.setattr(ms, "_memory", memory_db)
+
+    async def _run() -> list[str]:
+        return await asyncio.gather(
+            ms.truememory_store(content="gather store A " + "x" * 400, user_id="test"),
+            ms.truememory_store(content="gather store B " + "y" * 400, user_id="test"),
+            ms.truememory_store(content="gather store C " + "z" * 400, user_id="test"),
+        )
+
+    t0 = time.perf_counter()
+    results = asyncio.run(_run())
+    elapsed = time.perf_counter() - t0
+
+    assert len(results) == 3
+    assert all(isinstance(r, str) for r in results), "All results must be JSON strings"
+    assert elapsed < 5.0, (
+        f"3 gather()-ed truememory_store coroutines took {elapsed:.2f}s — "
+        f"the async-handler regression may have returned. Expected < 5s."
+    )

--- a/tests/test_health_stats.py
+++ b/tests/test_health_stats.py
@@ -104,7 +104,8 @@ def test_health_vectors_degraded_surfaces_engine_error(server, monkeypatch):
 
 
 def test_truememory_stats_includes_health(server):
-    result_json = server.truememory_stats()
+    import asyncio
+    result_json = asyncio.run(server.truememory_stats())
     result = json.loads(result_json)
     assert "health" in result
     assert isinstance(result["health"], dict)

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -423,6 +423,33 @@ class TrueMemoryEngine:
 
         self._ensure_connection()
 
+        # Pre-compute both embeddings OUTSIDE the write lock.
+        #
+        # Previously embed_single() — which makes two model.encode() calls
+        # (~10-50ms each) — ran inside _write_lock, serializing all
+        # concurrent stores through the encoding step. Encoding is
+        # thread-safe (PyTorch releases the GIL inside .encode()), so
+        # concurrent stores can encode in parallel; they only need to
+        # contend for the lock at the actual INSERTs, which are microseconds.
+        #
+        # This is the engine half of the parallel-store-hang fix; the MCP
+        # half is async-ifying the @mcp.tool() handlers in mcp_server.py.
+        content_blob = None
+        sep_blob = None
+        if self._has_vectors:
+            try:
+                from truememory.vector_search import (
+                    _build_sep_text,
+                    get_model,
+                    serialize_f32,
+                )
+                model = get_model()
+                content_blob = serialize_f32(model.encode([content])[0])
+                sep_text = _build_sep_text(sender, recipient, timestamp, content)
+                sep_blob = serialize_f32(model.encode([sep_text])[0])
+            except Exception:
+                logger.debug("Failed to pre-compute embeddings during add()", exc_info=True)
+
         with self._write_lock:
             msg = {
                 "content": content,
@@ -434,13 +461,20 @@ class TrueMemoryEngine:
             }
             new_id = insert_message(self.conn, msg)
 
-            # Embed the message for vector search
-            if self._has_vectors:
+            # Insert pre-computed vector embeddings (no encoding here — μs-level).
+            if self._has_vectors and content_blob is not None:
                 try:
-                    from truememory.vector_search import embed_single
-                    embed_single(self.conn, new_id, content)
+                    self.conn.execute(
+                        "INSERT INTO vec_messages(rowid, embedding) VALUES (?, ?)",
+                        (new_id, content_blob),
+                    )
+                    if sep_blob is not None:
+                        self.conn.execute(
+                            "INSERT INTO vec_messages_sep(rowid, embedding) VALUES (?, ?)",
+                            (new_id, sep_blob),
+                        )
                 except Exception:
-                    logger.debug("Failed to embed message %s during add()", new_id, exc_info=True)
+                    logger.debug("Failed to insert pre-computed vectors for message %s", new_id, exc_info=True)
 
             # Incrementally update entity profile
             if self._has_personality and sender:

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -22,6 +22,7 @@ Configuration via environment variables:
 
 from __future__ import annotations
 
+import asyncio
 import gc
 import json
 import logging
@@ -530,7 +531,7 @@ def _parallel_search(queries, user_id, internal_limit, llm_fn, output_limit):
 
 @mcp.tool()
 @_tracked("tool_store")
-def truememory_store(
+async def truememory_store(
     content: str,
     user_id: str = "",
     metadata: str = "",
@@ -556,13 +557,17 @@ def truememory_store(
         meta = json.loads(metadata) if metadata else None
     except (json.JSONDecodeError, ValueError):
         meta = None
-    result = m.add(content=content, user_id=user_id or None, metadata=meta)
+    # Run engine.add in a thread so the FastMCP event loop stays free to
+    # accept concurrent JSON-RPC requests (fixes parallel-store hang).
+    result = await asyncio.to_thread(
+        m.add, content=content, user_id=user_id or None, metadata=meta
+    )
     return json.dumps(result, indent=2)
 
 
 @mcp.tool()
 @_tracked("tool_search")
-def truememory_search(
+async def truememory_search(
     query: str,
     user_id: str = "",
     limit: int = 10,
@@ -595,18 +600,21 @@ def truememory_search(
 
     if len(queries) == 1:
         m = _get_memory()
-        results = m.search_deep(
+        results = await asyncio.to_thread(
+            m.search_deep,
             queries[0], user_id=uid, limit=_SEARCH_INTERNAL_LIMIT, llm_fn=llm_fn,
         )
         return json.dumps(results[:limit], indent=2)
 
-    results = _parallel_search(queries, uid, _SEARCH_INTERNAL_LIMIT, llm_fn, limit)
+    results = await asyncio.to_thread(
+        _parallel_search, queries, uid, _SEARCH_INTERNAL_LIMIT, llm_fn, limit
+    )
     return json.dumps(results, indent=2)
 
 
 @mcp.tool()
 @_tracked("tool_search_deep")
-def truememory_search_deep(
+async def truememory_search_deep(
     query: str,
     user_id: str = "",
     limit: int = 10,
@@ -640,25 +648,28 @@ def truememory_search_deep(
 
     if len(queries) == 1:
         m = _get_memory()
-        results = m.search_deep(
+        results = await asyncio.to_thread(
+            m.search_deep,
             queries[0], user_id=uid, limit=_DEEP_INTERNAL_LIMIT, llm_fn=llm_fn,
         )
         return json.dumps(results[:limit], indent=2)
 
-    results = _parallel_search(queries, uid, _DEEP_INTERNAL_LIMIT, llm_fn, limit)
+    results = await asyncio.to_thread(
+        _parallel_search, queries, uid, _DEEP_INTERNAL_LIMIT, llm_fn, limit
+    )
     return json.dumps(results, indent=2)
 
 
 @mcp.tool()
 @_tracked("tool_get")
-def truememory_get(memory_id: int) -> str:
+async def truememory_get(memory_id: int) -> str:
     """Get a specific memory by its ID.
 
     Args:
         memory_id: The integer ID of the memory to retrieve.
     """
     m = _get_memory()
-    result = m.get(memory_id)
+    result = await asyncio.to_thread(m.get, memory_id)
     if result is None:
         return json.dumps({"error": f"Memory {memory_id} not found"})
     return json.dumps(result, indent=2)
@@ -666,26 +677,30 @@ def truememory_get(memory_id: int) -> str:
 
 @mcp.tool()
 @_tracked("tool_forget")
-def truememory_forget(memory_id: int) -> str:
+async def truememory_forget(memory_id: int) -> str:
     """Delete a memory by its ID.
 
     Args:
         memory_id: The integer ID of the memory to delete.
     """
     m = _get_memory()
-    deleted = m.delete(memory_id)
+    deleted = await asyncio.to_thread(m.delete, memory_id)
     return json.dumps({"deleted": deleted, "memory_id": memory_id})
 
 
 @mcp.tool()
 @_tracked("tool_stats")
-def truememory_stats() -> str:
+async def truememory_stats() -> str:
     """Get memory system statistics. On first run, returns a welcome message
     and setup instructions — present these to the user to walk them through
     choosing Edge, Base, or Pro tier."""
     m = _get_memory()
-    m._engine._ensure_connection()
-    stats = m.stats()
+    # Stats touches the DB (ensure_connection + COUNT queries) — run in a
+    # thread so the event loop stays free for other MCP requests.
+    def _gather_stats():
+        m._engine._ensure_connection()
+        return m.stats()
+    stats = await asyncio.to_thread(_gather_stats)
     config = _load_config()
     stats["version"] = __version__
     stats["tier"] = config.get("tier", "edge")
@@ -942,7 +957,7 @@ def truememory_configure(
 
 @mcp.tool()
 @_tracked("tool_entity_profile")
-def truememory_entity_profile(entity: str) -> str:
+async def truememory_entity_profile(entity: str) -> str:
     """Get the personality profile for an entity (person).
 
     Returns communication style, preferences, traits, and topics
@@ -952,16 +967,19 @@ def truememory_entity_profile(entity: str) -> str:
         entity: Name of the person/entity to look up.
     """
     m = _get_memory()
-    m._engine._ensure_connection()
 
-    try:
-        from truememory.personality import get_entity_profile
-        profile = get_entity_profile(m._engine.conn, entity)
-        if profile:
-            return json.dumps(profile, indent=2, default=str)
-        return json.dumps({"error": f"No profile found for '{entity}'"})
-    except Exception as e:
-        return json.dumps({"error": str(e)})
+    def _lookup():
+        m._engine._ensure_connection()
+        try:
+            from truememory.personality import get_entity_profile
+            profile = get_entity_profile(m._engine.conn, entity)
+            if profile:
+                return json.dumps(profile, indent=2, default=str)
+            return json.dumps({"error": f"No profile found for '{entity}'"})
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    return await asyncio.to_thread(_lookup)
 
 
 # ---------------------------------------------------------------------------

--- a/truememory/telemetry.py
+++ b/truememory/telemetry.py
@@ -20,6 +20,7 @@ What is NEVER tracked:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import platform
@@ -147,8 +148,38 @@ def identify(email: str, properties: dict | None = None) -> None:
 
 
 def tracked(event_name: str):
-    """Decorator that emits a telemetry event after a tool function runs."""
+    """Decorator that emits a telemetry event after a tool function runs.
+
+    Detects coroutine functions and returns an async wrapper for them so
+    FastMCP correctly sees them as `async def` and dispatches them on the
+    event loop. Without this branch, wrapping an `async def` MCP tool in
+    `@tracked` produces a sync wrapper that returns an unawaited coroutine
+    object, which silently breaks the tool AND defeats the entire purpose
+    of making the handler async in the first place.
+    """
     def decorator(fn):
+        if asyncio.iscoroutinefunction(fn):
+            @wraps(fn)
+            async def async_wrapper(*args, **kwargs):
+                if not _enabled:
+                    return await fn(*args, **kwargs)
+                start = time.monotonic()
+                success = True
+                try:
+                    return await fn(*args, **kwargs)
+                except Exception:
+                    success = False
+                    raise
+                finally:
+                    try:
+                        track(event_name, {
+                            "latency_ms": round((time.monotonic() - start) * 1000, 1),
+                            "success": success,
+                        })
+                    except Exception:
+                        pass
+            return async_wrapper
+
         @wraps(fn)
         def wrapper(*args, **kwargs):
             if not _enabled:


### PR DESCRIPTION
## Summary

Resolves the 10-15 second Claude Code harness hang when 3+ parallel `truememory_store` (or `truememory_search`) MCP calls are issued in a single tool batch. Server-side writes complete in ~60ms — the hang is at the MCP transport + engine-lock layers.

Two-layer fix:

1. **MCP layer**: 7 hot-path `@mcp.tool()` handlers changed `def → async def`. Engine calls wrapped in `asyncio.to_thread()` so FastMCP's single event-loop thread stays free for concurrent JSON-RPC requests. Also fixes `@tracked` to return an async wrapper for coroutine functions (otherwise the async-ification is silently defeated by the existing sync wrapper).

2. **Engine layer**: `TrueMemoryEngine.add()` pre-computes both embeddings OUTSIDE `_write_lock`. Previously the lock was held during ~10-50ms of `model.encode()` per store, serializing all concurrent writes. PyTorch releases the GIL inside `.encode()`, so concurrent stores now overlap on inference; they only contend at the actual INSERTs (μs).

## Changes

| File | Change |
|---|---|
| `truememory/mcp_server.py` | 7 tool handlers `def → async def`; engine calls via `await asyncio.to_thread(...)` |
| `truememory/engine.py` | `add()` pre-computes content + separation embeddings outside `_write_lock` |
| `truememory/telemetry.py` | `@tracked` detects coroutine functions and returns an async wrapper for them |
| `tests/test_health_stats.py` | Update `test_truememory_stats_includes_health` to await the now-async handler |
| `tests/test_concurrent_store_hang.py` | **NEW** — 3 regression tests (threaded `engine.add()`, handler-shape check, `asyncio.gather()` end-to-end) |

`truememory_configure` intentionally stays sync — heavy state mutation, called once at setup, not on the hot path.

## Test Plan

- [x] New regression tests pass: `pytest tests/test_concurrent_store_hang.py` (3/3)
- [x] Health stats tests pass: `pytest tests/test_health_stats.py` (11/11)
- [x] Threading tests pass: `pytest tests/test_ensure_connection_threading.py` (2/2)
- [x] Wider suite on Windows: 572 pass / 17 pre-existing failures unrelated to this change (`test_platform_compat.py` POSIX-path tests, `test_spawn_gate.py` system-memory dependent, `test_cli_help.py` locale issues, etc.)
- [ ] **Manual verification needed on POSIX** — pytest on Linux/macOS to confirm no regression in the Windows-failing tests

## Breaking Changes

The 7 MCP tool handlers are now `async def`. **Transparent for MCP clients** (JSON-RPC wire protocol unchanged). Direct Python callers must update:

```diff
- result = truememory_store(content="...", user_id="...")
+ result = await truememory_store(content="...", user_id="...")
+ # or, from sync code:  result = asyncio.run(truememory_store(content="...", user_id="..."))
```

Co-Authored-By: claude-opus-4-7 <wontreply@getfucked.ai>
