### PR TITLE
fix: adaptive MPS throttler + tier switch safety

### DIFF
--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,0 +1,132 @@
+"""Tests for tier_switch/sensors.py — the three monitoring channels."""
+
+import subprocess
+import time
+from unittest.mock import MagicMock, patch
+
+from truememory.tier_switch.sensors import (
+    GrowthRateTracker,
+    read_mps_memory,
+    read_thermal_pressure,
+)
+
+
+# ── Channel 1: MPS Memory Level ──
+
+
+def test_mps_memory_ok():
+    mock_torch = MagicMock()
+    mock_torch.backends.mps.is_available.return_value = True
+    mock_torch.mps.driver_allocated_memory.return_value = int(2 * 1024**3)
+    with patch.dict("sys.modules", {"torch": mock_torch}):
+        result = read_mps_memory(cap_gb=12.0)
+    assert result["status"] == "ok"
+    assert abs(result["used_gb"] - 2.0) < 0.01
+    assert abs(result["ratio"] - 2.0 / 12.0) < 0.01
+
+
+def test_mps_memory_warning():
+    mock_torch = MagicMock()
+    mock_torch.backends.mps.is_available.return_value = True
+    mock_torch.mps.driver_allocated_memory.return_value = int(10.5 * 1024**3)
+    with patch.dict("sys.modules", {"torch": mock_torch}):
+        result = read_mps_memory(cap_gb=12.0)
+    assert result["status"] == "warning"
+    assert abs(result["ratio"] - 10.5 / 12.0) < 0.01
+
+
+def test_mps_memory_critical():
+    mock_torch = MagicMock()
+    mock_torch.backends.mps.is_available.return_value = True
+    mock_torch.mps.driver_allocated_memory.return_value = int(11.5 * 1024**3)
+    with patch.dict("sys.modules", {"torch": mock_torch}):
+        result = read_mps_memory(cap_gb=12.0)
+    assert result["status"] == "critical"
+    assert result["ratio"] >= 0.95
+
+
+def test_mps_memory_no_torch():
+    with patch.dict("sys.modules", {"torch": None}):
+        result = read_mps_memory(cap_gb=12.0)
+    assert result["status"] == "ok"
+    assert result["used_gb"] == 0.0
+
+
+# ── Channel 2: Growth Rate Tracker ──
+
+
+def test_growth_rate_first_reading_ok():
+    tracker = GrowthRateTracker(cap_gb=12.0)
+    result = tracker.update(5.0)
+    assert result["status"] == "ok"
+    assert result["slope_gb_per_20s"] == 0.0
+
+
+def test_growth_rate_stable():
+    tracker = GrowthRateTracker(cap_gb=12.0)
+    tracker._prev_gb = 5.0
+    tracker._prev_time = time.time() - 20
+    result = tracker.update(5.1)
+    assert result["status"] == "ok"
+    assert result["slope_pct"] < 3.0
+
+
+def test_growth_rate_warning():
+    tracker = GrowthRateTracker(cap_gb=12.0)
+    tracker._prev_gb = 5.0
+    tracker._prev_time = time.time() - 20
+    result = tracker.update(5.7)
+    assert result["status"] == "warning"
+    assert result["slope_pct"] >= 5.0
+
+
+def test_growth_rate_critical():
+    tracker = GrowthRateTracker(cap_gb=12.0)
+    tracker._prev_gb = 5.0
+    tracker._prev_time = time.time() - 20
+    result = tracker.update(6.5)
+    assert result["status"] == "critical"
+    assert result["slope_pct"] >= 10.0
+
+
+# ── Channel 3: Thermal Pressure ──
+
+
+def test_thermal_ok():
+    fake_output = "CPU_Scheduler_Limit = 100\n"
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=fake_output, stderr=""
+        )
+        result = read_thermal_pressure()
+    assert result["status"] == "ok"
+    assert result["scheduler_limit"] == 100
+
+
+def test_thermal_warning():
+    fake_output = "CPU_Scheduler_Limit = 85\n"
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=fake_output, stderr=""
+        )
+        result = read_thermal_pressure()
+    assert result["status"] == "warning"
+    assert result["scheduler_limit"] == 85
+
+
+def test_thermal_critical():
+    fake_output = "CPU_Scheduler_Limit = 60\n"
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=fake_output, stderr=""
+        )
+        result = read_thermal_pressure()
+    assert result["status"] == "critical"
+    assert result["scheduler_limit"] == 60
+
+
+def test_thermal_command_fails():
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("pmset", 5)):
+        result = read_thermal_pressure()
+    assert result["status"] == "ok"
+    assert result["scheduler_limit"] == 100

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,0 +1,144 @@
+"""Tests for ThrottlerStateMachine — all with mock data, no GPU needed."""
+
+import time
+
+from truememory.tier_switch.state_machine import ThrottlerStateMachine
+
+
+def _ok_readings():
+    return {
+        "mps_level": {"status": "ok", "used_gb": 3.0, "ratio": 0.25},
+        "growth_rate": {"status": "ok", "slope_pct": 1.0},
+        "thermal": {"status": "ok", "scheduler_limit": 100},
+    }
+
+
+def _warning_mps():
+    r = _ok_readings()
+    r["mps_level"] = {"status": "warning", "used_gb": 10.5, "ratio": 0.875}
+    return r
+
+
+def _warning_growth():
+    r = _ok_readings()
+    r["growth_rate"] = {"status": "warning", "slope_pct": 6.0}
+    return r
+
+
+def _critical_thermal():
+    r = _ok_readings()
+    r["thermal"] = {"status": "critical", "scheduler_limit": 60}
+    return r
+
+
+def _critical_mps():
+    r = _ok_readings()
+    r["mps_level"] = {"status": "critical", "used_gb": 11.5, "ratio": 0.96}
+    return r
+
+
+def test_starts_at_batch_1():
+    sm = ThrottlerStateMachine(start_batch=1, max_batch=12, ramp_step=2)
+    assert sm.batch_size == 1
+    assert sm.state == ThrottlerStateMachine.PROBING
+
+
+def test_safety_check_all_ok():
+    sm = ThrottlerStateMachine(start_batch=4, max_batch=12, ramp_step=2)
+    result = sm.safety_check(_ok_readings())
+    assert result == 4
+    assert sm.good_streak == 1
+
+
+def test_safety_check_warning_steps_down():
+    sm = ThrottlerStateMachine(start_batch=6, max_batch=12, ramp_step=2)
+    result = sm.safety_check(_warning_mps())
+    assert result == 4
+
+
+def test_safety_check_critical_halves():
+    sm = ThrottlerStateMachine(start_batch=8, max_batch=12, ramp_step=2)
+    result = sm.safety_check(_critical_thermal())
+    assert result == 4
+
+
+def test_step_down_enters_stable():
+    sm = ThrottlerStateMachine(start_batch=6, max_batch=12, ramp_step=2)
+    sm.safety_check(_warning_mps())
+    assert sm.state == ThrottlerStateMachine.STABLE
+
+
+def test_backoff_enters_backoff():
+    sm = ThrottlerStateMachine(start_batch=8, max_batch=12, ramp_step=2)
+    sm.safety_check(_critical_mps())
+    assert sm.state == ThrottlerStateMachine.BACKOFF
+
+
+def test_backoff_cooldown_returns_to_probing():
+    sm = ThrottlerStateMachine(start_batch=8, max_batch=12, ramp_step=2)
+    sm.safety_check(_critical_mps())
+    assert sm.state == ThrottlerStateMachine.BACKOFF
+    sm.last_backoff_time = time.time() - 121
+    sm.good_streak = 3
+    assert sm.should_ramp_check() is True
+    assert sm.state == ThrottlerStateMachine.PROBING
+
+
+def test_ramp_requires_3_good_streaks():
+    sm = ThrottlerStateMachine(start_batch=4, max_batch=12, ramp_step=2)
+    sm.last_ramp_time = time.time() - 200
+    sm.good_streak = 2
+    assert sm.should_ramp_check() is False
+    sm.good_streak = 3
+    assert sm.should_ramp_check() is True
+
+
+def test_ramp_requires_120s_cooldown():
+    sm = ThrottlerStateMachine(start_batch=4, max_batch=12, ramp_step=2)
+    sm.good_streak = 5
+    sm.last_ramp_time = time.time() - 60
+    assert sm.should_ramp_check() is False
+    sm.last_ramp_time = time.time() - 121
+    assert sm.should_ramp_check() is True
+
+
+def test_ramp_requires_all_channels_ok():
+    sm = ThrottlerStateMachine(start_batch=4, max_batch=12, ramp_step=2)
+    result = sm.ramp_up(_warning_mps())
+    assert result == 4  # no ramp
+
+
+def test_ramp_increases_by_step():
+    sm = ThrottlerStateMachine(start_batch=4, max_batch=12, ramp_step=2)
+    result = sm.ramp_up(_ok_readings())
+    assert result == 6
+
+
+def test_ramp_caps_at_max():
+    sm = ThrottlerStateMachine(start_batch=11, max_batch=12, ramp_step=2)
+    result = sm.ramp_up(_ok_readings())
+    assert result == 12
+
+
+def test_warning_on_growth_rate():
+    sm = ThrottlerStateMachine(start_batch=6, max_batch=12, ramp_step=2)
+    result = sm.safety_check(_warning_growth())
+    assert result == 4
+    assert sm.state == ThrottlerStateMachine.STABLE
+
+
+def test_critical_on_mps_level():
+    sm = ThrottlerStateMachine(start_batch=8, max_batch=12, ramp_step=2)
+    result = sm.safety_check(_critical_mps())
+    assert result == 4
+    assert sm.state == ThrottlerStateMachine.BACKOFF
+
+
+def test_batch_never_below_1():
+    sm = ThrottlerStateMachine(start_batch=1, max_batch=12, ramp_step=2)
+    result = sm.safety_check(_warning_mps())
+    assert result == 1
+
+    sm2 = ThrottlerStateMachine(start_batch=1, max_batch=12, ramp_step=2)
+    result = sm2.safety_check(_critical_mps())
+    assert result == 1

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -772,10 +772,9 @@ def truememory_configure(
                 "error": "api_provider must be one of: anthropic, openrouter, openai",
             })
 
-    # Save to persistent config
+    # Save to persistent config (tier change deferred to _finalize_rebuild)
     config = _load_config()
     old_tier = config.get("tier", "edge")
-    config["tier"] = tier
 
     # Store API key if provided
     if api_key and api_provider:
@@ -797,7 +796,8 @@ def truememory_configure(
     except Exception:
         pass
 
-    _save_config(config)
+    if api_key or email:
+        _save_config(config)
 
     # Invalidate cached LLM function so it picks up the new key
     if api_key:

--- a/truememory/model_client.py
+++ b/truememory/model_client.py
@@ -115,7 +115,7 @@ def _request_with_autostart(request: dict) -> dict:
     """Send request, auto-starting server if needed."""
     try:
         return _send_request(request)
-    except (ConnectionRefusedError, FileNotFoundError, OSError):
+    except (ConnectionRefusedError, FileNotFoundError, socket.timeout, OSError):
         pass
 
     if not _start_server():

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -53,6 +53,9 @@ _HEADER_SIZE = struct.calcsize(_HEADER_FMT)
 class ModelServer:
     """Serves embedding and reranking over a Unix domain socket."""
 
+    _SUSTAINED_THRESHOLD = 10
+    _SUSTAINED_WINDOW = 30
+
     def __init__(self):
         self._embed_model = None
         self._embed_tier: str | None = None
@@ -61,6 +64,9 @@ class ModelServer:
         self._lock = threading.Lock()
         self._last_activity = time.time()
         self._running = True
+        self._embed_timestamps: list[float] = []
+        self._throttler = None
+        self._throttler_active = False
 
     def _get_embed_model(self, tier: str):
         if self._embed_model is not None and self._embed_tier == tier:
@@ -133,9 +139,35 @@ class ModelServer:
         if op == "embed":
             texts = request["texts"]
             tier = request.get("tier", "")
+
+            now = time.time()
+            self._embed_timestamps.append(now)
+            self._embed_timestamps = [
+                t for t in self._embed_timestamps
+                if now - t < self._SUSTAINED_WINDOW
+            ]
+
+            if (len(self._embed_timestamps) >= self._SUSTAINED_THRESHOLD
+                    and not self._throttler_active):
+                self._activate_throttler()
+
+            if self._throttler_active and self._throttler:
+                self._throttler.before_batch()
+
+            encode_start = time.time()
             with self._lock:
                 model = self._get_embed_model(tier)
                 vectors = model.encode(texts, show_progress_bar=False)
+            encode_time = time.time() - encode_start
+
+            if self._throttler_active and self._throttler:
+                self._throttler.after_batch(len(texts), encode_time)
+                if self._throttler.should_flush_cache():
+                    self._flush_mps_cache()
+
+            if self._throttler_active and len(self._embed_timestamps) < 3:
+                self._deactivate_throttler()
+
             return {"ok": True, "vectors": np.asarray(vectors, dtype=np.float32)}
 
         if op == "rerank":
@@ -149,6 +181,45 @@ class ModelServer:
             return {"ok": True, "scores": np.asarray(scores, dtype=np.float32)}
 
         return {"ok": False, "error": f"Unknown op: {op}"}
+
+    def _activate_throttler(self):
+        """Start adaptive throttling for sustained workload."""
+        try:
+            from truememory.tier_switch.throttler import DynamicThrottler
+        except ImportError:
+            log.warning("Cannot import DynamicThrottler — running without throttling")
+            return
+        device = "cpu"
+        try:
+            import torch
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                device = "mps"
+        except ImportError:
+            pass
+        self._throttler = DynamicThrottler(device=device)
+        self._throttler_active = True
+        log.info(
+            "Sustained workload detected (%d requests in %ds) — throttler activated",
+            len(self._embed_timestamps), self._SUSTAINED_WINDOW,
+        )
+
+    def _deactivate_throttler(self):
+        """Stop adaptive throttling — workload ended."""
+        self._throttler = None
+        self._throttler_active = False
+        self._embed_timestamps.clear()
+        log.info("Workload ended — throttler deactivated")
+
+    def _flush_mps_cache(self):
+        """Flush MPS cache — only called when throttler says to."""
+        try:
+            import torch
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                torch.mps.empty_cache()
+                torch.mps.synchronize()
+        except Exception:
+            pass
+        gc.collect()
 
     def handle_client(self, conn: socket.socket):
         try:

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -22,6 +22,7 @@ def _set_mps_memory_cap():
     else:
         ratio = "0.50"
     os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] = ratio
+    os.environ.setdefault("PYTORCH_MPS_LOW_WATERMARK_RATIO", "0.0")
 
 
 _set_mps_memory_cap()

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -8,19 +8,36 @@ Auto-exits after idle timeout (default 300s, configurable via
 TRUEMEMORY_MODEL_SERVER_IDLE env var).
 """
 
-import gc
-import logging
 import os
-import pickle
-import signal
-import socket
-import struct
-import sys
-import threading
-import time
-from pathlib import Path
+import psutil
 
-import numpy as np
+
+def _set_mps_memory_cap():
+    """Set MPS memory cap BEFORE torch is imported."""
+    if os.environ.get("PYTORCH_MPS_HIGH_WATERMARK_RATIO"):
+        return
+    total_gb = psutil.virtual_memory().total / (1024**3)
+    if total_gb >= 32:
+        ratio = "0.55"
+    else:
+        ratio = "0.50"
+    os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] = ratio
+
+
+_set_mps_memory_cap()
+
+import gc  # noqa: E402
+import logging  # noqa: E402
+import pickle  # noqa: E402
+import signal  # noqa: E402
+import socket  # noqa: E402
+import struct  # noqa: E402
+import sys  # noqa: E402
+import threading  # noqa: E402
+import time  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import numpy as np  # noqa: E402
 
 log = logging.getLogger(__name__)
 

--- a/truememory/tier_switch/sensors.py
+++ b/truememory/tier_switch/sensors.py
@@ -1,0 +1,105 @@
+"""Sensor stack for the adaptive MPS throttler.
+
+Three independent monitoring channels: MPS memory level, memory growth
+rate, and thermal pressure. Each returns a status dict usable by the
+state machine in the throttler.
+"""
+
+import logging
+import subprocess
+import time
+
+log = logging.getLogger(__name__)
+
+
+def read_mps_memory(cap_gb: float) -> dict:
+    """Read MPS driver-allocated memory and classify against cap."""
+    try:
+        import torch
+
+        if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
+            return {"used_gb": 0.0, "ratio": 0.0, "status": "ok"}
+
+        used_bytes = torch.mps.driver_allocated_memory()
+        used_gb = used_bytes / (1024**3)
+    except (ImportError, AttributeError, RuntimeError):
+        return {"used_gb": 0.0, "ratio": 0.0, "status": "ok"}
+
+    ratio = used_gb / cap_gb if cap_gb > 0 else 0.0
+
+    if ratio >= 0.95:
+        status = "critical"
+    elif ratio >= 0.85:
+        status = "warning"
+    else:
+        status = "ok"
+
+    return {"used_gb": used_gb, "ratio": ratio, "status": status}
+
+
+class GrowthRateTracker:
+    """Tracks MPS memory growth rate between readings."""
+
+    def __init__(self, cap_gb: float):
+        self._cap_gb = cap_gb
+        self._prev_gb: float = 0.0
+        self._prev_time: float = 0.0
+
+    def update(self, current_gb: float) -> dict:
+        """Record a new reading and return growth rate status."""
+        now = time.time()
+
+        if self._prev_time == 0.0:
+            self._prev_gb = current_gb
+            self._prev_time = now
+            return {"slope_gb_per_20s": 0.0, "slope_pct": 0.0, "status": "ok"}
+
+        dt = now - self._prev_time
+        if dt <= 0:
+            return {"slope_gb_per_20s": 0.0, "slope_pct": 0.0, "status": "ok"}
+
+        raw_slope = (current_gb - self._prev_gb) / dt
+        slope_20s = raw_slope * 20.0
+        slope_pct = (slope_20s / self._cap_gb * 100.0) if self._cap_gb > 0 else 0.0
+
+        self._prev_gb = current_gb
+        self._prev_time = now
+
+        if slope_pct >= 10.0:
+            status = "critical"
+        elif slope_pct >= 5.0:
+            status = "warning"
+        else:
+            status = "ok"
+
+        return {"slope_gb_per_20s": slope_20s, "slope_pct": slope_pct, "status": status}
+
+
+def read_thermal_pressure() -> dict:
+    """Read macOS thermal pressure via pmset."""
+    try:
+        proc = subprocess.run(
+            ["pmset", "-g", "therm"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        output = proc.stdout
+        limit = 100
+        for line in output.splitlines():
+            if "CPU_Scheduler_Limit" in line or "CPU_Speed_Limit" in line:
+                parts = line.split("=")
+                if len(parts) >= 2:
+                    limit = int(parts[-1].strip())
+                    break
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError, ValueError):
+        return {"scheduler_limit": 100, "status": "ok"}
+
+    if limit <= 70:
+        status = "critical"
+    elif limit < 100:
+        status = "warning"
+    else:
+        status = "ok"
+
+    return {"scheduler_limit": limit, "status": status}

--- a/truememory/tier_switch/state_machine.py
+++ b/truememory/tier_switch/state_machine.py
@@ -1,0 +1,134 @@
+"""Throttler state machine — PROBING/STABLE/BACKOFF logic.
+
+Takes sensor readings as input, outputs batch size decisions.
+Implements asymmetric intervals: fast decrease, slow increase.
+
+Does NOT call sensors directly — receives readings from the
+DynamicThrottler class which plugs in real sensors.
+"""
+
+import logging
+import time
+
+log = logging.getLogger(__name__)
+
+
+class ThrottlerStateMachine:
+    """Three-state decision engine for adaptive batch sizing."""
+
+    PROBING = "probing"
+    STABLE = "stable"
+    BACKOFF = "backoff"
+
+    RAMP_COOLDOWN = 120
+    BACKOFF_COOLDOWN = 120
+    SAFETY_CHECK_INTERVAL = 5
+    GOOD_WINDOWS_REQUIRED = 3
+
+    def __init__(self, start_batch: int, max_batch: int, ramp_step: int):
+        self.batch_size = start_batch
+        self.max_batch = max_batch
+        self.ramp_step = ramp_step
+        self.state = self.PROBING
+        self.good_streak = 0
+        self.batch_count = 0
+        self.last_ramp_time = 0.0
+        self.last_backoff_time = 0.0
+
+    def on_batch_complete(self):
+        """Call after every batch. Increments batch counter."""
+        self.batch_count += 1
+
+    def should_safety_check(self) -> bool:
+        """Returns True every SAFETY_CHECK_INTERVAL batches."""
+        return self.batch_count >= self.SAFETY_CHECK_INTERVAL
+
+    def safety_check(self, readings: dict) -> int:
+        """Fast safety check — called every 5 batches.
+
+        Args:
+            readings: dict with keys "mps_level", "growth_rate", "thermal"
+                      each containing a dict with "status" key
+
+        Returns:
+            Updated batch_size
+        """
+        self.batch_count = 0
+
+        for channel in ("mps_level", "growth_rate", "thermal"):
+            if readings.get(channel, {}).get("status") == "critical":
+                return self._do_backoff(channel, readings[channel])
+
+        for channel in ("mps_level", "growth_rate", "thermal"):
+            if readings.get(channel, {}).get("status") == "warning":
+                return self._do_step_down(channel, readings[channel])
+
+        self.good_streak += 1
+        return self.batch_size
+
+    def should_ramp_check(self) -> bool:
+        """Returns True if conditions are met to consider a ramp-up."""
+        if self.state == self.BACKOFF:
+            if time.time() - self.last_backoff_time >= self.BACKOFF_COOLDOWN:
+                self.state = self.PROBING
+                log.info("Backoff cooldown expired, re-entering PROBING")
+            else:
+                return False
+
+        if self.state != self.PROBING:
+            return False
+        if self.batch_size >= self.max_batch:
+            return False
+        if self.good_streak < self.GOOD_WINDOWS_REQUIRED:
+            return False
+        if time.time() - self.last_ramp_time < self.RAMP_COOLDOWN:
+            return False
+        if time.time() - self.last_backoff_time < self.BACKOFF_COOLDOWN:
+            return False
+
+        return True
+
+    def ramp_up(self, triple_sample_means: dict) -> int:
+        """Slow ramp-up check — called every 120s with triple-sample means.
+
+        Args:
+            triple_sample_means: dict with same structure as safety_check
+                                 readings, but values are MEANS of 3 samples
+
+        Returns:
+            Updated batch_size (may or may not have increased)
+        """
+        for channel in ("mps_level", "growth_rate", "thermal"):
+            if triple_sample_means.get(channel, {}).get("status") != "ok":
+                self.good_streak = 0
+                return self.batch_size
+
+        old = self.batch_size
+        self.batch_size = min(self.max_batch, self.batch_size + self.ramp_step)
+        self.last_ramp_time = time.time()
+        self.good_streak = 0
+        log.info("Ramp-up: %d → %d", old, self.batch_size)
+        return self.batch_size
+
+    def _do_step_down(self, channel: str, reading: dict) -> int:
+        """WARNING response — step down by ramp_step."""
+        old = self.batch_size
+        self.batch_size = max(1, self.batch_size - self.ramp_step)
+        self.state = self.STABLE
+        self.good_streak = 0
+        log.info(
+            "Step-down: %d → %d (WARNING on %s)", old, self.batch_size, channel
+        )
+        return self.batch_size
+
+    def _do_backoff(self, channel: str, reading: dict) -> int:
+        """CRITICAL response — halve batch immediately."""
+        old = self.batch_size
+        self.batch_size = max(1, self.batch_size // 2)
+        self.state = self.BACKOFF
+        self.good_streak = 0
+        self.last_backoff_time = time.time()
+        log.warning(
+            "BACKOFF: %d → %d (CRITICAL on %s)", old, self.batch_size, channel
+        )
+        return self.batch_size

--- a/truememory/tier_switch/throttler.py
+++ b/truememory/tier_switch/throttler.py
@@ -1,7 +1,8 @@
-"""Simplified throttler for tier-switch re-embedding.
+"""Adaptive MPS throttler for tier-switch re-embedding.
 
-Checks available RAM before each batch and pauses only when memory is
-low. The worker handles OOM by halving batch_size and retrying.
+Three-channel monitoring (MPS memory level, growth rate, thermal
+pressure) with a PROBING/STABLE/BACKOFF state machine. Starts at
+batch=1, ramps up slowly, backs off quickly.
 """
 
 import gc
@@ -10,63 +11,88 @@ import time
 
 import psutil
 
+from truememory.tier_switch.sensors import (
+    GrowthRateTracker,
+    read_mps_memory,
+    read_thermal_pressure,
+)
+from truememory.tier_switch.state_machine import ThrottlerStateMachine
+
 log = logging.getLogger(__name__)
 
-_LOW_RAM_GB = 2.0
-_LOW_RAM_PAUSE = 5.0
-_INTER_BATCH_PAUSE = 0.2
+_MACHINE_PROFILES = {
+    # (min_gb, max_gb): (ratio, start, max_batch, ramp_step)
+    (0, 12): (0.50, 1, 4, 1),
+    (12, 20): (0.50, 1, 8, 1),
+    (20, 30): (0.50, 1, 12, 2),
+    (30, 1024): (0.55, 1, 16, 2),
+}
+
+
+def _get_profile(total_gb: float) -> tuple[float, int, int, int]:
+    for (lo, hi), profile in _MACHINE_PROFILES.items():
+        if lo <= total_gb < hi:
+            return profile
+    return (0.50, 1, 12, 2)
 
 
 class DynamicThrottler:
-    """RAM-aware throttler with minimal overhead."""
+    """Adaptive 3-channel throttler with state machine."""
 
     def __init__(self, device: str = "cpu"):
         self.device = device
-        total_gb = psutil.virtual_memory().total / (1024**3)
+        self.total_gb = psutil.virtual_memory().total / (1024**3)
 
-        if device in ("mps", "cuda"):
-            if total_gb >= 32:
-                self.batch_size = 32
-            elif total_gb >= 16:
-                self.batch_size = 16
-            else:
-                self.batch_size = 8
-        else:
-            if total_gb >= 16:
-                self.batch_size = 64
-            else:
-                self.batch_size = 32
+        ratio, start, max_batch, ramp_step = _get_profile(self.total_gb)
+        self.mps_cap_gb = self.total_gb * ratio
+
+        self.state_machine = ThrottlerStateMachine(
+            start_batch=start,
+            max_batch=max_batch,
+            ramp_step=ramp_step,
+        )
+
+        self.growth_tracker = GrowthRateTracker(cap_gb=self.mps_cap_gb)
 
         self.items_processed = 0
         self.start_time = time.time()
         self.batch_times: list[float] = []
-        self.last_throttle_time = 0.0
+        self.last_throttle_time = 0.0  # backward compat: worker sets this on OOM
+        self._last_readings: dict = {}
 
         log.info(
-            "Throttler init: device=%s batch_size=%d total_ram=%.0fGB",
-            device, self.batch_size, total_gb,
+            "Throttler init: device=%s total_ram=%.0fGB mps_cap=%.1fGB "
+            "start=%d max=%d step=%d",
+            device, self.total_gb, self.mps_cap_gb,
+            start, max_batch, ramp_step,
         )
 
+    @property
+    def batch_size(self) -> int:
+        return self.state_machine.batch_size
+
+    @batch_size.setter
+    def batch_size(self, value: int):
+        self.state_machine.batch_size = value
+
     def before_batch(self) -> tuple[int, dict]:
-        """Check RAM and return (batch_size, metrics). Pauses if low."""
-        vm = psutil.virtual_memory()
-        avail_gb = vm.available / (1024**3)
+        """Check sensors, update state machine, return (batch_size, metrics)."""
+        self.state_machine.on_batch_complete()
 
-        if avail_gb < _LOW_RAM_GB:
-            log.warning(
-                "Low RAM (%.1fGB available), pausing %.0fs",
-                avail_gb, _LOW_RAM_PAUSE,
-            )
-            time.sleep(_LOW_RAM_PAUSE)
-            self.flush_gpu_cache()
-        else:
-            time.sleep(_INTER_BATCH_PAUSE)
+        if self.state_machine.should_safety_check():
+            readings = self._read_all_channels()
+            self._last_readings = readings
+            self.state_machine.safety_check(readings)
 
-        metrics = {
-            "ram_avail_gb": avail_gb,
-            "ram_pct": vm.percent,
-        }
-        return self.batch_size, metrics
+        if self.state_machine.should_ramp_check():
+            means = self._triple_sample()
+            self.state_machine.ramp_up(means)
+
+        sleep_time = 0.05 + self.state_machine.batch_size * 0.02
+        time.sleep(sleep_time)
+
+        metrics = self._build_metrics()
+        return self.state_machine.batch_size, metrics
 
     def after_batch(self, batch_items: int, batch_time: float):
         """Record batch completion for throughput tracking."""
@@ -84,6 +110,78 @@ class DynamicThrottler:
         """Estimated seconds to process remaining items."""
         throughput = self.get_throughput()
         return remaining / throughput if throughput > 0 else float("inf")
+
+    def should_flush_cache(self) -> bool:
+        """Return True only on WARNING/BACKOFF — not during normal PROBING."""
+        return self.state_machine.state in (
+            ThrottlerStateMachine.STABLE,
+            ThrottlerStateMachine.BACKOFF,
+        )
+
+    def on_oom(self):
+        """Handle OOM by triggering BACKOFF in the state machine."""
+        self.state_machine._do_backoff("oom", {"status": "critical"})
+
+    def _read_all_channels(self) -> dict:
+        """Single quick reading of all 3 channels."""
+        try:
+            mps = read_mps_memory(self.mps_cap_gb)
+        except Exception:
+            mps = {"used_gb": 0.0, "ratio": 0.0, "status": "ok"}
+
+        try:
+            growth = self.growth_tracker.update(mps["used_gb"])
+        except Exception:
+            growth = {"slope_gb_per_20s": 0.0, "slope_pct": 0.0, "status": "ok"}
+
+        try:
+            thermal = read_thermal_pressure()
+        except Exception:
+            thermal = {"scheduler_limit": 100, "status": "ok"}
+
+        return {
+            "mps_level": mps,
+            "growth_rate": growth,
+            "thermal": thermal,
+        }
+
+    def _triple_sample(self) -> dict:
+        """Take 3 readings 10s apart, return mean-based status."""
+        samples = []
+        for i in range(3):
+            if i > 0:
+                time.sleep(10)
+            samples.append(self._read_all_channels())
+        return self._compute_means(samples)
+
+    def _compute_means(self, samples: list[dict]) -> dict:
+        """Compute mean status across 3 samples.
+
+        For ramp-up: ANY warning/critical in any sample → mean is that level.
+        """
+        result = {}
+        for channel in ("mps_level", "growth_rate", "thermal"):
+            statuses = [s[channel]["status"] for s in samples]
+            if "critical" in statuses:
+                result[channel] = {"status": "critical"}
+            elif "warning" in statuses:
+                result[channel] = {"status": "warning"}
+            else:
+                result[channel] = {"status": "ok"}
+        return result
+
+    def _build_metrics(self) -> dict:
+        """Build metrics dict for status reporting."""
+        readings = self._last_readings
+        return {
+            "batch_size": self.state_machine.batch_size,
+            "state": self.state_machine.state,
+            "mps_used_gb": readings.get("mps_level", {}).get("used_gb", 0.0),
+            "mps_ratio": readings.get("mps_level", {}).get("ratio", 0.0),
+            "growth_slope_pct": readings.get("growth_rate", {}).get("slope_pct", 0.0),
+            "thermal_limit": readings.get("thermal", {}).get("scheduler_limit", 100),
+            "good_streak": self.state_machine.good_streak,
+        }
 
     @staticmethod
     def flush_gpu_cache():

--- a/truememory/tier_switch/worker.py
+++ b/truememory/tier_switch/worker.py
@@ -16,6 +16,8 @@ from truememory.tier_switch.throttler import DynamicThrottler
 
 log = logging.getLogger(__name__)
 
+_HARD_TIMEOUT = 9000  # 2.5 hours
+
 StatusCallback = Callable[[int, int, dict], None]
 
 
@@ -101,12 +103,22 @@ class RebuildWorker:
         processed = 0
         last_id = 0
         offset = 0
+        start_time = time.time()
 
         with no_grad:
             while offset < total:
                 if self._cancelled:
                     log.info("RebuildWorker cancelled at %d/%d", processed, total)
                     self._update_status("cancelled", processed, total)
+                    return False, processed
+
+                if time.time() - start_time > _HARD_TIMEOUT:
+                    log.warning(
+                        "Re-embedding timed out at %d/%d (%.0f%%) after %.0f minutes",
+                        processed, total, processed / total * 100,
+                        (time.time() - start_time) / 60,
+                    )
+                    self._update_status("timeout", processed, total)
                     return False, processed
 
                 batch_size, metrics = self.throttler.before_batch()

--- a/truememory/tier_switch/worker.py
+++ b/truememory/tier_switch/worker.py
@@ -136,13 +136,10 @@ class RebuildWorker:
                 except Exception as exc:
                     if self._is_oom_error(exc):
                         log.warning(
-                            "OOM at batch_size=%d, halving and retrying",
+                            "OOM at batch_size=%d, triggering BACKOFF",
                             batch_size,
                         )
-                        self.throttler.batch_size = max(
-                            1, self.throttler.batch_size // 2
-                        )
-                        self.throttler.last_throttle_time = time.time()
+                        self.throttler.on_oom()
                         DynamicThrottler.flush_gpu_cache()
                         continue
                     log.error(
@@ -163,7 +160,8 @@ class RebuildWorker:
                 last_id = batch[-1]["id"]
 
                 self.throttler.after_batch(batch_count, batch_time)
-                DynamicThrottler.flush_gpu_cache()
+                if self.throttler.should_flush_cache():
+                    DynamicThrottler.flush_gpu_cache()
 
                 VectorCacheRegistry.update_progress(
                     self.conn, self.target_group, last_id,


### PR DESCRIPTION
## Summary

Replaces the simple RAM-check throttler (101 lines) with an adaptive 3-channel MPS throttler that prevents the 17GB memory balloon during tier switch re-embedding.

**Root cause:** The old throttler used `psutil.virtual_memory()` which doesn't see MPS allocations, started at batch=16 (too aggressive), and had no thermal monitoring. Result: MPS ballooned to 17GB on a 24GB machine, causing overheating and lag.

**Fix:** 9 files changed, +774 lines:
- **MPS cap** (`PYTORCH_MPS_HIGH_WATERMARK_RATIO`) set at model server startup before torch import
- **Config-flip-at-finalize** — tier only changes after 100% rebuild completion
- **2.5-hour hard timeout** — prevents indefinite rebuilds
- **3-channel sensor stack** — MPS memory level, growth rate, thermal pressure
- **State machine** — PROBING/STABLE/BACKOFF with asymmetric intervals (fast decrease, slow increase)
- **Adaptive batch sizing** — starts at 1, ramps via triple-sample verification
- **Conditional MPS flush** — only on WARNING/BACKOFF, not every batch
- **Server-side sustained workload detection** — throttler activates only during re-embedding

Machine profiles:
| RAM | MPS Cap | Start | Max | Step |
|-----|---------|-------|-----|------|
| 8GB | 4.0GB | 1 | 4 | +1 |
| 16GB | 8.0GB | 1 | 8 | +1 |
| 24GB | 12.0GB | 1 | 12 | +2 |
| 32GB+ | 17.6GB | 1 | 16 | +2 |

## Test plan

- [x] 637 tests pass (611 existing + 12 sensor + 15 state machine - 1 pre-existing failure in test_spawn_gate)
- [x] Ruff lint clean
- [x] Architecture diagram compliance verified
- [x] CONTEXT.md lessons 1-8 compliance verified
- [x] Reviewed by Gemini 2.5 Pro + Qwen3 235B (pre and post implementation)
- [ ] Phase 09: Live Edge→Base→Edge test with Activity Monitor (manual)