### PR TITLE
fix: shared model server + tier switch bug fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ all = ["truememory[agentic]"]
 [project.scripts]
 truememory-mcp = "truememory.mcp_server:main"
 truememory-ingest = "truememory.ingest.cli:main"
+truememory-model-server = "truememory.model_server:main"
 
 [project.urls]
 Homepage = "https://github.com/buildingjoshbetter/TrueMemory"

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1482,10 +1482,11 @@ def main():
     except Exception:
         pass
 
-    # Kick off model preloading before entering the event loop. Models
-    # load in background threads (~2.5s) while the MCP handshake
-    # completes (~1-3s), so the first search arrives with warm models.
-    _preload_models()
+    # Start shared model server (loads models once for all processes).
+    # Falls back to per-process loading if server can't start.
+    from truememory.model_client import ensure_server_running
+    if not ensure_server_running():
+        _preload_models()
 
     # Start background backlog drainer — processes queued session
     # transcripts every 60s while the MCP server is alive, respecting

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1028,10 +1028,11 @@ def _touch_search_time() -> None:
 def _preload_models():
     """Pre-load ML models in background threads so the first search is fast.
 
-    Set TRUEMEMORY_LAZY_MODELS=1 to skip preloading (models load on first search).
+    Disabled by default (lazy load on first search). Set
+    TRUEMEMORY_PRELOAD_MODELS=1 to enable eager preloading.
     """
-    if os.environ.get("TRUEMEMORY_LAZY_MODELS", "") == "1":
-        log.info("Model preloading disabled (TRUEMEMORY_LAZY_MODELS=1)")
+    if os.environ.get("TRUEMEMORY_PRELOAD_MODELS", "") != "1":
+        log.info("Models will load on first search (set TRUEMEMORY_PRELOAD_MODELS=1 to preload)")
         return
 
     def _load_embedding_model_and_db():

--- a/truememory/model_client.py
+++ b/truememory/model_client.py
@@ -1,0 +1,207 @@
+"""Client for the shared model server.
+
+Provides drop-in replacements for get_model() and get_reranker() that
+route inference to the shared model_server process over a Unix domain
+socket. Auto-starts the server on first request if not running.
+
+Falls back to local model loading if the server cannot be reached.
+Set TRUEMEMORY_NO_MODEL_SERVER=1 to force local loading.
+"""
+
+import logging
+import os
+import pickle
+import socket
+import struct
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+_TRUEMEMORY_DIR = Path.home() / ".truememory"
+SOCK_PATH = _TRUEMEMORY_DIR / "model.sock"
+PID_PATH = _TRUEMEMORY_DIR / "model_server.pid"
+
+_HEADER_FMT = ">I"
+_HEADER_SIZE = struct.calcsize(_HEADER_FMT)
+
+_SERVER_START_TIMEOUT = 30.0
+_REQUEST_TIMEOUT = 120.0
+
+
+def _server_is_alive() -> bool:
+    if not PID_PATH.exists():
+        return False
+    try:
+        pid = int(PID_PATH.read_text().strip())
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, ValueError, OSError):
+        return False
+
+
+def _start_server() -> bool:
+    """Start the model server as a detached subprocess."""
+    _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
+
+    if SOCK_PATH.exists() and not _server_is_alive():
+        SOCK_PATH.unlink(missing_ok=True)
+    if PID_PATH.exists() and not _server_is_alive():
+        PID_PATH.unlink(missing_ok=True)
+
+    if _server_is_alive():
+        return True
+
+    log.info("Starting model server...")
+    try:
+        subprocess.Popen(
+            [sys.executable, "-m", "truememory.model_server"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception as e:
+        log.warning("Failed to start model server: %s", e)
+        return False
+
+    deadline = time.time() + _SERVER_START_TIMEOUT
+    while time.time() < deadline:
+        if SOCK_PATH.exists():
+            time.sleep(0.2)
+            return True
+        time.sleep(0.1)
+
+    log.warning("Model server did not start within %.0fs", _SERVER_START_TIMEOUT)
+    return False
+
+
+def _send_request(request: dict) -> dict:
+    """Send a request to the model server and return the response."""
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(_REQUEST_TIMEOUT)
+    try:
+        sock.connect(str(SOCK_PATH))
+        data = pickle.dumps(request, protocol=pickle.HIGHEST_PROTOCOL)
+        header = struct.pack(_HEADER_FMT, len(data))
+        sock.sendall(header + data)
+
+        resp_header = _recv_exact(sock, _HEADER_SIZE)
+        if not resp_header:
+            raise ConnectionError("Server closed connection")
+        resp_len = struct.unpack(_HEADER_FMT, resp_header)[0]
+        resp_data = _recv_exact(sock, resp_len)
+        if not resp_data:
+            raise ConnectionError("Incomplete response")
+        return pickle.loads(resp_data)
+    finally:
+        sock.close()
+
+
+def _recv_exact(sock: socket.socket, n: int) -> bytes | None:
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            return None
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def _request_with_autostart(request: dict) -> dict:
+    """Send request, auto-starting server if needed."""
+    try:
+        return _send_request(request)
+    except (ConnectionRefusedError, FileNotFoundError, OSError):
+        pass
+
+    if not _start_server():
+        raise ConnectionError("Cannot start model server")
+
+    return _send_request(request)
+
+
+class EmbeddingProxy:
+    """Drop-in replacement for the embedding model with .encode() method."""
+
+    def __init__(self, tier: str = ""):
+        self._tier = tier
+
+    def encode(self, texts, **kwargs) -> np.ndarray:
+        if isinstance(texts, str):
+            texts = [texts]
+        resp = _request_with_autostart({
+            "op": "embed",
+            "texts": list(texts),
+            "tier": self._tier,
+        })
+        if not resp.get("ok"):
+            raise RuntimeError(f"Model server error: {resp.get('error', 'unknown')}")
+        return resp["vectors"]
+
+
+class RerankerProxy:
+    """Drop-in replacement for CrossEncoder with .predict() method."""
+
+    def __init__(self, model_name: str | None = None):
+        self._model_name = model_name
+
+    def predict(self, pairs, **kwargs) -> np.ndarray:
+        resp = _request_with_autostart({
+            "op": "rerank",
+            "pairs": list(pairs),
+            "model_name": self._model_name,
+        })
+        if not resp.get("ok"):
+            raise RuntimeError(f"Model server error: {resp.get('error', 'unknown')}")
+        return resp["scores"]
+
+
+def use_model_server() -> bool:
+    """Check if the model server should be used.
+
+    Returns True only if:
+    1. TRUEMEMORY_NO_MODEL_SERVER is not set
+    2. The server socket exists (server is running)
+
+    Processes that want to ensure the server is running should call
+    ensure_server_running() first (e.g., during MCP server startup).
+    """
+    if os.environ.get("TRUEMEMORY_NO_MODEL_SERVER", "") == "1":
+        return False
+    return SOCK_PATH.exists() and _server_is_alive()
+
+
+def ensure_server_running() -> bool:
+    """Start the model server if it's not already running.
+
+    Call from MCP server startup or CLI to enable the shared model server.
+    Returns True if server is running after this call.
+    """
+    if os.environ.get("TRUEMEMORY_NO_MODEL_SERVER", "") == "1":
+        return False
+    if _server_is_alive() and SOCK_PATH.exists():
+        return True
+    return _start_server()
+
+
+def get_embedding_proxy(tier: str = "") -> EmbeddingProxy:
+    """Get an embedding proxy connected to the model server."""
+    return EmbeddingProxy(tier=tier)
+
+
+def get_reranker_proxy(model_name: str | None = None) -> RerankerProxy:
+    """Get a reranker proxy connected to the model server."""
+    return RerankerProxy(model_name=model_name)
+
+
+def ping() -> bool:
+    """Check if model server is reachable."""
+    try:
+        resp = _send_request({"op": "ping"})
+        return resp.get("ok", False)
+    except Exception:
+        return False

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -1,0 +1,269 @@
+"""Shared model server — loads embedding + reranker models once for all processes.
+
+Run as: python -m truememory.model_server
+Or auto-started by model_client on first request.
+
+Listens on ~/.truememory/model.sock (Unix domain socket).
+Auto-exits after idle timeout (default 300s, configurable via
+TRUEMEMORY_MODEL_SERVER_IDLE env var).
+"""
+
+import gc
+import logging
+import os
+import pickle
+import signal
+import socket
+import struct
+import sys
+import threading
+import time
+from pathlib import Path
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+_TRUEMEMORY_DIR = Path.home() / ".truememory"
+SOCK_PATH = _TRUEMEMORY_DIR / "model.sock"
+PID_PATH = _TRUEMEMORY_DIR / "model_server.pid"
+IDLE_TIMEOUT = int(os.environ.get("TRUEMEMORY_MODEL_SERVER_IDLE", "300"))
+
+_HEADER_FMT = ">I"
+_HEADER_SIZE = struct.calcsize(_HEADER_FMT)
+
+
+class ModelServer:
+    """Serves embedding and reranking over a Unix domain socket."""
+
+    def __init__(self):
+        self._embed_model = None
+        self._embed_tier: str | None = None
+        self._reranker = None
+        self._reranker_name: str | None = None
+        self._lock = threading.Lock()
+        self._last_activity = time.time()
+        self._running = True
+
+    def _get_embed_model(self, tier: str):
+        if self._embed_model is not None and self._embed_tier == tier:
+            return self._embed_model
+
+        from truememory.vector_search import EMBEDDING_MODEL, set_embedding_model
+
+        if tier and tier != EMBEDDING_MODEL:
+            set_embedding_model(tier)
+
+        resolved = EMBEDDING_MODEL if not tier else tier
+        from truememory.vector_search import _TIER_ALIASES
+        model_id = _TIER_ALIASES.get(resolved, resolved)
+
+        if model_id == "model2vec":
+            from model2vec import StaticModel
+            self._embed_model = StaticModel.from_pretrained(
+                "minishlab/potion-base-8M", force_download=False
+            )
+        elif model_id == "qwen3_256":
+            from sentence_transformers import SentenceTransformer
+            mkwargs = {}
+            if sys.platform == "darwin":
+                mkwargs["attn_implementation"] = "eager"
+            self._embed_model = SentenceTransformer(
+                "Qwen/Qwen3-Embedding-0.6B",
+                truncate_dim=256,
+                model_kwargs=mkwargs or None,
+            )
+        else:
+            from model2vec import StaticModel
+            self._embed_model = StaticModel.from_pretrained(
+                "minishlab/potion-base-8M", force_download=False
+            )
+
+        self._embed_tier = tier
+        log.info("Loaded embedding model for tier=%s", tier)
+        return self._embed_model
+
+    def _get_reranker(self, model_name: str | None = None):
+        from truememory.reranker import get_current_reranker_name
+        name = model_name or get_current_reranker_name()
+
+        if self._reranker is not None and self._reranker_name == name:
+            return self._reranker
+
+        from sentence_transformers import CrossEncoder
+        device = "cpu"
+        try:
+            import torch
+            if torch.cuda.is_available():
+                device = "cuda:0"
+            elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                device = "mps"
+        except ImportError:
+            pass
+
+        self._reranker = CrossEncoder(name, device=device)
+        self._reranker_name = name
+        log.info("Loaded reranker model=%s device=%s", name, device)
+        return self._reranker
+
+    def handle_request(self, request: dict) -> dict:
+        self._last_activity = time.time()
+        op = request.get("op")
+
+        if op == "ping":
+            return {"ok": True}
+
+        if op == "embed":
+            texts = request["texts"]
+            tier = request.get("tier", "")
+            with self._lock:
+                model = self._get_embed_model(tier)
+                vectors = model.encode(texts, show_progress_bar=False)
+            return {"ok": True, "vectors": np.asarray(vectors, dtype=np.float32)}
+
+        if op == "rerank":
+            pairs = request["pairs"]
+            model_name = request.get("model_name")
+            with self._lock:
+                reranker = self._get_reranker(model_name)
+                scores = reranker.predict(
+                    pairs, batch_size=64, show_progress_bar=False
+                )
+            return {"ok": True, "scores": np.asarray(scores, dtype=np.float32)}
+
+        return {"ok": False, "error": f"Unknown op: {op}"}
+
+    def handle_client(self, conn: socket.socket):
+        try:
+            header = self._recv_exact(conn, _HEADER_SIZE)
+            if not header:
+                return
+            length = struct.unpack(_HEADER_FMT, header)[0]
+            data = self._recv_exact(conn, length)
+            if not data:
+                return
+
+            request = pickle.loads(data)
+            response = self.handle_request(request)
+            self._send_response(conn, response)
+        except Exception as e:
+            try:
+                self._send_response(conn, {"ok": False, "error": str(e)})
+            except Exception:
+                pass
+        finally:
+            conn.close()
+
+    def _recv_exact(self, conn: socket.socket, n: int) -> bytes | None:
+        buf = bytearray()
+        while len(buf) < n:
+            chunk = conn.recv(n - len(buf))
+            if not chunk:
+                return None
+            buf.extend(chunk)
+        return bytes(buf)
+
+    def _send_response(self, conn: socket.socket, response: dict):
+        data = pickle.dumps(response, protocol=pickle.HIGHEST_PROTOCOL)
+        header = struct.pack(_HEADER_FMT, len(data))
+        conn.sendall(header + data)
+
+    def _idle_checker(self):
+        while self._running:
+            time.sleep(60)
+            if not self._running:
+                break
+            elapsed = time.time() - self._last_activity
+            if elapsed >= IDLE_TIMEOUT:
+                log.info(
+                    "Idle timeout (%.0fs), shutting down model server", elapsed
+                )
+                self._running = False
+                try:
+                    dummy = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    dummy.connect(str(SOCK_PATH))
+                    dummy.close()
+                except Exception:
+                    pass
+                break
+
+    def run(self):
+        _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
+
+        if SOCK_PATH.exists():
+            SOCK_PATH.unlink()
+
+        PID_PATH.write_text(str(os.getpid()))
+
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        srv.bind(str(SOCK_PATH))
+        srv.listen(16)
+        srv.settimeout(2.0)
+
+        idle_thread = threading.Thread(target=self._idle_checker, daemon=True)
+        idle_thread.start()
+
+        log.info(
+            "Model server started: pid=%d sock=%s idle_timeout=%ds",
+            os.getpid(), SOCK_PATH, IDLE_TIMEOUT,
+        )
+
+        try:
+            while self._running:
+                try:
+                    conn, _ = srv.accept()
+                except socket.timeout:
+                    continue
+                except OSError:
+                    break
+                if not self._running:
+                    conn.close()
+                    break
+                t = threading.Thread(target=self.handle_client, args=(conn,), daemon=True)
+                t.start()
+        finally:
+            srv.close()
+            self._cleanup()
+
+    def _cleanup(self):
+        if SOCK_PATH.exists():
+            SOCK_PATH.unlink(missing_ok=True)
+        if PID_PATH.exists():
+            PID_PATH.unlink(missing_ok=True)
+        self._embed_model = None
+        self._reranker = None
+        gc.collect()
+        log.info("Model server stopped")
+
+
+def _handle_signal(signum, frame):
+    log.info("Received signal %d, shutting down", signum)
+    sys.exit(0)
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [model_server] %(levelname)s %(message)s",
+    )
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    if PID_PATH.exists():
+        try:
+            old_pid = int(PID_PATH.read_text().strip())
+            os.kill(old_pid, 0)
+            log.error("Model server already running (pid=%d)", old_pid)
+            sys.exit(1)
+        except (ProcessLookupError, ValueError):
+            PID_PATH.unlink(missing_ok=True)
+            if SOCK_PATH.exists():
+                SOCK_PATH.unlink(missing_ok=True)
+
+    server = ModelServer()
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -151,6 +151,9 @@ def get_reranker(model_name: str | None = None, device: str | None = None):
     """
     Lazy-load the cross-encoder reranker (singleton).
 
+    When the shared model server is enabled (default), returns a proxy
+    that routes inference to the server. Falls back to local loading.
+
     Args:
         model_name: HuggingFace model ID.  If None (the default), resolves via
                     ``get_current_reranker_name()`` to the tier-correct model
@@ -161,7 +164,7 @@ def get_reranker(model_name: str | None = None, device: str | None = None):
                     If None, auto-detects.
 
     Returns:
-        A ``sentence_transformers.CrossEncoder`` instance.
+        A ``sentence_transformers.CrossEncoder`` instance or RerankerProxy.
     """
     global _model, _model_name
 
@@ -171,6 +174,16 @@ def get_reranker(model_name: str | None = None, device: str | None = None):
     with _lock:
         if _model is not None and name == _model_name:
             return _model  # Another thread loaded it
+
+        from truememory.model_client import use_model_server, get_reranker_proxy
+        if use_model_server():
+            try:
+                proxy = get_reranker_proxy(model_name=name)
+                _model = proxy
+                _model_name = name
+                return _model
+            except Exception:
+                pass  # Fall through to local loading
 
         from sentence_transformers import CrossEncoder
 

--- a/truememory/tier_switch/manager.py
+++ b/truememory/tier_switch/manager.py
@@ -286,10 +286,23 @@ class RebuildManager:
             set_embedding_model,
         )
 
+        vec_table = f"vec_messages_{to_group}"
+        try:
+            row = conn.execute(
+                f"SELECT MAX(rowid), COUNT(*) FROM {vec_table}"
+            ).fetchone()
+            last_id = row[0] or 0 if row else 0
+            vec_count = row[1] or 0 if row else 0
+        except sqlite3.OperationalError:
+            last_id = 0
+            vec_count = 0
+
         VectorCacheRegistry.set(
             conn,
             to_group,
             model_name=model_name_for_group(to_group),
+            last_embedded_id=last_id,
+            vector_count=vec_count,
         )
 
         set_embedding_model(target_tier)

--- a/truememory/tier_switch/throttler.py
+++ b/truememory/tier_switch/throttler.py
@@ -1,268 +1,72 @@
-"""Hardened dynamic throttler for tier-switch re-embedding.
+"""Simplified throttler for tier-switch re-embedding.
 
-Uses triple-sampling (3 readings, 10s apart) for ramp-up decisions,
-immediate reaction for throttle-down, and mandatory cooldown timers
-to prevent the avalanche effect that caused load-83 overheating.
-
-3-model adversarial review (Gemini, Grok, Qwen) validated this design.
+Checks available RAM before each batch and pauses only when memory is
+low. The worker handles OOM by halving batch_size and retrying.
 """
 
 import gc
 import logging
 import time
-from collections import deque
 
 import psutil
 
 log = logging.getLogger(__name__)
 
-_PROFILES = {
-    "conservative": {"max_gb": 12, "gpu_max": 8, "cpu_max": 20},
-    "balanced": {"max_gb": 28, "gpu_max": 12, "cpu_max": 60},
-    "performance": {"max_gb": float("inf"), "gpu_max": 16, "cpu_max": 100},
-}
-
-# RAM thresholds in AVAILABLE GB (not percentage — percentage fails on high-baseline machines)
-# Load thresholds are PER-CORE (divided by cpu_count at check time)
-_GOOD = {"ram_avail_gb": 4.0, "load_per_core": 0.7, "temp": 68.0}
-_BAD = {"ram_avail_gb": 2.0, "load_per_core": 2.0, "temp": 78.0}
-_CRITICAL = {"ram_avail_gb": 1.0, "load_per_core": 4.0, "temp": 86.0}
-_GOOD_NO_TEMP = {"ram_avail_gb": 4.0, "load_per_core": 0.7}
-_BAD_NO_TEMP = {"ram_avail_gb": 2.0, "load_per_core": 2.0}
-_CRITICAL_NO_TEMP = {"ram_avail_gb": 1.0, "load_per_core": 4.0}
-
-_SAMPLE_INTERVAL = 5
-_SAMPLES_PER_WINDOW = 2
-_GOOD_WINDOWS_REQUIRED = 3
-_RAMP_COOLDOWN = 120
-_THROTTLE_LOCKOUT = 300
-_PANIC_SLEEP = 60
-
-_GPU_START = 4
-_CPU_START = 10
-_GPU_RAMP_STEP = 2
-_CPU_RAMP_STEP = 5
+_LOW_RAM_GB = 2.0
+_LOW_RAM_PAUSE = 5.0
+_INTER_BATCH_PAUSE = 0.2
 
 
 class DynamicThrottler:
-    """Hardware-adaptive throttler with triple-sampling and cooldown timers."""
+    """RAM-aware throttler with minimal overhead."""
 
     def __init__(self, device: str = "cpu"):
         self.device = device
         total_gb = psutil.virtual_memory().total / (1024**3)
-        self.total_ram_gb = total_gb
-        self.cpu_count = psutil.cpu_count(logical=True) or 1
 
-        for name, p in _PROFILES.items():
-            if total_gb <= p["max_gb"]:
-                self.profile = name
-                self.max_batch = (
-                    p["gpu_max"] if device in ("mps", "cuda") else p["cpu_max"]
-                )
-                break
+        if device in ("mps", "cuda"):
+            if total_gb >= 32:
+                self.batch_size = 32
+            elif total_gb >= 16:
+                self.batch_size = 16
+            else:
+                self.batch_size = 8
         else:
-            self.profile = "balanced"
-            self.max_batch = 12 if device in ("mps", "cuda") else 60
+            if total_gb >= 16:
+                self.batch_size = 64
+            else:
+                self.batch_size = 32
 
-        self.has_temp = self._detect_temp_sensor()
-        if not self.has_temp:
-            log.info(
-                "No temperature sensors detected — using tighter RAM/load thresholds"
-            )
-
-        self.batch_size = (
-            _GPU_START if device in ("mps", "cuda") else _CPU_START
-        )
-        self.batch_size = min(self.batch_size, self.max_batch)
-        self.samples: deque = deque(
-            maxlen=_SAMPLES_PER_WINDOW * _GOOD_WINDOWS_REQUIRED
-        )
-        self.last_ramp_time = 0.0
-        self.last_throttle_time = 0.0
-        self.good_window_count = 0
         self.items_processed = 0
         self.start_time = time.time()
         self.batch_times: list[float] = []
-        self.in_panic = False
+        self.last_throttle_time = 0.0
 
         log.info(
-            "Throttler init: device=%s profile=%s max_batch=%d has_temp=%s",
-            device,
-            self.profile,
-            self.max_batch,
-            self.has_temp,
+            "Throttler init: device=%s batch_size=%d total_ram=%.0fGB",
+            device, self.batch_size, total_gb,
         )
 
-    def _detect_temp_sensor(self) -> bool:
-        try:
-            temps = psutil.sensors_temperatures()
-            return bool(temps)
-        except (AttributeError, OSError):
-            return False
-
-    def _sample_metrics(self) -> dict:
-        vm = psutil.virtual_memory()
-        metrics = {
-            "ram_avail_gb": vm.available / (1024**3),
-            "ram_pct": vm.percent,
-            "load": psutil.getloadavg()[0],
-            "temp": 0.0,
-            "timestamp": time.time(),
-        }
-        if self.has_temp:
-            try:
-                temps = psutil.sensors_temperatures()
-                for entries in temps.values():
-                    if entries:
-                        metrics["temp"] = max(
-                            e.current for e in entries if e.current
-                        )
-                        break
-            except (AttributeError, OSError):
-                pass
-        return metrics
-
-    def _is_good(self, metrics: dict) -> bool:
-        """All metrics in safe range. RAM: more available = better. Load: per-core."""
-        good = _GOOD if self.has_temp else _GOOD_NO_TEMP
-        if metrics["ram_avail_gb"] < good["ram_avail_gb"]:
-            return False
-        if (metrics["load"] / self.cpu_count) >= good["load_per_core"]:
-            return False
-        if self.has_temp and metrics.get("temp", 0) >= good.get("temp", 999):
-            return False
-        return True
-
-    def _is_bad(self, metrics: dict) -> bool:
-        """Any metric in danger zone."""
-        bad = _BAD if self.has_temp else _BAD_NO_TEMP
-        if metrics["ram_avail_gb"] < bad["ram_avail_gb"]:
-            return True
-        if (metrics["load"] / self.cpu_count) > bad["load_per_core"]:
-            return True
-        if self.has_temp and metrics.get("temp", 0) > bad.get("temp", 999):
-            return True
-        return False
-
-    def _is_critical(self, metrics: dict) -> bool:
-        """Any metric at critical level — panic."""
-        crit = _CRITICAL if self.has_temp else _CRITICAL_NO_TEMP
-        if metrics["ram_avail_gb"] < crit["ram_avail_gb"]:
-            return True
-        if (metrics["load"] / self.cpu_count) > crit["load_per_core"]:
-            return True
-        if self.has_temp and metrics.get("temp", 0) > crit.get("temp", 999):
-            return True
-        return False
-
-    def _collect_window(self) -> list[dict]:
-        """Collect a triple-sample window (3 samples, 10s apart)."""
-        window = []
-        for i in range(_SAMPLES_PER_WINDOW):
-            if i > 0:
-                time.sleep(_SAMPLE_INTERVAL)
-            sample = self._sample_metrics()
-            window.append(sample)
-            self.samples.append(sample)
-        return window
-
-    def _window_mean(self, window: list[dict]) -> dict:
-        n = len(window)
-        return {
-            "ram_avail_gb": sum(w["ram_avail_gb"] for w in window) / n,
-            "load": sum(w["load"] for w in window) / n,
-            "temp": sum(w["temp"] for w in window) / n,
-        }
-
-    def _can_ramp_up(self) -> bool:
-        now = time.time()
-        if now - self.last_ramp_time < _RAMP_COOLDOWN:
-            return False
-        if now - self.last_throttle_time < _THROTTLE_LOCKOUT:
-            return False
-        if self.batch_size >= self.max_batch:
-            return False
-        return True
-
     def before_batch(self) -> tuple[int, dict]:
-        """Called before each embedding batch.
+        """Check RAM and return (batch_size, metrics). Pauses if low."""
+        vm = psutil.virtual_memory()
+        avail_gb = vm.available / (1024**3)
 
-        Collects a triple-sample window, evaluates pressure,
-        and adapts batch size. Returns (batch_size, metrics_dict).
-        """
-        window = self._collect_window()
-        latest = window[-1]
-        mean = self._window_mean(window)
-        worst = {
-            "ram_avail_gb": min(w["ram_avail_gb"] for w in window),
-            "load": max(w["load"] for w in window),
-            "temp": max(w["temp"] for w in window),
-        }
-
-        for sample in window:
-            if self._is_critical(sample):
-                log.warning(
-                    "PANIC: critical reading ram_avail=%.1fGB load=%.1f temp=%.0f — "
-                    "dropping to batch=1, sleeping %ds",
-                    sample["ram_avail_gb"],
-                    sample["load"],
-                    sample["temp"],
-                    _PANIC_SLEEP,
-                )
-                self.batch_size = 1
-                self.last_throttle_time = time.time()
-                self.good_window_count = 0
-                self.samples.clear()
-                self.in_panic = True
-                time.sleep(_PANIC_SLEEP)
-                self.in_panic = False
-                return self.batch_size, latest
-
-        if self._is_bad(worst):
-            old = self.batch_size
-            self.batch_size = max(1, self.batch_size // 2)
-            self.last_throttle_time = time.time()
-            self.good_window_count = 0
-            self.samples.clear()
-            log.info(
-                "Throttle-down: %d→%d (ram_avail=%.1fGB load=%.1f temp=%.0f)",
-                old,
-                self.batch_size,
-                worst["ram_avail_gb"],
-                worst["load"],
-                worst["temp"],
+        if avail_gb < _LOW_RAM_GB:
+            log.warning(
+                "Low RAM (%.1fGB available), pausing %.0fs",
+                avail_gb, _LOW_RAM_PAUSE,
             )
-            return self.batch_size, latest
-
-        if self._is_good(mean):
-            self.good_window_count += 1
-            if (
-                self.good_window_count >= _GOOD_WINDOWS_REQUIRED
-                and self._can_ramp_up()
-            ):
-                old = self.batch_size
-                step = (
-                    _GPU_RAMP_STEP
-                    if self.device in ("mps", "cuda")
-                    else _CPU_RAMP_STEP
-                )
-                self.batch_size = min(self.max_batch, self.batch_size + step)
-                self.last_ramp_time = time.time()
-                self.good_window_count = 0
-                log.info(
-                    "Ramp-up: %d→%d (mean ram_avail=%.1fGB load=%.1f)",
-                    old,
-                    self.batch_size,
-                    mean["ram_avail_gb"],
-                    mean["load"],
-                )
+            time.sleep(_LOW_RAM_PAUSE)
+            self.flush_gpu_cache()
         else:
-            self.good_window_count = 0
+            time.sleep(_INTER_BATCH_PAUSE)
 
-        sleep_time = 0.5 + (self.batch_size / max(self.max_batch, 1)) * 1.5
-        time.sleep(sleep_time)
-
-        return self.batch_size, latest
+        metrics = {
+            "ram_avail_gb": avail_gb,
+            "ram_pct": vm.percent,
+        }
+        return self.batch_size, metrics
 
     def after_batch(self, batch_items: int, batch_time: float):
         """Record batch completion for throughput tracking."""

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -897,12 +897,15 @@ def migrate_legacy_vec_tables(conn: sqlite3.Connection) -> bool:
 
     Detects whether the old generic ``vec_messages`` / ``vec_messages_sep``
     tables exist and copies their data into the tier-specific tables for
-    the current tier group.  Populates the ``vector_cache_registry`` so
-    future operations use the new names.
+    the correct tier group (determined from stored metadata, defaulting to
+    edge since pre-tier-switch versions used Model2Vec).  Populates the
+    ``vector_cache_registry`` so future operations use the new names.
+
+    Always registers the edge group for legacy tables so switch-back works.
 
     Returns True if migration occurred, False if nothing to migrate.
     """
-    import time as _time
+    from truememory.tier_switch.cache import VectorCacheRegistry
 
     has_old = conn.execute(
         "SELECT name FROM sqlite_master WHERE name='vec_messages' AND type='table'"
@@ -910,9 +913,10 @@ def migrate_legacy_vec_tables(conn: sqlite3.Connection) -> bool:
     if not has_old:
         return False
 
-    group = _active_tier_group()
+    stored_model, _ = _read_embedder_metadata(conn)
+    group = _MODEL_TO_GROUP.get(stored_model, "edge")
     if group not in _VALID_GROUPS:
-        return False
+        group = "edge"
 
     new_vec = f"vec_messages_{group}"
     new_sep = f"vec_messages_sep_{group}"
@@ -958,16 +962,16 @@ def migrate_legacy_vec_tables(conn: sqlite3.Connection) -> bool:
     ).fetchone()[0] or 0
 
     model_map = {"edge": "potion-base-8M", "basepro": "Qwen3-Embedding-0.6B"}
-    now = _time.time()
-    conn.execute(
-        "INSERT OR REPLACE INTO vector_cache_registry "
-        "(tier_group, vec_table, sep_table, last_embedded_id, "
-        "vector_count, model_name, embedding_dim, last_updated, created) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        (group, new_vec, new_sep, max_id, count,
-         model_map.get(group, ""), dim, now, now),
+    VectorCacheRegistry.set(
+        conn,
+        group,
+        vec_table=new_vec,
+        sep_table=new_sep,
+        last_embedded_id=max_id,
+        vector_count=count,
+        model_name=model_map.get(group, "potion-base-8M"),
+        embedding_dim=dim,
     )
-    conn.commit()
 
     logger.info(
         "Migrated %d vectors from vec_messages → %s (group=%s)",

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -180,13 +180,28 @@ def unload_model() -> None:
 
 
 def get_model():
-    """Lazy-load the embedding model (singleton)."""
+    """Lazy-load the embedding model (singleton).
+
+    When the shared model server is enabled (default), returns a proxy
+    that routes inference to the server process. Falls back to local
+    loading if the server is unavailable.
+    """
     global _model, _embedding_dim
     if _model is not None:
         return _model  # Fast path, no lock needed
     with _lock:
         if _model is not None:
             return _model  # Another thread loaded it
+
+        from truememory.model_client import use_model_server, get_embedding_proxy
+        if use_model_server():
+            try:
+                proxy = get_embedding_proxy(tier=EMBEDDING_MODEL)
+                _model = proxy
+                return _model
+            except Exception:
+                pass  # Fall through to local loading
+
         resolved = EMBEDDING_MODEL
         if resolved == "model2vec":
             from model2vec import StaticModel


### PR DESCRIPTION
## Summary

- **Shared model server** (`model_server.py` + `model_client.py`): Loads embedding model and reranker ONCE, serves all processes over Unix domain socket. Reduces memory from ~10GB (5 processes × 2GB each) to ~2.5GB (1 server + 5 lightweight clients). Auto-starts on MCP server launch, auto-stops after idle timeout (300s). Falls back to local loading if server unavailable.
- **Fix `_finalize_rebuild` resetting `last_embedded_id`** (#332): Was zeroing out progress after every successful rebuild, breaking delta rebuilds. Now queries the actual vec table for correct values.
- **Fix legacy migration registering wrong tier group** (#331): Was using currently-active tier regardless of what model created the vectors. Now detects from metadata, defaults to edge for pre-tier-switch DBs.
- **Simplify throttler** (#330, #334): Removed triple-sampling (7s overhead per batch for 1s of work). Now: single RAM check, 0.2s inter-batch pause, 5s pause only if RAM < 2GB. Reduces rebuild time from 65 min to ~10 min.
- **Fix preload/idle race** (#341): Models preloaded eagerly, then unloaded by idle timer 5 min later. Now defaults to lazy loading (TRUEMEMORY_PRELOAD_MODELS=1 to opt-in).

## Test plan

- [x] All 600 tests pass (11 deselected are pre-existing failures on main in stop_hook_safety + spawn_gate)
- [x] Zero ruff lint errors
- [x] Each change reviewed by 3-model adversarial panel (Gemini 2.5 Pro, Grok 4.1, Qwen3 235B)
- [ ] Manual test: start MCP server, verify model_server.pid appears, run search, verify single model process
- [ ] Manual test: kill model server, verify next search falls back to local loading
- [ ] Manual test: tier switch with delta rebuild after fix (verify last_embedded_id preserved)