### PR TITLE
fix(mcp): explicit queries list + 60s timeout for search tools (closes #328)

### DIFF
--- a/tests/test_concurrent_store_hang.py
+++ b/tests/test_concurrent_store_hang.py
@@ -1,0 +1,159 @@
+"""Regression lock for the parallel-store hang.
+
+Symptom (before fix): when Claude Code issues 3+ `truememory_store` MCP
+calls in a single parallel tool batch, the harness UI hangs 10-15+ seconds
+before any response renders, even though each individual store completes
+server-side in ~60ms. Root cause was two-layer:
+
+1. MCP layer: all 8 `@mcp.tool()` handlers were sync `def`, causing
+   FastMCP to dispatch them via `return fn(**kwargs)` which blocks the
+   single asyncio event loop thread for the duration of each call. JSON-RPC
+   requests serialized at the transport layer.
+
+2. Engine layer: `TrueMemoryEngine.add()` acquired `_write_lock` BEFORE
+   calling `embed_single()` (~10-50ms of model.encode). Encoding is
+   thread-safe (PyTorch releases the GIL inside .encode()), so concurrent
+   stores could have overlapped on inference — but the lock prevented it.
+
+Fix:
+- MCP: tools changed to `async def`, engine calls wrapped in
+  `await asyncio.to_thread(...)`.
+- Engine: embeddings pre-computed OUTSIDE `_write_lock`; lock now only
+  guards the 3 INSERTs + commit.
+
+This test exercises the engine half — kicks 3 concurrent `engine.add()`
+calls from threads and asserts the total wall-clock is well under what
+serialized encodes would take. The MCP half is verified by a separate
+asyncio.gather-based test.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading
+import time
+
+import pytest
+
+from truememory.client import Memory
+
+
+@pytest.fixture
+def memory_db(tmp_path, monkeypatch):
+    """Fresh Memory instance with a per-test DB; force Edge tier for speed."""
+    db_path = tmp_path / "concurrent_store.db"
+    monkeypatch.setenv("TRUEMEMORY_DB", str(db_path))
+    monkeypatch.setenv("TRUEMEMORY_EMBED_MODEL", "edge")
+    m = Memory()
+    yield m
+
+
+def test_engine_add_releases_lock_during_embed(memory_db):
+    """Three threads each call m.add(); total wall-clock must be well under
+    3 × serialized-encode time. The fix moves embedding OUTSIDE the
+    write lock so encodes overlap. Edge embeddings are ~5-15ms each; with
+    parallel encoding, 3 concurrent stores should land near a single-store
+    cost + small lock-contention overhead.
+    """
+    contents = [
+        "concurrent store test fact A " + "x" * 400,
+        "concurrent store test fact B " + "y" * 400,
+        "concurrent store test fact C " + "z" * 400,
+    ]
+    results: list[dict] = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def worker(content: str) -> None:
+        try:
+            r = memory_db.add(content=content, user_id="test")
+            with lock:
+                results.append(r)
+        except BaseException as e:  # noqa: BLE001 — capture all
+            with lock:
+                errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(c,)) for c in contents]
+    t0 = time.perf_counter()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    elapsed = time.perf_counter() - t0
+
+    assert not errors, f"Concurrent add() raised: {errors!r}"
+    assert len(results) == 3, f"Expected 3 results, got {len(results)}"
+
+    # The hard requirement: all 3 stores complete in well under 30s. The
+    # original bug was 10-15s harness-perceived hang on 3 concurrent stores.
+    # After the fix, 3 concurrent Edge stores should finish in < 5s
+    # (typically 200-800ms, but allow generous headroom for CI variance).
+    assert elapsed < 5.0, (
+        f"3 concurrent stores took {elapsed:.2f}s — the lock-during-embed "
+        f"regression may have returned. Expected < 5s."
+    )
+
+    # Each row must be queryable + have its own ID
+    ids = {r["id"] for r in results}
+    assert len(ids) == 3, f"Expected 3 distinct ids, got {ids}"
+
+
+def test_mcp_handlers_are_async():
+    """The 6 hot-path MCP tool handlers must be coroutine functions.
+    Sync handlers serialize concurrent MCP requests at the FastMCP layer.
+
+    truememory_configure stays sync (called once at setup, has complex
+    mutable state — not on the hot path).
+    """
+    from truememory import mcp_server as ms
+
+    expected_async = [
+        "truememory_store",
+        "truememory_search",
+        "truememory_search_deep",
+        "truememory_get",
+        "truememory_forget",
+        "truememory_stats",
+        "truememory_entity_profile",
+    ]
+    for name in expected_async:
+        fn = getattr(ms, name)
+        assert inspect.iscoroutinefunction(fn), (
+            f"{name} must be `async def` so FastMCP doesn't block the "
+            f"event loop. If you change it back to sync, expect the "
+            f"parallel-store hang to return."
+        )
+
+    # Configure intentionally stays sync — assert that too so future refactors
+    # know it's deliberate.
+    assert not inspect.iscoroutinefunction(ms.truememory_configure), (
+        "truememory_configure is intentionally sync — heavy state mutation, "
+        "called once per session at setup, not on the hot path."
+    )
+
+
+def test_mcp_store_via_asyncio_gather(memory_db, monkeypatch):
+    """Three concurrent truememory_store coroutines via asyncio.gather must
+    all complete in well under 5s. Exercises the MCP-layer fix end-to-end.
+    """
+    from truememory import mcp_server as ms
+
+    monkeypatch.setattr(ms, "_memory", memory_db)
+
+    async def _run() -> list[str]:
+        return await asyncio.gather(
+            ms.truememory_store(content="gather store A " + "x" * 400, user_id="test"),
+            ms.truememory_store(content="gather store B " + "y" * 400, user_id="test"),
+            ms.truememory_store(content="gather store C " + "z" * 400, user_id="test"),
+        )
+
+    t0 = time.perf_counter()
+    results = asyncio.run(_run())
+    elapsed = time.perf_counter() - t0
+
+    assert len(results) == 3
+    assert all(isinstance(r, str) for r in results), "All results must be JSON strings"
+    assert elapsed < 5.0, (
+        f"3 gather()-ed truememory_store coroutines took {elapsed:.2f}s — "
+        f"the async-handler regression may have returned. Expected < 5s."
+    )

--- a/tests/test_health_stats.py
+++ b/tests/test_health_stats.py
@@ -104,7 +104,8 @@ def test_health_vectors_degraded_surfaces_engine_error(server, monkeypatch):
 
 
 def test_truememory_stats_includes_health(server):
-    result_json = server.truememory_stats()
+    import asyncio
+    result_json = asyncio.run(server.truememory_stats())
     result = json.loads(result_json)
     assert "health" in result
     assert isinstance(result["health"], dict)

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -423,6 +423,33 @@ class TrueMemoryEngine:
 
         self._ensure_connection()
 
+        # Pre-compute both embeddings OUTSIDE the write lock.
+        #
+        # Previously embed_single() — which makes two model.encode() calls
+        # (~10-50ms each) — ran inside _write_lock, serializing all
+        # concurrent stores through the encoding step. Encoding is
+        # thread-safe (PyTorch releases the GIL inside .encode()), so
+        # concurrent stores can encode in parallel; they only need to
+        # contend for the lock at the actual INSERTs, which are microseconds.
+        #
+        # This is the engine half of the parallel-store-hang fix; the MCP
+        # half is async-ifying the @mcp.tool() handlers in mcp_server.py.
+        content_blob = None
+        sep_blob = None
+        if self._has_vectors:
+            try:
+                from truememory.vector_search import (
+                    _build_sep_text,
+                    get_model,
+                    serialize_f32,
+                )
+                model = get_model()
+                content_blob = serialize_f32(model.encode([content])[0])
+                sep_text = _build_sep_text(sender, recipient, timestamp, content)
+                sep_blob = serialize_f32(model.encode([sep_text])[0])
+            except Exception:
+                logger.debug("Failed to pre-compute embeddings during add()", exc_info=True)
+
         with self._write_lock:
             msg = {
                 "content": content,
@@ -434,13 +461,20 @@ class TrueMemoryEngine:
             }
             new_id = insert_message(self.conn, msg)
 
-            # Embed the message for vector search
-            if self._has_vectors:
+            # Insert pre-computed vector embeddings (no encoding here — μs-level).
+            if self._has_vectors and content_blob is not None:
                 try:
-                    from truememory.vector_search import embed_single
-                    embed_single(self.conn, new_id, content)
+                    self.conn.execute(
+                        "INSERT INTO vec_messages(rowid, embedding) VALUES (?, ?)",
+                        (new_id, content_blob),
+                    )
+                    if sep_blob is not None:
+                        self.conn.execute(
+                            "INSERT INTO vec_messages_sep(rowid, embedding) VALUES (?, ?)",
+                            (new_id, sep_blob),
+                        )
                 except Exception:
-                    logger.debug("Failed to embed message %s during add()", new_id, exc_info=True)
+                    logger.debug("Failed to insert pre-computed vectors for message %s", new_id, exc_info=True)
 
             # Incrementally update entity profile
             if self._has_personality and sender:

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -22,6 +22,7 @@ Configuration via environment variables:
 
 from __future__ import annotations
 
+import asyncio
 import gc
 import json
 import logging
@@ -530,7 +531,7 @@ def _parallel_search(queries, user_id, internal_limit, llm_fn, output_limit):
 
 @mcp.tool()
 @_tracked("tool_store")
-def truememory_store(
+async def truememory_store(
     content: str,
     user_id: str = "",
     metadata: str = "",
@@ -556,13 +557,17 @@ def truememory_store(
         meta = json.loads(metadata) if metadata else None
     except (json.JSONDecodeError, ValueError):
         meta = None
-    result = m.add(content=content, user_id=user_id or None, metadata=meta)
+    # Run engine.add in a thread so the FastMCP event loop stays free to
+    # accept concurrent JSON-RPC requests (fixes parallel-store hang).
+    result = await asyncio.to_thread(
+        m.add, content=content, user_id=user_id or None, metadata=meta
+    )
     return json.dumps(result, indent=2)
 
 
 @mcp.tool()
 @_tracked("tool_search")
-def truememory_search(
+async def truememory_search(
     query: str,
     user_id: str = "",
     limit: int = 10,
@@ -595,18 +600,21 @@ def truememory_search(
 
     if len(queries) == 1:
         m = _get_memory()
-        results = m.search_deep(
+        results = await asyncio.to_thread(
+            m.search_deep,
             queries[0], user_id=uid, limit=_SEARCH_INTERNAL_LIMIT, llm_fn=llm_fn,
         )
         return json.dumps(results[:limit], indent=2)
 
-    results = _parallel_search(queries, uid, _SEARCH_INTERNAL_LIMIT, llm_fn, limit)
+    results = await asyncio.to_thread(
+        _parallel_search, queries, uid, _SEARCH_INTERNAL_LIMIT, llm_fn, limit
+    )
     return json.dumps(results, indent=2)
 
 
 @mcp.tool()
 @_tracked("tool_search_deep")
-def truememory_search_deep(
+async def truememory_search_deep(
     query: str,
     user_id: str = "",
     limit: int = 10,
@@ -640,25 +648,28 @@ def truememory_search_deep(
 
     if len(queries) == 1:
         m = _get_memory()
-        results = m.search_deep(
+        results = await asyncio.to_thread(
+            m.search_deep,
             queries[0], user_id=uid, limit=_DEEP_INTERNAL_LIMIT, llm_fn=llm_fn,
         )
         return json.dumps(results[:limit], indent=2)
 
-    results = _parallel_search(queries, uid, _DEEP_INTERNAL_LIMIT, llm_fn, limit)
+    results = await asyncio.to_thread(
+        _parallel_search, queries, uid, _DEEP_INTERNAL_LIMIT, llm_fn, limit
+    )
     return json.dumps(results, indent=2)
 
 
 @mcp.tool()
 @_tracked("tool_get")
-def truememory_get(memory_id: int) -> str:
+async def truememory_get(memory_id: int) -> str:
     """Get a specific memory by its ID.
 
     Args:
         memory_id: The integer ID of the memory to retrieve.
     """
     m = _get_memory()
-    result = m.get(memory_id)
+    result = await asyncio.to_thread(m.get, memory_id)
     if result is None:
         return json.dumps({"error": f"Memory {memory_id} not found"})
     return json.dumps(result, indent=2)
@@ -666,26 +677,30 @@ def truememory_get(memory_id: int) -> str:
 
 @mcp.tool()
 @_tracked("tool_forget")
-def truememory_forget(memory_id: int) -> str:
+async def truememory_forget(memory_id: int) -> str:
     """Delete a memory by its ID.
 
     Args:
         memory_id: The integer ID of the memory to delete.
     """
     m = _get_memory()
-    deleted = m.delete(memory_id)
+    deleted = await asyncio.to_thread(m.delete, memory_id)
     return json.dumps({"deleted": deleted, "memory_id": memory_id})
 
 
 @mcp.tool()
 @_tracked("tool_stats")
-def truememory_stats() -> str:
+async def truememory_stats() -> str:
     """Get memory system statistics. On first run, returns a welcome message
     and setup instructions — present these to the user to walk them through
     choosing Edge, Base, or Pro tier."""
     m = _get_memory()
-    m._engine._ensure_connection()
-    stats = m.stats()
+    # Stats touches the DB (ensure_connection + COUNT queries) — run in a
+    # thread so the event loop stays free for other MCP requests.
+    def _gather_stats():
+        m._engine._ensure_connection()
+        return m.stats()
+    stats = await asyncio.to_thread(_gather_stats)
     config = _load_config()
     stats["version"] = __version__
     stats["tier"] = config.get("tier", "edge")
@@ -942,7 +957,7 @@ def truememory_configure(
 
 @mcp.tool()
 @_tracked("tool_entity_profile")
-def truememory_entity_profile(entity: str) -> str:
+async def truememory_entity_profile(entity: str) -> str:
     """Get the personality profile for an entity (person).
 
     Returns communication style, preferences, traits, and topics
@@ -952,16 +967,19 @@ def truememory_entity_profile(entity: str) -> str:
         entity: Name of the person/entity to look up.
     """
     m = _get_memory()
-    m._engine._ensure_connection()
 
-    try:
-        from truememory.personality import get_entity_profile
-        profile = get_entity_profile(m._engine.conn, entity)
-        if profile:
-            return json.dumps(profile, indent=2, default=str)
-        return json.dumps({"error": f"No profile found for '{entity}'"})
-    except Exception as e:
-        return json.dumps({"error": str(e)})
+    def _lookup():
+        m._engine._ensure_connection()
+        try:
+            from truememory.personality import get_entity_profile
+            profile = get_entity_profile(m._engine.conn, entity)
+            if profile:
+                return json.dumps(profile, indent=2, default=str)
+            return json.dumps({"error": f"No profile found for '{entity}'"})
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    return await asyncio.to_thread(_lookup)
 
 
 # ---------------------------------------------------------------------------

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -379,6 +379,12 @@ def _get_llm_fn():
 _SEARCH_INTERNAL_LIMIT = 100   # Benchmark sweet spot
 _DEEP_INTERNAL_LIMIT = 500     # Beyond benchmark — maximum recall
 
+# Hard ceiling on a single truememory_search / truememory_search_deep call.
+# Protects against any single LLM-call, reranker-load, or SQLite-lock stall
+# escalating into a multi-minute MCP-client hang. 60s is generous — typical
+# Pro-tier search_deep completes in ~10s — but it's still recoverable.
+_SEARCH_TIMEOUT_S = 60.0
+
 # Tiered rerankers: standard search resolves per-tier via _current_reranker()
 # so Base / Pro get gte-reranker-modernbert-base (paper §2.0). The deep
 # reranker is tier-independent by design — it's a "maximum recall" escape
@@ -568,96 +574,196 @@ async def truememory_store(
 @mcp.tool()
 @_tracked("tool_search")
 async def truememory_search(
-    query: str,
+    query: str = "",
     user_id: str = "",
     limit: int = 10,
+    queries: list[str] | None = None,
 ) -> str:
     """Search memories using the full agentic retrieval pipeline (HyDE query
     expansion, cross-encoder reranking, multi-round retrieval).
 
-    Supports multiple queries separated by | for parallel execution.
-    Example: "user preferences | project context | recent decisions"
-    All queries run simultaneously and results are merged and deduplicated.
+    For multi-topic parallel search, pass an explicit ``queries`` list.
+    Each entry runs as its own search_deep in parallel (up to 5 workers)
+    and results are merged + deduplicated. Example::
+
+        queries=["user preferences", "project context", "recent decisions"]
+
+    Pipe-separated queries in ``query`` ("A | B | C") are still supported
+    for backward compatibility but DEPRECATED — they often fire by accident
+    when agents include ``|`` as natural-prose punctuation. Prefer the
+    explicit ``queries`` list.
+
+    A hard 60s timeout protects against any single stall (LLM call,
+    reranker load, SQLite lock) escalating into a multi-minute hang.
 
     Args:
-        query: Natural language search query. Use | to separate multiple queries.
+        query: Natural language search query (single topic). For parallel
+            multi-topic search, use ``queries`` instead.
         user_id: Filter results to this user (optional).
         limit: Maximum number of results to return.
+        queries: Explicit list of queries to run in parallel. Preferred
+            over pipe-separated ``query`` for multi-topic search.
     """
-    if not query or not query.strip():
-        return json.dumps([])
     _touch_search_time()
     limit = max(1, min(limit, 200))
     MAX_QUERY_LENGTH = 2000
-    if len(query) > MAX_QUERY_LENGTH:
-        query = query[:MAX_QUERY_LENGTH]
+
+    # Resolve which queries to run. Explicit ``queries`` wins; otherwise
+    # fall back to pipe-split (deprecated) or single-query.
+    if queries:
+        queries_to_run = [
+            q.strip()[:MAX_QUERY_LENGTH]
+            for q in queries
+            if q and q.strip()
+        ]
+    else:
+        if not query or not query.strip():
+            return json.dumps([])
+        if len(query) > MAX_QUERY_LENGTH:
+            query = query[:MAX_QUERY_LENGTH]
+        if "|" in query:
+            log.warning(
+                "truememory_search: pipe-separated queries in `query` are "
+                "deprecated; pass an explicit `queries` list instead. "
+                "Got %d splits from query=%r",
+                query.count("|") + 1, query[:80],
+            )
+            queries_to_run = [q.strip() for q in query.split("|") if q.strip()]
+        else:
+            queries_to_run = [query.strip()]
+
+    if not queries_to_run:
+        return json.dumps([])
+
     _set_reranker(_current_reranker())
     llm_fn = _get_llm_fn()
     uid = user_id or None
-    queries = [q.strip() for q in query.split("|") if q.strip()]
-    if not queries:
-        return json.dumps([])
 
-    if len(queries) == 1:
-        m = _get_memory()
-        results = await asyncio.to_thread(
-            m.search_deep,
-            queries[0], user_id=uid, limit=_SEARCH_INTERNAL_LIMIT, llm_fn=llm_fn,
+    try:
+        if len(queries_to_run) == 1:
+            m = _get_memory()
+            results = await asyncio.wait_for(
+                asyncio.to_thread(
+                    m.search_deep,
+                    queries_to_run[0], user_id=uid,
+                    limit=_SEARCH_INTERNAL_LIMIT, llm_fn=llm_fn,
+                ),
+                timeout=_SEARCH_TIMEOUT_S,
+            )
+            return json.dumps(results[:limit], indent=2)
+
+        results = await asyncio.wait_for(
+            asyncio.to_thread(
+                _parallel_search, queries_to_run, uid,
+                _SEARCH_INTERNAL_LIMIT, llm_fn, limit,
+            ),
+            timeout=_SEARCH_TIMEOUT_S,
         )
-        return json.dumps(results[:limit], indent=2)
-
-    results = await asyncio.to_thread(
-        _parallel_search, queries, uid, _SEARCH_INTERNAL_LIMIT, llm_fn, limit
-    )
-    return json.dumps(results, indent=2)
+        return json.dumps(results, indent=2)
+    except asyncio.TimeoutError:
+        log.error(
+            "truememory_search exceeded %.0fs timeout — aborting. queries=%d",
+            _SEARCH_TIMEOUT_S, len(queries_to_run),
+        )
+        return json.dumps({
+            "error": f"search timed out after {int(_SEARCH_TIMEOUT_S)}s",
+            "queries": len(queries_to_run),
+        })
 
 
 @mcp.tool()
 @_tracked("tool_search_deep")
 async def truememory_search_deep(
-    query: str,
+    query: str = "",
     user_id: str = "",
     limit: int = 10,
+    queries: list[str] | None = None,
 ) -> str:
     """Maximum-depth memory search (top_k=500, multi-round, full reranking).
     Uses a heavier cross-encoder (BAAI/bge-reranker-v2-m3, 568M params) than
     the standard tier-selected reranker — higher recall at higher latency.
 
     Use when truememory_search doesn't find what you need, or for questions
-    requiring evidence scattered across many memories. Supports multiple
-    queries separated by | for parallel execution.
+    requiring evidence scattered across many memories.
+
+    For multi-topic parallel search, pass an explicit ``queries`` list.
+    Pipe-separated queries in ``query`` are still supported but DEPRECATED
+    (see ``truememory_search`` for rationale).
+
+    A hard 60s timeout protects against any single stall escalating into a
+    multi-minute hang.
 
     Args:
-        query: Natural language search query. Use | to separate multiple queries.
+        query: Natural language search query (single topic). For parallel
+            multi-topic search, use ``queries`` instead.
         user_id: Filter results to this user (optional).
         limit: Maximum number of results to return.
+        queries: Explicit list of queries to run in parallel. Preferred
+            over pipe-separated ``query`` for multi-topic search.
     """
-    if not query or not query.strip():
-        return json.dumps([])
     _touch_search_time()
     limit = max(1, min(limit, 200))
     MAX_QUERY_LENGTH = 2000
-    if len(query) > MAX_QUERY_LENGTH:
-        query = query[:MAX_QUERY_LENGTH]
+
+    if queries:
+        queries_to_run = [
+            q.strip()[:MAX_QUERY_LENGTH]
+            for q in queries
+            if q and q.strip()
+        ]
+    else:
+        if not query or not query.strip():
+            return json.dumps([])
+        if len(query) > MAX_QUERY_LENGTH:
+            query = query[:MAX_QUERY_LENGTH]
+        if "|" in query:
+            log.warning(
+                "truememory_search_deep: pipe-separated queries in `query` "
+                "are deprecated; pass an explicit `queries` list instead. "
+                "Got %d splits from query=%r",
+                query.count("|") + 1, query[:80],
+            )
+            queries_to_run = [q.strip() for q in query.split("|") if q.strip()]
+        else:
+            queries_to_run = [query.strip()]
+
+    if not queries_to_run:
+        return json.dumps([])
+
     _set_reranker(_DEEP_RERANKER)
     llm_fn = _get_llm_fn()
     uid = user_id or None
-    queries = [q.strip() for q in query.split("|") if q.strip()]
-    if not queries:
-        return json.dumps([])
 
-    if len(queries) == 1:
-        m = _get_memory()
-        results = await asyncio.to_thread(
-            m.search_deep,
-            queries[0], user_id=uid, limit=_DEEP_INTERNAL_LIMIT, llm_fn=llm_fn,
+    try:
+        if len(queries_to_run) == 1:
+            m = _get_memory()
+            results = await asyncio.wait_for(
+                asyncio.to_thread(
+                    m.search_deep,
+                    queries_to_run[0], user_id=uid,
+                    limit=_DEEP_INTERNAL_LIMIT, llm_fn=llm_fn,
+                ),
+                timeout=_SEARCH_TIMEOUT_S,
+            )
+            return json.dumps(results[:limit], indent=2)
+
+        results = await asyncio.wait_for(
+            asyncio.to_thread(
+                _parallel_search, queries_to_run, uid,
+                _DEEP_INTERNAL_LIMIT, llm_fn, limit,
+            ),
+            timeout=_SEARCH_TIMEOUT_S,
         )
-        return json.dumps(results[:limit], indent=2)
-
-    results = await asyncio.to_thread(
-        _parallel_search, queries, uid, _DEEP_INTERNAL_LIMIT, llm_fn, limit
-    )
-    return json.dumps(results, indent=2)
+        return json.dumps(results, indent=2)
+    except asyncio.TimeoutError:
+        log.error(
+            "truememory_search_deep exceeded %.0fs timeout — aborting. queries=%d",
+            _SEARCH_TIMEOUT_S, len(queries_to_run),
+        )
+        return json.dumps({
+            "error": f"search timed out after {int(_SEARCH_TIMEOUT_S)}s",
+            "queries": len(queries_to_run),
+        })
 
 
 @mcp.tool()

--- a/truememory/telemetry.py
+++ b/truememory/telemetry.py
@@ -20,6 +20,7 @@ What is NEVER tracked:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import platform
@@ -147,8 +148,38 @@ def identify(email: str, properties: dict | None = None) -> None:
 
 
 def tracked(event_name: str):
-    """Decorator that emits a telemetry event after a tool function runs."""
+    """Decorator that emits a telemetry event after a tool function runs.
+
+    Detects coroutine functions and returns an async wrapper for them so
+    FastMCP correctly sees them as `async def` and dispatches them on the
+    event loop. Without this branch, wrapping an `async def` MCP tool in
+    `@tracked` produces a sync wrapper that returns an unawaited coroutine
+    object, which silently breaks the tool AND defeats the entire purpose
+    of making the handler async in the first place.
+    """
     def decorator(fn):
+        if asyncio.iscoroutinefunction(fn):
+            @wraps(fn)
+            async def async_wrapper(*args, **kwargs):
+                if not _enabled:
+                    return await fn(*args, **kwargs)
+                start = time.monotonic()
+                success = True
+                try:
+                    return await fn(*args, **kwargs)
+                except Exception:
+                    success = False
+                    raise
+                finally:
+                    try:
+                        track(event_name, {
+                            "latency_ms": round((time.monotonic() - start) * 1000, 1),
+                            "success": success,
+                        })
+                    except Exception:
+                        pass
+            return async_wrapper
+
         @wraps(fn)
         def wrapper(*args, **kwargs):
             if not _enabled:


### PR DESCRIPTION
## Summary

`truememory_search` and `truememory_search_deep` currently split the `query` string on `|` to fan out parallel sub-searches. Agents writing prose queries commonly include `|` as natural punctuation, triggering parallel fanout they never intended. Combined with concurrent subagents calling the search tools, this compounded into a 1h21m hang for me today.

This PR adds an explicit `queries: list[str]` parameter as the preferred way to request parallel searches, keeps pipe-split working with a deprecation warning for one release, and wraps both handlers with `asyncio.wait_for(timeout=60.0)` so any future stall surfaces as a recoverable error rather than an indefinite hang. Fully backward compatible.

**Stacks on top of #318** (the async-handlers parallel-store-hang fix). When #318 merges, this PR's diff will simplify to only the new logic.

## Changes

| File | Change |
|------|--------|
| `truememory/mcp_server.py` | Add `queries: list[str]` param to both search tools; add `_SEARCH_TIMEOUT_S = 60.0` constant; wrap both handlers with `asyncio.wait_for`; emit deprecation warning log when pipe-split is invoked. |

## Test plan

- [ ] Single-query call: `truememory_search(query="x")` returns results, no warning logged.
- [ ] Pipe-split legacy: `truememory_search(query="a | b")` returns merged results, emits deprecation warning.
- [ ] Explicit queries: `truememory_search(queries=["a", "b"])` returns merged results, no warning.
- [ ] Empty: `truememory_search()` and `truememory_search(query="")` return `"[]"`.
- [ ] Timeout: synthetic test injecting a 90s sleep into `_parallel_search` aborts cleanly at 60s.

## References

Symptom was previously documented in a personal note: pipe-separated searches "fan out to multiple search_deep calls and DOUBLY hang." Today's 1h21m hang shows the symptom in `mcp-debug.log`: zero `Memory.search_deep ENTER` entries during the hang window, heartbeats firing normally, two queued requests draining at abort time.

Co-Authored-By: claude-opus-4-7 <wontreply@getfucked.ai>
