### PR TITLE
fix(hooks): guard fcntl import on Windows — _shared + session_start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Hook subprocesses crashed on every Windows launch** —
+  ``truememory/ingest/hooks/_shared.py`` and
+  ``truememory/ingest/hooks/session_start.py`` both called bare
+  ``import fcntl`` at module top, with no ``try / except ImportError``
+  guard. ``fcntl`` is POSIX-only, so on Windows every import raised
+  ``ModuleNotFoundError`` before any function ran. That cascaded to every
+  hook process that imports from ``_shared`` (SessionStart,
+  UserPromptSubmit, Stop) — silently breaking the hook-based
+  memory-extraction pipeline on Windows. Guarded both imports with the same
+  ``_HAS_FCNTL`` flag pattern already used by ``ingest/pipeline.py``,
+  ``hooks/core.py``, and ``hooks/user_prompt_submit.py``. The two call
+  sites (``_shared.check_extraction_budget`` and
+  ``session_start._maybe_scan_for_orphaned_sessions``) now gate their
+  ``fcntl.flock`` calls on ``_HAS_FCNTL`` and fall through to a non-locking
+  path on Windows.
+
+### Tests
+- ``tests/ingest/test_hooks_windows_portability.py`` (8 tests) — pins
+  the ``_HAS_FCNTL`` flag contract on both modules, verifies
+  ``check_extraction_budget`` behaves correctly without ``fcntl``
+  (allows, enforces cap, resets hourly), and includes a POSIX-only
+  regression lock that ``fcntl.flock(LOCK_EX)`` is still acquired on
+  platforms where it's available — so a future refactor can't silently
+  drop cross-process coordination.
+
 ## [0.6.8] — 2026-05-11
 
 ### Fixed

--- a/tests/ingest/test_hooks_windows_portability.py
+++ b/tests/ingest/test_hooks_windows_portability.py
@@ -1,0 +1,230 @@
+"""Regression locks for the Windows-portability fix in
+``truememory/ingest/hooks/_shared.py`` and
+``truememory/ingest/hooks/session_start.py``.
+
+Bug (before fix): both modules called ``import fcntl`` at module top with no
+``try / except ImportError`` guard. On Windows, ``fcntl`` does not exist, so
+``import truememory.ingest.hooks._shared`` raised ``ModuleNotFoundError``
+immediately. That cascaded to every Claude Code hook subprocess
+(``session_start``, ``user_prompt_submit``, ``stop``) which all import from
+``_shared``, breaking the entire hook-based memory-extraction pipeline on
+Windows.
+
+The fix mirrors the established pattern already used by
+``truememory/ingest/pipeline.py``, ``truememory/hooks/core.py``, and
+``truememory/ingest/hooks/user_prompt_submit.py``: a ``try / except
+ImportError`` wraps the import and sets ``_HAS_FCNTL``; every ``fcntl.*``
+call site guards on the flag.
+
+These tests pin three things:
+
+1. Both modules expose ``_HAS_FCNTL`` (presence of the flag is the contract
+   that the import is guarded — without the try/except, the flag would
+   never be assigned because the import would raise).
+2. ``check_extraction_budget`` falls back to a non-atomic read-modify-write
+   without raising when ``_HAS_FCNTL`` is False, and still enforces the
+   hourly cap deterministically (the lock is for concurrency, not for
+   correctness in single-threaded paths).
+3. On a POSIX environment with ``fcntl`` available, ``check_extraction_budget``
+   actually acquires LOCK_EX — a regression lock so a future refactor can't
+   silently drop the cross-process coordination on platforms that need it.
+
+Test fixtures rebuild ``_BUDGET_FILE`` per test inside ``tmp_path`` so the
+user's real ``~/.truememory/.extraction_budget`` is never touched.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Bug #1: module-level import contract
+# ---------------------------------------------------------------------------
+
+
+def test_shared_exposes_has_fcntl_flag():
+    """The ``_HAS_FCNTL`` module attribute is the contract that the import
+    is wrapped in try/except. Without the wrapper, the module would fail
+    to import on Windows with ModuleNotFoundError, so the attribute would
+    never be assigned — meaning if you can read the attribute, the guard
+    is in place.
+    """
+    from truememory.ingest.hooks import _shared
+    assert hasattr(_shared, "_HAS_FCNTL"), (
+        "_shared.py is missing the _HAS_FCNTL flag — the module-level "
+        "`import fcntl` is probably bare again, which crashes every Claude "
+        "Code hook on Windows."
+    )
+    assert isinstance(_shared._HAS_FCNTL, bool)
+
+
+def test_session_start_exposes_has_fcntl_flag():
+    """Same contract for session_start. Without this, the SessionStart hook
+    process exits with non-zero on every Windows launch before recall_memories
+    ever runs — meaning no memory injection on Windows."""
+    from truememory.ingest.hooks import session_start
+    assert hasattr(session_start, "_HAS_FCNTL"), (
+        "session_start.py is missing the _HAS_FCNTL flag — the SessionStart "
+        "hook process will crash on every Windows launch."
+    )
+    assert isinstance(session_start._HAS_FCNTL, bool)
+
+
+def test_has_fcntl_flags_agree_with_platform():
+    """The flag must reflect the host environment. On POSIX with fcntl
+    installed, True. On Windows or any other no-fcntl environment, False.
+    A mismatch means the try/except is masking a real ImportError that
+    should be surfaced.
+    """
+    try:
+        import fcntl  # noqa: F401
+        expected = True
+    except ImportError:
+        expected = False
+
+    from truememory.ingest.hooks import _shared, session_start
+    assert _shared._HAS_FCNTL is expected
+    assert session_start._HAS_FCNTL is expected
+
+
+# ---------------------------------------------------------------------------
+# Bug #2: check_extraction_budget runtime behavior without fcntl
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _isolated_budget_file(tmp_path, monkeypatch):
+    """Point ``_BUDGET_FILE`` at a per-test temp path so tests don't poison
+    the user's real ``~/.truememory/.extraction_budget`` and don't interfere
+    with each other."""
+    from truememory.ingest.hooks import _shared
+    budget_path = tmp_path / ".extraction_budget"
+    monkeypatch.setattr(_shared, "_BUDGET_FILE", budget_path)
+    return budget_path
+
+
+def test_check_extraction_budget_allows_first_call_without_fcntl(
+    _isolated_budget_file, monkeypatch,
+):
+    """Without fcntl, the function must still allow extractions up to the
+    cap. The lock skip is not the same as denying extraction — that would
+    silently break the hook pipeline on Windows.
+    """
+    from truememory.ingest.hooks import _shared
+    monkeypatch.setattr(_shared, "_HAS_FCNTL", False)
+    monkeypatch.setattr(_shared, "_MAX_EXTRACTIONS_PER_HOUR", 5)
+
+    assert _shared.check_extraction_budget() is True
+    assert _isolated_budget_file.exists()
+    data = json.loads(_isolated_budget_file.read_text(encoding="utf-8"))
+    assert data["count"] == 1
+    assert data["hour"] == int(time.time() // 3600)
+
+
+def test_check_extraction_budget_enforces_cap_without_fcntl(
+    _isolated_budget_file, monkeypatch,
+):
+    """The lock is for concurrency safety across processes; the cap itself
+    must still be enforced sequentially. Burn through the cap and verify
+    the next call is denied.
+    """
+    from truememory.ingest.hooks import _shared
+    monkeypatch.setattr(_shared, "_HAS_FCNTL", False)
+    monkeypatch.setattr(_shared, "_MAX_EXTRACTIONS_PER_HOUR", 3)
+
+    assert _shared.check_extraction_budget() is True
+    assert _shared.check_extraction_budget() is True
+    assert _shared.check_extraction_budget() is True
+    assert _shared.check_extraction_budget() is False, (
+        "4th call must be denied — the per-hour cap is enforced regardless "
+        "of whether the lock is available."
+    )
+
+
+def test_check_extraction_budget_resets_at_new_hour_without_fcntl(
+    _isolated_budget_file, monkeypatch,
+):
+    """When the recorded hour differs from the current hour, the counter
+    must reset. Verify the Windows path preserves this semantics — without
+    the reset, a single hour of heavy usage would permanently deny extraction
+    on Windows.
+    """
+    from truememory.ingest.hooks import _shared
+    monkeypatch.setattr(_shared, "_HAS_FCNTL", False)
+    monkeypatch.setattr(_shared, "_MAX_EXTRACTIONS_PER_HOUR", 1)
+
+    # Pre-populate the budget file with prior-hour data already at the cap.
+    prior_hour = int(time.time() // 3600) - 1
+    _isolated_budget_file.parent.mkdir(parents=True, exist_ok=True)
+    _isolated_budget_file.write_text(
+        json.dumps({"hour": prior_hour, "count": 999}), encoding="utf-8",
+    )
+
+    # Current hour is fresh — must allow extraction.
+    assert _shared.check_extraction_budget() is True
+
+
+def test_check_extraction_budget_does_not_call_fcntl_when_unavailable(
+    _isolated_budget_file, monkeypatch,
+):
+    """Defensive: even if a future refactor accidentally calls
+    ``fcntl.flock`` outside the ``_HAS_FCNTL`` guard, the test catches it
+    because the unguarded call would raise NameError or AttributeError
+    when _HAS_FCNTL is False and fcntl is bound to a module that isn't
+    actually loaded.
+    """
+    from truememory.ingest.hooks import _shared
+    monkeypatch.setattr(_shared, "_HAS_FCNTL", False)
+    monkeypatch.setattr(_shared, "_MAX_EXTRACTIONS_PER_HOUR", 5)
+
+    # Must complete without raising even when fcntl path is "disabled".
+    result = _shared.check_extraction_budget()
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Bug #2 regression lock: lock IS acquired on POSIX
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only — Windows has no fcntl module to call",
+)
+def test_check_extraction_budget_acquires_lock_when_fcntl_available(
+    _isolated_budget_file, monkeypatch,
+):
+    """Regression lock: on POSIX, ``check_extraction_budget`` must call
+    ``fcntl.flock`` with LOCK_EX. Without cross-process coordination, two
+    concurrent ingest processes would race on the read-modify-write and
+    the budget cap could be silently exceeded.
+    """
+    from truememory.ingest.hooks import _shared
+    monkeypatch.setattr(_shared, "_MAX_EXTRACTIONS_PER_HOUR", 5)
+    assert _shared._HAS_FCNTL is True, "test prerequisite: fcntl must be available"
+
+    flock_calls: list[tuple] = []
+    real_flock = _shared.fcntl.flock
+
+    def _spy_flock(fd, op):
+        flock_calls.append((fd, op))
+        return real_flock(fd, op)
+
+    monkeypatch.setattr(_shared.fcntl, "flock", _spy_flock)
+
+    _shared.check_extraction_budget()
+
+    assert flock_calls, (
+        "fcntl.flock was not called on POSIX — the cross-process lock has "
+        "been silently disabled. This would let concurrent ingest processes "
+        "race on the budget file and exceed the hourly cap."
+    )
+    fd, op = flock_calls[0]
+    assert op == _shared.fcntl.LOCK_EX, (
+        f"Expected LOCK_EX (exclusive), got op={op!r}. A shared lock would "
+        f"not prevent concurrent writers."
+    )

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -1,11 +1,23 @@
 """Shared utilities for TrueMemory hooks."""
 
 from pathlib import Path
-import fcntl
 import json
 import logging
 import os
 import time
+
+# fcntl is POSIX-only — Windows has no equivalent file-range locking primitive.
+# Without this guard the entire module fails to import on Windows, which in
+# turn breaks every Claude Code hook that imports from here (session_start,
+# user_prompt_submit, stop). The Windows code path falls back to non-atomic
+# read/write for the extraction budget; the worst-case race window allows
+# 1-2 extra extractions per hour, which is acceptable given the alternative
+# is no enforcement at all.
+try:
+    import fcntl  # type: ignore[import-not-found]
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover — Windows path
+    _HAS_FCNTL = False
 
 log = logging.getLogger(__name__)
 
@@ -88,14 +100,23 @@ def check_extraction_budget() -> bool:
     """Check if the hourly extraction budget allows another extraction.
 
     Returns True if extraction is allowed, False if budget is exhausted.
-    Uses flock for atomicity across concurrent processes.
+
+    On POSIX, uses ``fcntl.flock`` for atomic read-modify-write — the only
+    safe way to coordinate this across the concurrent ingest processes the
+    backlog drainer spawns. On Windows (no ``fcntl``), falls back to a
+    non-atomic read-modify-write with a narrow race window: two processes
+    could both pass the check before either writes, briefly exceeding the
+    cap by 1-2 extractions per hour. This is acceptable given the
+    alternative is either no enforcement or a Windows-specific named-mutex
+    implementation whose complexity dwarfs the rare overshoot.
     """
     if _MAX_EXTRACTIONS_PER_HOUR <= 0:
         return True
     try:
         _BUDGET_FILE.parent.mkdir(parents=True, exist_ok=True)
         fd = os.open(str(_BUDGET_FILE), os.O_RDWR | os.O_CREAT)
-        fcntl.flock(fd, fcntl.LOCK_EX)
+        if _HAS_FCNTL:
+            fcntl.flock(fd, fcntl.LOCK_EX)
         try:
             raw = os.read(fd, 4096).decode("utf-8", errors="replace").strip()
             data = json.loads(raw) if raw else {}

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -21,12 +21,24 @@ Output (stdout JSON):
 """
 
 import argparse
-import fcntl
 import json
 import logging
 import os
 import sys
 from pathlib import Path
+
+# fcntl is POSIX-only — Windows has no equivalent file-range locking. Without
+# this guard, every Claude Code session-start hook crashes on Windows with
+# ModuleNotFoundError before ever running. Only the orphaned-session scan
+# uses fcntl (advisory lock to prevent concurrent scans); the Windows path
+# skips the lock and proceeds — worst case is two processes scanning
+# simultaneously and queueing the same sessions, which the backlog drainer's
+# atomic rename already deduplicates.
+try:
+    import fcntl  # type: ignore[import-not-found]
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover — Windows path
+    _HAS_FCNTL = False
 
 log = logging.getLogger(__name__)
 
@@ -284,7 +296,13 @@ def _scan_stale_sessions() -> None:
     _SCAN_MARKER.parent.mkdir(parents=True, exist_ok=True)
     try:
         scan_fd = os.open(str(_SCAN_MARKER), os.O_RDWR | os.O_CREAT)
-        fcntl.flock(scan_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        if _HAS_FCNTL:
+            # POSIX: non-blocking advisory lock prevents concurrent scans.
+            # If another scan is in progress, exit early.
+            fcntl.flock(scan_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        # Windows: no advisory lock — concurrent scans may run simultaneously.
+        # The backlog drainer's atomic .json → .processing rename deduplicates
+        # any overlapping work, so the worst case is wasted CPU, not corruption.
     except (BlockingIOError, OSError):
         return
 


### PR DESCRIPTION
## Summary

`truememory/ingest/hooks/_shared.py` and `truememory/ingest/hooks/session_start.py`
both called bare `import fcntl` at module top with no `try / except ImportError`
guard. `fcntl` is POSIX-only — on Windows every import raised
`ModuleNotFoundError` before any function ran. That cascaded to every Claude
Code hook subprocess that imports from `_shared` (SessionStart,
UserPromptSubmit, Stop), silently breaking the hook-based memory-extraction
pipeline on Windows.

Fix mirrors the established `_HAS_FCNTL` flag pattern already used by
`ingest/pipeline.py`, `hooks/core.py`, and `ingest/hooks/user_prompt_submit.py`.
Both call sites (`_shared.check_extraction_budget` and
`session_start._scan_stale_sessions`) now gate their `fcntl.flock` calls on
`_HAS_FCNTL`. POSIX behavior is unchanged; Windows falls through to the
non-locking path with documented worst-case race semantics (1-2 extra
extractions per hour for the budget check, deduplicated overlap for the stale
scan).

This is a sibling fix to the WNOHANG guard in the cold-start resilience PR
(if that one is open) — same POSIX-only-API class of bug, same `hasattr`/
`try-except`-guard pattern.

## Changes

| File | Change |
|------|--------|
| `truememory/ingest/hooks/_shared.py` | Bare `import fcntl` → `try / except ImportError` + `_HAS_FCNTL` flag; `check_extraction_budget` guards `fcntl.flock(LOCK_EX)` on the flag; documented fallback semantics |
| `truememory/ingest/hooks/session_start.py` | Bare `import fcntl` → same `_HAS_FCNTL` guard; `_scan_stale_sessions` guards `fcntl.flock(LOCK_EX \| LOCK_NB)` on the flag with inline comment explaining the dedup path |
| `tests/ingest/test_hooks_windows_portability.py` | New file (8 tests): `_HAS_FCNTL` flag contract on both modules, `check_extraction_budget` behaves correctly without `fcntl` (allows, enforces cap, resets hourly), POSIX-only regression lock that `fcntl.flock(LOCK_EX)` is still acquired on platforms where it's available |
| `CHANGELOG.md` | Unreleased entry documenting the bug, fix, and test coverage |

## Test Plan

- [ ] `python -m pytest tests/ingest/test_hooks_windows_portability.py -v` → 7 passed + 1 skipped on Windows (the POSIX regression lock); 8 passed on POSIX
- [ ] On Windows: `python -c "from truememory.ingest.hooks import _shared, session_start, user_prompt_submit; print('OK')"` → exits 0
- [ ] Trigger a Claude Code SessionStart hook on Windows and confirm no `ModuleNotFoundError: No module named 'fcntl'` in stderr — the hook should run to completion and inject memory context
- [ ] On POSIX, spawn two concurrent `python -c "from truememory.ingest.hooks._shared import check_extraction_budget; print(check_extraction_budget())"` and confirm the budget counter increments correctly (i.e. the lock is still doing its job)

## Design Notes

- **Why fall back to non-atomic read-modify-write on Windows instead of a
  named mutex?** The Windows-specific Mutex API (`win32event.CreateMutex` /
  `pywin32`) would add a non-stdlib dependency for a code path whose
  worst-case bug (1-2 extra extractions per hour, never a corruption) is
  far below the threshold that justifies a new dependency.
- **Why skip the non-blocking scan lock on Windows instead of polling a
  filesystem-marker file?** The orphaned-session scan only runs every 15
  minutes per session-start; even if two scans run concurrently, the
  backlog drainer's atomic `.json → .processing` rename deduplicates any
  overlapping work. Adding a marker-file lock would be more code with
  similar race characteristics.
- **Why not delete the entire scan on Windows?** Hooks should have the
  same observable behavior across platforms wherever the trade-off is
  acceptable. Disabling functionality on Windows would create a
  silent-feature-gap that's harder to debug than a documented race window.

Co-Authored-By: claude-opus-4-7 <wontreply@getfucked.ai>


## Merge ordering

**Status:** `MERGEABLE` (clean against `origin/main`).

**Blocks:** #351 (Windows subprocess portability — `session_start.py:~226` Popen edit needs this PR's `_HAS_FCNTL` guard at file top to be in place first).

**Depends on:** none. Disjoint from #344 / #346 / #347 / #348 / #349 / #350 / #352 / #353.

**Recommended sequence position:** between #344 and #346.

**Full sequence** (10 PRs from a 3-agent coordination):
```
#353 (CI runner) → #344 → #345 (this) → #346 → #351 → #348 → #352 → #347 → #349 → #350
```
