### PR TITLE
fix: stale session scanner + gated incremental extraction (#320)

### DIFF
--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -33,6 +33,9 @@ MEMORY_LIMIT = int(os.environ.get("TRUEMEMORY_RECALL_LIMIT", "25"))
 ONBOARDED_MARKER = Path.home() / ".truememory" / ".onboarded"
 BACKLOG_DIR = Path.home() / ".truememory" / "backlog"
 _DRAIN_CAP = 3
+_SCAN_MARKER = Path.home() / ".truememory" / ".last_stale_scan"
+_SCAN_INTERVAL = 900  # 15 minutes
+_SCAN_CAP = 3  # max sessions to queue per scan
 
 BANNER = r"""
 ████████╗██████╗ ██╗   ██╗███████╗    ███╗   ███╗███████╗███╗   ███╗ ██████╗ ██████╗ ██╗   ██╗
@@ -198,6 +201,82 @@ def _drain_backlog() -> None:
             log.debug("Failed to drain backlog entry %s: %s", marker_path.name, e)
 
 
+def _scan_stale_sessions() -> None:
+    """Find transcripts from recent sessions that were never extracted.
+
+    Runs at most once per _SCAN_INTERVAL. Scans Claude Code's project
+    directories for session transcripts modified in the last 24 hours
+    that have no corresponding extraction marker.
+    """
+    import time
+    import re
+
+    if _SCAN_MARKER.exists():
+        try:
+            if time.time() - _SCAN_MARKER.stat().st_mtime < _SCAN_INTERVAL:
+                return
+        except OSError:
+            pass
+
+    try:
+        _SCAN_MARKER.parent.mkdir(parents=True, exist_ok=True)
+        _SCAN_MARKER.write_text(str(time.time()), encoding="utf-8")
+    except OSError:
+        pass
+
+    claude_dir = Path.home() / ".claude" / "projects"
+    if not claude_dir.exists():
+        return
+
+    from truememory.ingest.hooks._shared import EXTRACTED_DIR, _safe_session_id
+    from truememory.ingest.hooks.stop import _queue_to_backlog
+
+    uuid_re = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+    cutoff = time.time() - 86400
+    queued = 0
+
+    for project_dir in claude_dir.iterdir():
+        if not project_dir.is_dir():
+            continue
+        for transcript in project_dir.iterdir():
+            if transcript.suffix != ".jsonl":
+                continue
+            if not transcript.is_file():
+                continue
+            session_id = transcript.stem
+            if not uuid_re.match(session_id):
+                continue
+            try:
+                stat = transcript.stat()
+                if stat.st_mtime < cutoff:
+                    continue
+                if stat.st_size < 5000:
+                    continue
+            except OSError:
+                continue
+
+            safe_id = _safe_session_id(session_id)
+            if not safe_id:
+                continue
+
+            marker = EXTRACTED_DIR / safe_id
+            if marker.exists():
+                continue
+
+            _queue_to_backlog(
+                str(transcript), session_id, "", "",
+                reason="stale_session_recovery",
+            )
+            queued += 1
+            if queued >= _SCAN_CAP:
+                break
+        if queued >= _SCAN_CAP:
+            break
+
+    if queued > 0:
+        log.info("Stale session scanner: queued %d unextracted sessions", queued)
+
+
 def main():
     if os.environ.get("TRUEMEMORY_EXTRACTION"):
         return
@@ -205,6 +284,7 @@ def main():
     args = _parse_args()
 
     _drain_backlog()
+    _scan_stale_sessions()
 
     try:
         input_data = json.load(sys.stdin)

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -169,9 +169,24 @@ def main():
 
     _try_capture_email(prompt)
 
-    # Incremental extraction disabled (Fix Sprint v3): extraction now
-    # happens only on session close (Stop) and context compression
-    # (Compact), both gated by per-session transcript-size idempotency.
+    transcript_path = input_data.get("transcript_path", "")
+    if transcript_path and Path(transcript_path).exists():
+        try:
+            from truememory.ingest.hooks._shared import should_extract_session, mark_session_extracted
+            if should_extract_session(session_id, transcript_path):
+                from truememory.ingest.hooks.stop import (
+                    _has_enough_messages, _run_background_ingestion,
+                    TRACE_DIR, LOG_DIR,
+                )
+                TRACE_DIR.mkdir(parents=True, exist_ok=True)
+                LOG_DIR.mkdir(parents=True, exist_ok=True)
+                if _has_enough_messages(transcript_path, 10):
+                    _run_background_ingestion(
+                        transcript_path, session_id, args.user, args.db,
+                    )
+                    mark_session_extracted(session_id, transcript_path)
+        except Exception:
+            pass
 
     recall_context = _try_auto_recall(prompt, args.user, args.db)
     if recall_context:


### PR DESCRIPTION
## Summary
- **Stale session scanner**: `session_start.py` scans `~/.claude/projects/*/*.jsonl` for unextracted transcripts from recent sessions (24h), queues to backlog. Rate-limited to once per 15 min, caps at 3 per scan. Uses UUID regex to skip subagent/non-session files.
- **Gated incremental**: `user_prompt_submit.py` re-enables mid-session extraction using `should_extract_session()` (per-session, size-based) instead of the old buggy `should_extract()` (global, time-based). Only fires on >1KB growth with >=10 messages.

## Why both?
Scanner catches sessions that ended without Stop/Compact (hard kill, OOM, SIGKILL). Incremental catches long sessions that are still running but haven't triggered Compact.

## Safety
- No new `Popen` calls added — scanner writes backlog markers (drained by existing spawn-gated code), incremental calls `_run_background_ingestion` which already wraps Popen in `spawn_gate()`
- Spawn gate verified intact in all 5 files
- Sacred parameters unchanged

## Test plan
- [x] Full pytest passes (611 passed, 0 failures)
- [x] Lint clean (ruff)
- [x] Spawn gate intact in all 5 files
- [x] 4-model consensus: 3/3 APPROVE (1 API unavailable)

Closes #320