### PR TITLE
fix(tests,mcp): harden _run_cli helper + propagate exit codes under python -m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **``tests/test_cli_help.py:_run_cli`` helper preferred the ASR-blocked
+  shim** — the pre-fix helper called ``shutil.which("truememory-mcp")``
+  and used the bare ``.exe`` shim when present, falling back to
+  ``python -m`` only if the shim wasn't on PATH. On Windows hosts with
+  Microsoft Defender ASR rule ``01443614`` ("Block executable files
+  from running unless they meet a prevalence, age, or trusted list
+  criteria") in **Block** mode, the shim is silently killed at launch
+  — making 7 of the 9 tests in this file fail with
+  ``PermissionError [WinError 5] Access is denied`` even on a healthy
+  install. Rewrote the helper to always invoke
+  ``[sys.executable, "-m", "truememory.mcp_server"]``, routing through
+  the signed ``python.exe`` wrapper. Sibling fix in PR #351 covered
+  the 2 remaining tests in this file that bypass the helper entirely.
+- **``mcp_server.py`` `__main__` block dropped exit codes under
+  ``python -m`` invocation** — the bottom-of-file
+  ``if __name__ == "__main__": main()`` discarded ``main()``'s return
+  value, so exit-code-2 paths (unknown flag, positional-arg typo)
+  silently exited 0 when the server was invoked via
+  ``python -m truememory.mcp_server``. The setuptools console-script
+  wrapper around ``truememory-mcp`` already does ``sys.exit(main())``,
+  so the bug was invisible until anything routed through ``-m``.
+  Changed to ``sys.exit(main() or 0)``. Surfaced by the ``_run_cli``
+  helper rewrite above — 2 tests asserting ``returncode != 0`` were
+  passing under the shim and silently regressed to passing-as-0 under
+  ``-m`` until this line landed.
+
 ## [0.6.8] — 2026-05-11
 
 ### Fixed

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -16,23 +16,25 @@ import pytest
 from truememory import __version__
 
 
-def _truememory_mcp_bin() -> str | None:
-    """Locate the installed truememory-mcp console script, or None.
-
-    Prefer the script installed by pip. Fall back to invoking via
-    `python -m truememory.mcp_server` — slower because it re-runs all
-    module-level imports, but works in any environment where truememory
-    is importable.
-    """
-    return shutil.which("truememory-mcp")
-
-
 def _run_cli(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
-    bin_path = _truememory_mcp_bin()
-    if bin_path:
-        cmd = [bin_path] + args
-    else:
-        cmd = [sys.executable, "-m", "truememory.mcp_server"] + args
+    """Run the truememory-mcp CLI via the module form.
+
+    Always invokes ``[sys.executable, "-m", "truememory.mcp_server"]``
+    rather than the bare ``truememory-mcp`` console-script shim. The
+    shim path is faster (cached imports) but is a setuptools / uv
+    trampoline with a per-install unique hash — Windows Defender's
+    Attack-Surface-Reduction rule ``01443614`` ("Block executable files
+    from running unless they meet a prevalence, age, or trusted list
+    criteria") silently kills it at launch on hardened Win11 baselines.
+    Routing through the signed ``python.exe`` wrapper passes ASR
+    everywhere; the per-test re-import cost is negligible at test scale.
+
+    Replaces the pre-fix two-arm helper that called ``shutil.which`` and
+    preferred the shim when present — that branch fired exactly on
+    Block-mode ASR boxes, making 7 of the tests in this file fail with
+    ``PermissionError [WinError 5] Access is denied``.
+    """
+    cmd = [sys.executable, "-m", "truememory.mcp_server"] + args
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
 

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1519,4 +1519,12 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    # `sys.exit(main())` rather than bare `main()` — so exit codes
+    # returned from `main()` propagate when invoked via
+    # ``python -m truememory.mcp_server``. The setuptools console-script
+    # wrapper around `truememory-mcp` already does `sys.exit(main())`
+    # for you; `-m` invocation does not, so the bare `main()` form
+    # silently masked exit-code-2 paths (unknown flag, positional arg
+    # typo) as exit 0 under `python -m`.
+    import sys as _sys
+    _sys.exit(main() or 0)


### PR DESCRIPTION
## Summary

Two tiny additive fixes that close the test-infrastructure gap left open by [#351](https://github.com/buildingjoshbetter/TrueMemory/pull/351) (PR-2b Windows subprocess portability). Surfaced live by a test run on a hardened-Win11 Block-mode ASR host hitting Defender on `truememory-ingest.exe`.

Branched off `origin/main` directly. Different region from #351's edits in the same file — mechanical merge regardless of order.

## What changed

### `tests/test_cli_help.py:_run_cli` helper
Replaced the two-arm helper (`shutil.which("truememory-mcp")` → bare shim, fall back to `python -m`) with a single `[sys.executable, "-m", "truememory.mcp_server"]` invocation. The shim path is faster (cached imports) but is a setuptools / uv trampoline with a per-install unique hash — Microsoft Defender's Attack-Surface-Reduction rule `01443614-cd74-433a-b99e-2ecdc07bfc25` ("Block executable files from running unless they meet a prevalence, age, or trusted list criteria") silently kills it at launch on hardened Win11 baselines. Routing through the signed `python.exe` wrapper passes ASR everywhere; the per-test re-import cost is negligible at test scale.

### `truememory/mcp_server.py:1521` (`__main__` block)
Changed `main()` to `sys.exit(main() or 0)`. The setuptools console-script wrapper around `truememory-mcp` already does `sys.exit(main())`, so exit codes propagated correctly under the shim. Under `python -m` the bare `main()` discarded the return value — exit-code-2 paths (unknown flag, positional-arg typo) silently masked as exit 0.

**Bundled here because the `_run_cli` rewrite above exposed the bug**: 2 of the 7 newly `-m`-routed tests assert `returncode != 0` (`test_unknown_flag_exits_nonzero_not_hang`, `test_positional_arg_exits_nonzero_not_hang`). Without the `sys.exit` line, those would silently fail on every CI run that exercised `python -m`. Single-concern in spirit — "make `python -m truememory.mcp_server` behave like the shim under all invocation paths" — even though it touches two files.

## Test results (Windows, Defender ASR Block mode)

Before this PR:

```
0 of 9 tests in test_cli_help.py pass
9 PermissionError [WinError 5] Access is denied (shim ASR-blocked)
```

After this PR:

```
7 of 9 tests pass
2 remaining failures: test_help_via_console_script_does_not_hang +
                     test_ingest_version_flag_exits_cleanly
```

The 2 remaining are PR-2b (#351) territory — they invoke the shim directly outside the helper at lines 94-98 + 137-152. Will pass once #351 lands (or when this branch rebases on it).

## Test plan

- [ ] `pytest tests/test_cli_help.py -v` on Linux / macOS — all 9 pass (no ASR there)
- [ ] `pytest tests/test_cli_help.py -v` on Windows Block-mode ASR — 7 of 9 pass (until #351 merges, then 9 of 9)
- [ ] `python -m truememory.mcp_server --halp` — exits 2 with usage text on stderr (previously exited 0)
- [ ] `python -m truememory.mcp_server help` (positional, no dashes) — exits 2 (previously exited 0)
- [ ] `truememory-mcp --halp` via the shim — still exits 2 (unchanged behaviour)

## Coordination context (multi-agent sweep)

PR-2c in the sweep registered after agent-B's PR-2b (#351) explicitly handed off the `_run_cli`-helper hardening (agent-B relay 2026-05-17 ~02:20 ET — "test-infra single-concern, doesn't belong on top of subprocess story").

Sibling sweep PRs:
- agent-A: [#344](https://github.com/buildingjoshbetter/TrueMemory/pull/344) (cold-start) · [#345](https://github.com/buildingjoshbetter/TrueMemory/pull/345) (fcntl) · [#347](https://github.com/buildingjoshbetter/TrueMemory/pull/347) (engine + tier-switch)
- agent-B: [#346](https://github.com/buildingjoshbetter/TrueMemory/pull/346) (installer ASR) · [#351](https://github.com/buildingjoshbetter/TrueMemory/pull/351) (subprocess portability) · PR-2a CI runner pending
- agent-C: [#348](https://github.com/buildingjoshbetter/TrueMemory/pull/348) (`_setup_claude` hygiene) · [#349](https://github.com/buildingjoshbetter/TrueMemory/pull/349) (logging + Popen cleanup) · [#350](https://github.com/buildingjoshbetter/TrueMemory/pull/350) (docs Windows callouts) · this PR

`mcp_server.py:1521` is unclaimed by any other agent's file ownership region per the multi-agent coordination registry.


## Merge ordering

**Order-independent against [#351](https://github.com/buildingjoshbetter/TrueMemory/pull/351).** Different region of `tests/test_cli_help.py` from #351 (this PR rewrites the `_run_cli` helper at lines 19-36; #351 fixes the two shim-direct tests at lines 94-98 + 137-152). Mechanical inter-PR merge regardless of order.

**Depends on:** none. `mcp_server.py:1521` (`sys.exit(main() or 0)` line in the `__main__` block) is unclaimed by any other agent's file ownership region.

**Blocks:** none.

**Recommended sequence position:** after #344 / #345 / #351 so the test-helper fixes are validated against the full subprocess-portability stack on a Windows runner (#353).
