### PR TITLE
ci(windows): add windows-latest to test matrix (non-blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,20 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+    # Windows reports failures on every PR (visible signal) but does not
+    # block merges yet — several in-flight PRs (#344 fcntl/WNOHANG, #345
+    # hooks guard, #351 subprocess portability, #352 test helper) still
+    # need to land before Windows can flip to required. Flip this off
+    # once the green baseline holds across two consecutive main-branch
+    # runs.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Adds `windows-latest` to the CI test matrix on every PR — 4 Python versions × 2 OSes = 8 jobs. Windows is marked `continue-on-error` so failures show up as visible signal on PR reviews without blocking merges. The block flips off once #344 (fcntl/WNOHANG), #345 (hooks fcntl guard), #351 (subprocess portability), and #352 (test helper hardening) all land — after that, a green-on-Windows main run for two cycles in a row should be the gate to remove `continue-on-error` and make Windows required.

Zero source dependencies. Order-independent vs every other open PR. Recommended to merge **first** so every other in-flight PR (#344 #345 #346 #347 #348 #349 #350 #351 #352) starts getting Windows regression coverage immediately on review.

## Changes

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Add `os: [ubuntu-latest, windows-latest]` to matrix · change `runs-on: ubuntu-latest` → `runs-on: ${{ matrix.os }}` · add `continue-on-error: ${{ matrix.os == 'windows-latest' }}` with inline comment explaining the temporary non-blocking posture |

## Test plan

- [x] YAML lints cleanly (3-key change, no structural drift)
- [x] `build-check` job unchanged (still ubuntu-only, 3.12 only, as designed for packaging signal)
- [x] No source code modified
- [ ] Merge this PR → observe Windows column appears on every open PR's checks list
- [ ] After #344 + #345 + #351 + #352 merge: confirm two consecutive green main-branch Windows runs → remove `continue-on-error` in a follow-up

Co-Authored-By: claude-opus-4-7 <wontreply@getfucked.ai>
