### PR TITLE
docs(hooks): clarify UserPromptSubmit is defensive-only + when to disable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,8 @@
 #   4. Runs `truememory-mcp --setup` (code from PyPI) to auto-configure
 #      Claude Code and/or Claude Desktop. Set TRUEMEMORY_SKIP_SETUP=1 to skip.
 #   5. Runs `truememory-ingest install` to wire up lifecycle hooks
-#      (SessionStart, Stop, UserPromptSubmit, PreCompact) and merge
-#      CLAUDE.md instructions so Claude uses TrueMemory proactively.
+#      (SessionStart, Stop, UserPromptSubmit — defensive-only, see user_prompt_submit.py,
+#       PreCompact) and merge CLAUDE.md instructions so Claude uses TrueMemory proactively.
 #
 # Environment overrides:
 #   TRUEMEMORY_PY=3.12         # pin a specific Python (default: 3.12)

--- a/truememory/ingest/CLAUDE_TEMPLATE.md
+++ b/truememory/ingest/CLAUDE_TEMPLATE.md
@@ -34,6 +34,7 @@ MEMORY.md may contain personal facts that were cached from earlier sessions. **D
 ## Background Processing
 - Memories are also extracted automatically from conversations via background processing.
 - The Stop hook captures the full transcript and runs deep extraction after sessions end.
+- The UserPromptSubmit hook is purely defensive (see its docstring); most users can safely disable it.
 - You do NOT need to store everything manually — focus on in-conversation corrections and explicit preferences.
 - The background extractor handles: personal facts, preferences, decisions, temporal facts, and technical context.
 

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -15,6 +15,20 @@ Design notes:
 - Automatically prunes buffer files older than 7 days on each invocation
   so they don't grow unbounded.
 
+When to disable this hook:
+- This hook is purely defensive — it duplicates session JSONL into a flat
+  buffer file in case the transcript on disk gets corrupted. In practice:
+  * Claude Code's session JSONL files (~/.claude/projects/<workspace>/)
+    rarely corrupt, and when they do Claude Code keeps its own backups
+  * SessionEnd / Stop hooks read transcript_path directly — NOT this buffer
+  * The hook fires synchronously on every user prompt → adds ~50-200ms of
+    python.exe spawn cost per turn
+
+  For users with a stable Claude Code install, the buffer never gets read
+  in anger. Safe to omit from settings.json hooks block if turn-time
+  latency or subprocess overhead matters more than belt-and-suspenders
+  crash recovery.
+
 Input (stdin JSON):
     {"session_id": "...", "prompt": "...", "transcript_path": "..."}
 


### PR DESCRIPTION
## Summary

The `UserPromptSubmit` hook is documented as *"defensive / diagnostic rather than load-bearing"* in its own docstring, but the install flow enables it by default and the README doesn't tell users that. This is fine — defaults-on-for-safety is defensible — but on Claude Code it fires synchronously per turn with python.exe spawn cost (~50-200ms × N turns). Users considering subscription-quota optimization or per-turn latency deserve to know they can drop it without losing extraction completeness (Stop / SessionEnd read transcript_path directly, never the buffer).

This PR is documentation-only: adds a "When to disable this hook" section to the docstring + matching one-liners in CLAUDE_TEMPLATE.md and install.sh.

## Changes
| File | Change |
|---|---|
| `truememory/ingest/hooks/user_prompt_submit.py` | Expanded docstring with "When to disable this hook" section |
| `truememory/ingest/CLAUDE_TEMPLATE.md` | One-line note on optional/defensive nature |
| `install.sh` | Inline comment on the hooks list pointing at the docstring |

## Test plan
- [ ] No code changes — only docstrings + comments + template markdown
- [ ] `truememory-ingest status` output unchanged
- [ ] `truememory-ingest install` behavior unchanged (hook still installed by default)

Co-Authored-By: claude-opus-4-7 <wontreply@getfucked.ai>
