### PR TITLE
fix: atomic rename claim prevents backlog drain TOCTOU (#319)

### DIFF
--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -234,12 +234,23 @@ def _cascade_next() -> None:
     next one before exiting. The chain terminates naturally when the
     backlog is empty or the spawn cap is reached. SessionStart hooks
     act as a backup kickstarter if the chain breaks.
+
+    Uses atomic rename (.json → .processing) to prevent TOCTOU races where
+    multiple drainers read the same marker before either acquires the flock.
     """
     import subprocess as _sp
+    import time as _time
 
     backlog_dir = Path.home() / ".truememory" / "backlog"
     if not backlog_dir.exists():
         return
+
+    for stale in backlog_dir.glob("*.processing"):
+        try:
+            if _time.time() - stale.stat().st_mtime > 300:
+                stale.rename(stale.with_suffix(".json"))
+        except OSError:
+            pass
 
     try:
         markers = sorted(backlog_dir.glob("*.json"))
@@ -255,16 +266,26 @@ def _cascade_next() -> None:
         return
 
     for marker_path in markers[:1]:
+        claimed_path = marker_path.with_suffix(".processing")
+        try:
+            marker_path.rename(claimed_path)
+        except (FileNotFoundError, OSError):
+            continue
+
         try:
             import json as _json
-            data = _json.loads(marker_path.read_text(encoding="utf-8"))
+            data = _json.loads(claimed_path.read_text(encoding="utf-8"))
             transcript = data.get("transcript_path", "")
             if not transcript or not Path(transcript).exists():
-                marker_path.unlink(missing_ok=True)
+                claimed_path.unlink(missing_ok=True)
                 continue
 
             with spawn_gate() as allowed:
                 if not allowed:
+                    try:
+                        claimed_path.rename(marker_path)
+                    except OSError:
+                        pass
                     return
 
                 cmd = [
@@ -285,14 +306,17 @@ def _cascade_next() -> None:
                     start_new_session=True,
                 )
                 register_spawned_pid(proc.pid)
-                marker_path.unlink(missing_ok=True)
 
+            claimed_path.unlink(missing_ok=True)
             logging.getLogger(__name__).info(
                 "Cascade: spawned next ingest for session %s (PID %d)",
                 data.get("session_id", "?"), proc.pid,
             )
         except Exception:
-            pass
+            try:
+                claimed_path.rename(marker_path)
+            except OSError:
+                pass
 
 
 def _preflight_writable_target(target: str | None, *, kind: str) -> bool:

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -140,9 +140,22 @@ def _drain_backlog() -> None:
     Uses the flock-based spawn gate from core to prevent the avalanche
     scenario where N concurrent SessionStart hooks all drain simultaneously,
     spawning N × _DRAIN_CAP ingest processes.
+
+    Uses atomic rename (.json → .processing) to prevent TOCTOU races where
+    multiple drainers read the same marker before either acquires the flock.
     """
     if not BACKLOG_DIR.exists():
         return
+
+    import time as _time
+
+    for stale in BACKLOG_DIR.glob("*.processing"):
+        try:
+            if _time.time() - stale.stat().st_mtime > 300:
+                stale.rename(stale.with_suffix(".json"))
+        except OSError:
+            pass
+
     try:
         markers = sorted(BACKLOG_DIR.glob("*.json"))[:_DRAIN_CAP]
     except Exception:
@@ -151,16 +164,26 @@ def _drain_backlog() -> None:
     from truememory.hooks.core import spawn_gate, register_spawned_pid
 
     for marker_path in markers:
+        claimed_path = marker_path.with_suffix(".processing")
         try:
-            data = json.loads(marker_path.read_text(encoding="utf-8"))
+            marker_path.rename(claimed_path)
+        except (FileNotFoundError, OSError):
+            continue
+
+        try:
+            data = json.loads(claimed_path.read_text(encoding="utf-8"))
             transcript = data.get("transcript_path", "")
             if not transcript or not Path(transcript).exists():
-                marker_path.unlink(missing_ok=True)
+                claimed_path.unlink(missing_ok=True)
                 continue
 
             with spawn_gate() as allowed:
                 if not allowed:
                     log.info("Drain: spawn cap reached, leaving remaining backlog for next session")
+                    try:
+                        claimed_path.rename(marker_path)
+                    except OSError:
+                        pass
                     return
 
                 import subprocess
@@ -192,9 +215,13 @@ def _drain_backlog() -> None:
                 )
                 _log_file.close()
                 register_spawned_pid(proc.pid)
-                marker_path.unlink(missing_ok=True)
+            claimed_path.unlink(missing_ok=True)
             log.info("Drained backlog session: %s", data.get("session_id", "?"))
         except Exception as e:
+            try:
+                claimed_path.rename(marker_path)
+            except OSError:
+                pass
             log.debug("Failed to drain backlog entry %s: %s", marker_path.name, e)
 
 

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1105,20 +1105,44 @@ def _reap_children() -> None:
 
 
 def _drain_batch_from_backlog(markers: list[Path]) -> None:
-    """Fill all available spawn slots from the backlog."""
+    """Fill all available spawn slots from the backlog.
+
+    Uses atomic rename (.json → .processing) to prevent TOCTOU races where
+    multiple drainers read the same marker before either acquires the flock.
+    """
     import subprocess as _subprocess
+    import time as _time
     from truememory.hooks.core import spawn_gate, register_spawned_pid
 
+    backlog_dir = markers[0].parent if markers else None
+    if backlog_dir:
+        for stale in backlog_dir.glob("*.processing"):
+            try:
+                if _time.time() - stale.stat().st_mtime > 300:
+                    stale.rename(stale.with_suffix(".json"))
+            except OSError:
+                pass
+
     for marker_path in markers:
+        claimed_path = marker_path.with_suffix(".processing")
         try:
-            data = json.loads(marker_path.read_text(encoding="utf-8"))
+            marker_path.rename(claimed_path)
+        except (FileNotFoundError, OSError):
+            continue
+
+        try:
+            data = json.loads(claimed_path.read_text(encoding="utf-8"))
             transcript = data.get("transcript_path", "")
             if not transcript or not Path(transcript).exists():
-                marker_path.unlink(missing_ok=True)
+                claimed_path.unlink(missing_ok=True)
                 continue
 
             with spawn_gate() as allowed:
                 if not allowed:
+                    try:
+                        claimed_path.rename(marker_path)
+                    except OSError:
+                        pass
                     return
 
                 cmd = [
@@ -1149,11 +1173,14 @@ def _drain_batch_from_backlog(markers: list[Path]) -> None:
                 )
                 _log_file.close()
                 register_spawned_pid(proc.pid)
-                marker_path.unlink(missing_ok=True)
 
+            claimed_path.unlink(missing_ok=True)
             log.info("Backlog drainer: processed session %s", data.get("session_id", "?"))
         except Exception:
-            pass
+            try:
+                claimed_path.rename(marker_path)
+            except OSError:
+                pass
 
 
 def _start_backlog_drainer() -> None:


### PR DESCRIPTION
## Summary
- Backlog marker read was outside spawn_gate flock, allowing duplicate ingest spawns
- Now uses `Path.rename()` as atomic claim before reading (same-directory, same-filesystem = atomic on POSIX)
- Stale `.processing` files (>5 min, crash recovery) restored to `.json` at drain start
- Applied to all 3 drain paths: `session_start.py`, `mcp_server.py`, `cli.py`

## Design notes
- `.processing` files only exist during the brief rename→spawn→unlink window (normally <100ms)
- The 5-min stale timeout is >1000x the normal window — purely for crashed-process recovery
- Spawn gate flock still used for Popen gating (not removed or weakened)

## Test plan
- [x] Full pytest passes (611 passed, 0 failed)
- [x] Lint clean (ruff)
- [x] Spawn gate intact in all 5 files (grep verified)
- [x] Pre-fix 4-model consensus: approach approved (stale cleanup was the only requested addition)

Closes #319