### PR TITLE
fix(mcp): logging hygiene + Popen file-handle cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **``_parallel_search`` silently swallowed per-query failures** —
+  ``mcp_server.py:_parallel_search`` ran each query in a thread-pool
+  future and wrapped ``f.result()`` in a bare
+  ``except Exception: pass``. Per-query timeouts and recoverable
+  failures are part of normal behaviour under load, so WARNING-level
+  logging would be noisy, but with no log call at all an operator
+  triaging "search quality dropped" had zero breadcrumb that any
+  query had failed. Replaced the bare ``pass`` with
+  ``log.debug("parallel search query failed: %s", e)`` — keeps the
+  signal recoverable with one log-level bump, no behaviour change for
+  the happy path.
+- **Backlog drainer leaked the spawn log file on Popen failure** —
+  ``mcp_server.py:_drain_batch_from_backlog`` opened the per-session
+  ``.log`` file, passed it to ``subprocess.Popen`` as ``stdout``, and
+  then called ``_log_file.close()`` AFTER the Popen returned. If Popen
+  raised (resource error, fd exhaustion, ASR block, child-binary
+  missing), ``close()`` never ran and the FD leaked on every spawn
+  failure. Wrapped the Popen call in ``try / finally`` so close always
+  runs. A ``with open(...)`` block would have been simpler but would
+  close the file too early — Popen needs the FD inheritable through
+  the child. The try/finally form preserves that contract.
+
 ## [0.6.8] — 2026-05-11
 
 ### Fixed

--- a/tests/test_mcp_logging_hygiene.py
+++ b/tests/test_mcp_logging_hygiene.py
@@ -1,0 +1,195 @@
+"""Regression locks for PR-5 — mcp_server.py logging + Popen file-handle
+cleanup hygiene.
+
+Two narrow additive fixes:
+
+1. ``_parallel_search`` logs per-query failures at DEBUG instead of
+   silently swallowing them. An operator triaging "search quality
+   dropped" had zero breadcrumb that any query failed; now there's a
+   trace at DEBUG so the noise stays out of WARNING but the signal is
+   recoverable with one log-level bump.
+
+2. ``_drain_batch_from_backlog`` wraps the Popen call in try/finally so
+   the spawn log_file handle gets closed even if Popen raises (resource
+   error, fd exhaustion, ASR block, etc.). A bare ``_log_file.close()``
+   AFTER Popen leaked the handle on every spawn failure.
+
+Both changes are purely additive — happy-path behaviour is unchanged.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — _parallel_search logs per-query failures at DEBUG
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_search_logs_query_failures_at_debug(monkeypatch, caplog):
+    """When a query raises inside the ThreadPoolExecutor batch, the
+    failure should be logged at DEBUG. Pre-fix, the exception was
+    swallowed with a bare ``pass`` — operators had zero trace.
+
+    The batch must still complete and return the successful queries'
+    merged results — DEBUG logging must not change control flow.
+    """
+    import truememory.mcp_server as ms
+
+    # Stub _get_memory so we don't need a real DB connection.
+    fake_memory = MagicMock()
+    fake_memory._engine.db_path = ":memory:"
+    monkeypatch.setattr(ms, "_get_memory", lambda: fake_memory)
+
+    # Stub the per-thread Memory() context so one query raises and the
+    # other returns valid results.
+    class _FakeMemory:
+        def __init__(self, path):
+            self.path = path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def search_deep(self, q, **kwargs):
+            if q == "raises":
+                raise RuntimeError("simulated query failure")
+            return [{"id": 1, "score": 0.9, "content": "ok"}]
+
+    monkeypatch.setattr(ms, "Memory", _FakeMemory)
+
+    with caplog.at_level(logging.DEBUG, logger="truememory.mcp_server"):
+        results = ms._parallel_search(
+            queries=["raises", "ok"],
+            user_id="",
+            internal_limit=10,
+            llm_fn=None,
+            output_limit=5,
+        )
+
+    # Successful query result must still come through.
+    assert any(r.get("id") == 1 for r in results), (
+        "Successful query results must survive a failing sibling query."
+    )
+
+    # The failure must have left a DEBUG breadcrumb.
+    debug_messages = [
+        rec.message for rec in caplog.records
+        if rec.levelno == logging.DEBUG and "parallel search query failed" in rec.message
+    ]
+    assert debug_messages, (
+        "Per-query failure must log at DEBUG with the 'parallel search "
+        "query failed' prefix; pre-fix there was no log call at all."
+    )
+    assert any("simulated query failure" in m for m in debug_messages), (
+        "The exception detail should make it into the log message."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — backlog drainer closes log file even when Popen raises
+# ---------------------------------------------------------------------------
+
+
+def test_backlog_drainer_closes_log_file_when_popen_raises(monkeypatch, tmp_path):
+    """When `subprocess.Popen` raises inside `_drain_batch_from_backlog`,
+    the spawn log_file handle must still be closed. Pre-fix, the
+    `_log_file.close()` AFTER the Popen call never ran on Popen
+    failure, leaking the FD on every spawn error.
+
+    Implementation note: `_drain_batch_from_backlog` does late imports
+    from `truememory.ingest.hooks._shared` and `truememory.hooks.core`.
+    On Windows, the former tries `import fcntl` at module top, which
+    raises `ModuleNotFoundError` until agent-A's #345 lands. We inject
+    a fake `_shared` into `sys.modules` BEFORE importing `mcp_server`
+    to dodge that pre-existing Windows-only bug — keeps this test
+    cross-platform without waiting on #345.
+    """
+    import sys
+    import types
+
+    fake_shared = types.ModuleType("truememory.ingest.hooks._shared")
+    fake_shared.cleanup_stale_processing = lambda d: None
+    fake_shared.check_extraction_budget = lambda: True
+    fake_shared.record_stale_processing_pid = lambda *a, **kw: None
+    fake_shared._safe_session_id = lambda s: s
+    sys.modules.setdefault("truememory.ingest.hooks._shared", fake_shared)
+
+    import truememory.mcp_server as ms
+    import truememory.hooks.core as core
+    import json
+
+    # Set HOME to tmp_path so the backlog drainer uses an isolated dir.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    backlog_dir = tmp_path / ".truememory" / "backlog"
+    backlog_dir.mkdir(parents=True)
+
+    # Create one backlog marker pointing at a fake transcript that exists.
+    transcript_path = tmp_path / "transcript.jsonl"
+    transcript_path.write_text("{}\n", encoding="utf-8")
+
+    marker_path = backlog_dir / "test-session.json"
+    marker_path.write_text(json.dumps({
+        "transcript_path": str(transcript_path),
+        "session_id": "test-session",
+        "user_id": "",
+        "db_path": "",
+    }), encoding="utf-8")
+
+    # Track all opened files so we can assert they get closed.
+    opened_files = []
+    original_open = open
+
+    def _spy_open(path, *args, **kwargs):
+        f = original_open(path, *args, **kwargs)
+        opened_files.append(f)
+        return f
+
+    # Make Popen always raise to exercise the failure path.
+    def _fake_popen(*args, **kwargs):
+        raise OSError(24, "Too many open files (simulated)")
+
+    # spawn_gate context manager yields `True` (slot allowed)
+    class _AllowedGate:
+        def __enter__(self):
+            return True
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(core, "spawn_gate", lambda: _AllowedGate())
+    monkeypatch.setattr(core, "register_spawned_pid", lambda pid: None)
+
+    # Patch open + Popen at the module level used by _drain_batch_from_backlog.
+    monkeypatch.setattr("builtins.open", _spy_open)
+    monkeypatch.setattr("subprocess.Popen", _fake_popen)
+
+    # Run the drainer. It should swallow the Popen failure via the
+    # outer try/except and continue, but the inner try/finally must
+    # have closed the log file handle.
+    ms._drain_batch_from_backlog([marker_path])
+
+    # Restore real open before pytest tries to use it for output capture.
+    monkeypatch.setattr("builtins.open", original_open)
+
+    # At least one log file was opened (the one for our marker).
+    log_files = [f for f in opened_files if str(getattr(f, "name", "")).endswith(".log")]
+    assert log_files, (
+        "Expected at least one .log file to be opened by the drainer "
+        "for our test session."
+    )
+
+    # Every log file we opened must now be closed.
+    for f in log_files:
+        assert f.closed, (
+            f"Log file {f.name} was left open after Popen raised — "
+            f"the try/finally cleanup didn't run. Pre-fix, the bare "
+            f"`_log_file.close()` after Popen leaked this handle."
+        )

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -517,8 +517,15 @@ def _parallel_search(queries, user_id, internal_limit, llm_fn, output_limit):
                     if rid not in seen_ids:
                         merged.append(r)
                         seen_ids.add(rid)
-            except Exception:
-                pass  # Individual query failure doesn't kill the batch
+            except Exception as e:
+                # Individual query failure doesn't kill the batch — but
+                # log at DEBUG so an operator triaging "search quality
+                # dropped" has a breadcrumb. WARNING would be noisy
+                # because per-query timeouts are part of normal
+                # behaviour under load; DEBUG keeps the signal but
+                # requires `TRUEMEMORY_LOG_LEVEL=DEBUG` (or equivalent)
+                # to surface, matching the existing comment's framing.
+                log.debug("parallel search query failed: %s", e)
 
     merged.sort(key=lambda x: -x.get("score", 0))
     return merged[:output_limit]
@@ -1169,18 +1176,28 @@ def _drain_batch_from_backlog(markers: list[Path]) -> None:
                 _log_dir = Path.home() / ".truememory" / "logs"
                 _log_dir.mkdir(parents=True, exist_ok=True)
                 _safe_sid = _safe_session_id(data.get('session_id', 'unknown')) or 'unknown'
+                # try/finally around Popen so a raise during process spawn
+                # (resource error, fd exhaustion, ASR block, etc.) doesn't
+                # leak the file handle. A `with open(...)` block would
+                # close `_log_file` immediately after Popen returns, but
+                # Popen needs the FD to survive long enough for the child
+                # to inherit it. try/finally gives us the
+                # close-on-spawn-failure guarantee without the early-close
+                # hazard.
                 _log_file = open(
                     _log_dir / f"{_safe_sid}.log",
                     "a", encoding="utf-8",
                 )
-                proc = _subprocess.Popen(
-                    cmd,
-                    stdout=_log_file,
-                    stderr=_subprocess.STDOUT,
-                    stdin=_subprocess.DEVNULL,
-                    start_new_session=True,
-                )
-                _log_file.close()
+                try:
+                    proc = _subprocess.Popen(
+                        cmd,
+                        stdout=_log_file,
+                        stderr=_subprocess.STDOUT,
+                        stdin=_subprocess.DEVNULL,
+                        start_new_session=True,
+                    )
+                finally:
+                    _log_file.close()
                 register_spawned_pid(proc.pid)
                 record_stale_processing_pid(claimed_path, proc.pid)
 


### PR DESCRIPTION
## Summary

Two tiny additive cleanups in `mcp_server.py`. Neither changes happy-path behaviour; both close gaps that bite on the failure path.

Branched off `origin/main` directly — no PR dependencies, ships standalone.

## What changed

### `_parallel_search` — line ~520
Per-query exceptions in the `ThreadPoolExecutor` batch were swallowed with a bare `except Exception: pass`. Per-query timeouts and recoverable failures are part of normal load behaviour, so WARNING-level logging would be noisy. But with **zero log call at all**, an operator triaging "search quality dropped" had no breadcrumb that any query had failed.

Replaced the bare `pass` with `log.debug("parallel search query failed: %s", e)`. Keeps the signal recoverable with one log-level bump (`TRUEMEMORY_LOG_LEVEL=DEBUG` or equivalent) without raising baseline noise.

### `_drain_batch_from_backlog` — line ~1172-1183
The per-session `.log` file was opened, handed to `subprocess.Popen` as `stdout`, and then closed AFTER Popen returned. If Popen raised (resource error, fd exhaustion, ASR block, child-binary missing), the `close()` never ran and the FD leaked on every spawn failure.

Wrapped the Popen call in `try` / `finally` so close always runs. A `with open(...)` form would close the file too early — Popen needs the FD inheritable through the child. The `try` / `finally` shape preserves that contract.

## Tests

`tests/test_mcp_logging_hygiene.py` — 2 new, both passing:

- `test_parallel_search_logs_query_failures_at_debug` — one query raises, sibling query succeeds; verify the DEBUG log fires with the failure detail AND the successful sibling's results still come through the batch.
- `test_backlog_drainer_closes_log_file_when_popen_raises` — `subprocess.Popen` patched to raise `OSError(EMFILE)`; verify every opened `.log` file is closed afterward.

The second test injects a fake `_shared` module into `sys.modules` to dodge the pre-existing `import fcntl` Windows-only bug that agent-A's #345 fixes — keeps the test cross-platform without waiting on #345.

## Test plan

- [ ] `pytest tests/test_mcp_logging_hygiene.py -v` — both pass on Linux / macOS / Windows
- [ ] Run with `TRUEMEMORY_LOG_LEVEL=DEBUG` (or stdlib `logging.basicConfig(level=DEBUG)`) and trigger a query failure — verify the DEBUG line appears
- [ ] `lsof` / `Process Explorer` against the MCP server process under a simulated Popen failure (e.g. `ulimit -n 1` on Linux) — verify no `.log` file handle persists after the drainer iteration

## Coordination context (multi-agent sweep)

This PR cross-cuts two other agents' file ownership regions, both purely additively:

- **Line 521** sits in agent-A's `mcp_server.py:1-1180` region (covered by #344's async-handler conversion). Adding a `log.debug` call is additive — no behaviour change, no merge conflict with #344.
- **Lines 1172-1183** sit at the boundary of agent-A's region and agent-B's planned **PR-2b** (Windows subprocess portability, which will add a `start_new_session` platform branch at the same Popen call). The `try` / `finally` wrapper here is additive too — PR-2b's `start_new_session` change goes inside the `try` block without conflict.

A **sibling Popen pattern at `truememory/ingest/hooks/session_start.py:217-227`** has the same leak. It lives in PR-2b's territory (line 226 is where the `start_new_session` Windows branch goes), so I left it for agent-B to fold into PR-2b or split as they prefer.

Coordination details are tracked in the multi-agent registry (private; ping `agent-C` for context).


## Merge ordering

**Order-independent.** Additive cross-cut into agent-A's `mcp_server.py:1-1180` region (line 521 `_parallel_search` per-query failure → `log.debug`) and agent-B's `mcp_server.py:~1181` region (lines 1172-1183 try/finally wrap around the backlog drainer Popen + `_log_file` cleanup). Pure additions — zero semantic conflict with [#344](https://github.com/buildingjoshbetter/TrueMemory/pull/344) (async-handler conversion) or [#351](https://github.com/buildingjoshbetter/TrueMemory/pull/351) (subprocess portability).

**Blocks:** none.

**Recommended sequence position:** late in the train (after #344 / #351 land so the rebase, if any, is trivial). Can also ship anywhere — no hard constraint either direction.

**Sibling pattern:** `truememory/ingest/hooks/session_start.py:217-227` has the same Popen+log_file leak. That file lives in #351's region (line 226 = `start_new_session` Windows branch), so left for agent-B to fold into #351 or split as preferred.
