### PR TITLE
feat(hooks+llm): turn-based memory injection on UserPromptSubmit + Claude CLI HyDE provider

### DIFF
--- a/tests/ingest/test_hooks_windows_portability.py
+++ b/tests/ingest/test_hooks_windows_portability.py
@@ -1,0 +1,230 @@
+"""Regression locks for the Windows-portability fix in
+``truememory/ingest/hooks/_shared.py`` and
+``truememory/ingest/hooks/session_start.py``.
+
+Bug (before fix): both modules called ``import fcntl`` at module top with no
+``try / except ImportError`` guard. On Windows, ``fcntl`` does not exist, so
+``import truememory.ingest.hooks._shared`` raised ``ModuleNotFoundError``
+immediately. That cascaded to every Claude Code hook subprocess
+(``session_start``, ``user_prompt_submit``, ``stop``) which all import from
+``_shared``, breaking the entire hook-based memory-extraction pipeline on
+Windows.
+
+The fix mirrors the established pattern already used by
+``truememory/ingest/pipeline.py``, ``truememory/hooks/core.py``, and
+``truememory/ingest/hooks/user_prompt_submit.py``: a ``try / except
+ImportError`` wraps the import and sets ``_HAS_FCNTL``; every ``fcntl.*``
+call site guards on the flag.
+
+These tests pin three things:
+
+1. Both modules expose ``_HAS_FCNTL`` (presence of the flag is the contract
+   that the import is guarded — without the try/except, the flag would
+   never be assigned because the import would raise).
+2. ``check_extraction_budget`` falls back to a non-atomic read-modify-write
+   without raising when ``_HAS_FCNTL`` is False, and still enforces the
+   hourly cap deterministically (the lock is for concurrency, not for
+   correctness in single-threaded paths).
+3. On a POSIX environment with ``fcntl`` available, ``check_extraction_budget``
+   actually acquires LOCK_EX — a regression lock so a future refactor can't
+   silently drop the cross-process coordination on platforms that need it.
+
+Test fixtures rebuild ``_BUDGET_FILE`` per test inside ``tmp_path`` so the
+user's real ``~/.truememory/.extraction_budget`` is never touched.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Bug #1: module-level import contract
+# ---------------------------------------------------------------------------
+
+
+def test_shared_exposes_has_fcntl_flag():
+    """The ``_HAS_FCNTL`` module attribute is the contract that the import
+    is wrapped in try/except. Without the wrapper, the module would fail
+    to import on Windows with ModuleNotFoundError, so the attribute would
+    never be assigned — meaning if you can read the attribute, the guard
+    is in place.
+    """
+    from truememory.ingest.hooks import _shared
+    assert hasattr(_shared, "_HAS_FCNTL"), (
+        "_shared.py is missing the _HAS_FCNTL flag — the module-level "
+        "`import fcntl` is probably bare again, which crashes every Claude "
+        "Code hook on Windows."
+    )
+    assert isinstance(_shared._HAS_FCNTL, bool)
+
+
+def test_session_start_exposes_has_fcntl_flag():
+    """Same contract for session_start. Without this, the SessionStart hook
+    process exits with non-zero on every Windows launch before recall_memories
+    ever runs — meaning no memory injection on Windows."""
+    from truememory.ingest.hooks import session_start
+    assert hasattr(session_start, "_HAS_FCNTL"), (
+        "session_start.py is missing the _HAS_FCNTL flag — the SessionStart "
+        "hook process will crash on every Windows launch."
+    )
+    assert isinstance(session_start._HAS_FCNTL, bool)
+
+
+def test_has_fcntl_flags_agree_with_platform():
+    """The flag must reflect the host environment. On POSIX with fcntl
+    installed, True. On Windows or any other no-fcntl environment, False.
+    A mismatch means the try/except is masking a real ImportError that
+    should be surfaced.
+    """
+    try:
+        import fcntl  # noqa: F401
+        expected = True
+    except ImportError:
+        expected = False
+
+    from truememory.ingest.hooks import _shared, session_start
+    assert _shared._HAS_FCNTL is expected
+    assert session_start._HAS_FCNTL is expected
+
+
+# ---------------------------------------------------------------------------
+# Bug #2: check_extraction_budget runtime behavior without fcntl
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _isolated_budget_file(tmp_path, monkeypatch):
+    """Point ``_BUDGET_FILE`` at a per-test temp path so tests don't poison
+    the user's real ``~/.truememory/.extraction_budget`` and don't interfere
+    with each other."""
+    from truememory.ingest.hooks import _shared
+    budget_path = tmp_path / ".extraction_budget"
+    monkeypatch.setattr(_shared, "_BUDGET_FILE", budget_path)
+    return budget_path
+
+
+def test_check_extraction_budget_allows_first_call_without_fcntl(
+    _isolated_budget_file, monkeypatch,
+):
+    """Without fcntl, the function must still allow extractions up to the
+    cap. The lock skip is not the same as denying extraction — that would
+    silently break the hook pipeline on Windows.
+    """
+    from truememory.ingest.hooks import _shared
+    monkeypatch.setattr(_shared, "_HAS_FCNTL", False)
+    monkeypatch.setattr(_shared, "_MAX_EXTRACTIONS_PER_HOUR", 5)
+
+    assert _shared.check_extraction_budget() is True
+    assert _isolated_budget_file.exists()
+    data = json.loads(_isolated_budget_file.read_text(encoding="utf-8"))
+    assert data["count"] == 1
+    assert data["hour"] == int(time.time() // 3600)
+
+
+def test_check_extraction_budget_enforces_cap_without_fcntl(
+    _isolated_budget_file, monkeypatch,
+):
+    """The lock is for concurrency safety across processes; the cap itself
+    must still be enforced sequentially. Burn through the cap and verify
+    the next call is denied.
+    """
+    from truememory.ingest.hooks import _shared
+    monkeypatch.setattr(_shared, "_HAS_FCNTL", False)
+    monkeypatch.setattr(_shared, "_MAX_EXTRACTIONS_PER_HOUR", 3)
+
+    assert _shared.check_extraction_budget() is True
+    assert _shared.check_extraction_budget() is True
+    assert _shared.check_extraction_budget() is True
+    assert _shared.check_extraction_budget() is False, (
+        "4th call must be denied — the per-hour cap is enforced regardless "
+        "of whether the lock is available."
+    )
+
+
+def test_check_extraction_budget_resets_at_new_hour_without_fcntl(
+    _isolated_budget_file, monkeypatch,
+):
+    """When the recorded hour differs from the current hour, the counter
+    must reset. Verify the Windows path preserves this semantics — without
+    the reset, a single hour of heavy usage would permanently deny extraction
+    on Windows.
+    """
+    from truememory.ingest.hooks import _shared
+    monkeypatch.setattr(_shared, "_HAS_FCNTL", False)
+    monkeypatch.setattr(_shared, "_MAX_EXTRACTIONS_PER_HOUR", 1)
+
+    # Pre-populate the budget file with prior-hour data already at the cap.
+    prior_hour = int(time.time() // 3600) - 1
+    _isolated_budget_file.parent.mkdir(parents=True, exist_ok=True)
+    _isolated_budget_file.write_text(
+        json.dumps({"hour": prior_hour, "count": 999}), encoding="utf-8",
+    )
+
+    # Current hour is fresh — must allow extraction.
+    assert _shared.check_extraction_budget() is True
+
+
+def test_check_extraction_budget_does_not_call_fcntl_when_unavailable(
+    _isolated_budget_file, monkeypatch,
+):
+    """Defensive: even if a future refactor accidentally calls
+    ``fcntl.flock`` outside the ``_HAS_FCNTL`` guard, the test catches it
+    because the unguarded call would raise NameError or AttributeError
+    when _HAS_FCNTL is False and fcntl is bound to a module that isn't
+    actually loaded.
+    """
+    from truememory.ingest.hooks import _shared
+    monkeypatch.setattr(_shared, "_HAS_FCNTL", False)
+    monkeypatch.setattr(_shared, "_MAX_EXTRACTIONS_PER_HOUR", 5)
+
+    # Must complete without raising even when fcntl path is "disabled".
+    result = _shared.check_extraction_budget()
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Bug #2 regression lock: lock IS acquired on POSIX
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only — Windows has no fcntl module to call",
+)
+def test_check_extraction_budget_acquires_lock_when_fcntl_available(
+    _isolated_budget_file, monkeypatch,
+):
+    """Regression lock: on POSIX, ``check_extraction_budget`` must call
+    ``fcntl.flock`` with LOCK_EX. Without cross-process coordination, two
+    concurrent ingest processes would race on the read-modify-write and
+    the budget cap could be silently exceeded.
+    """
+    from truememory.ingest.hooks import _shared
+    monkeypatch.setattr(_shared, "_MAX_EXTRACTIONS_PER_HOUR", 5)
+    assert _shared._HAS_FCNTL is True, "test prerequisite: fcntl must be available"
+
+    flock_calls: list[tuple] = []
+    real_flock = _shared.fcntl.flock
+
+    def _spy_flock(fd, op):
+        flock_calls.append((fd, op))
+        return real_flock(fd, op)
+
+    monkeypatch.setattr(_shared.fcntl, "flock", _spy_flock)
+
+    _shared.check_extraction_budget()
+
+    assert flock_calls, (
+        "fcntl.flock was not called on POSIX — the cross-process lock has "
+        "been silently disabled. This would let concurrent ingest processes "
+        "race on the budget file and exceed the hourly cap."
+    )
+    fd, op = flock_calls[0]
+    assert op == _shared.fcntl.LOCK_EX, (
+        f"Expected LOCK_EX (exclusive), got op={op!r}. A shared lock would "
+        f"not prevent concurrent writers."
+    )

--- a/tests/test_llm_fn_init.py
+++ b/tests/test_llm_fn_init.py
@@ -19,6 +19,11 @@ def server(monkeypatch, tmp_path):
     """Scope `_CONFIG_PATH` into tmp_path and reset LLM error state between
     tests. Avoids reloading the module (which would pollute
     huggingface_hub's cached HF_HOME).
+
+    Default: ``TRUEMEMORY_DISABLE_CLAUDE_CLI=1`` so legacy API-key tests
+    don't accidentally pick up the priority-1 Claude CLI provider on
+    machines where ``claude.exe`` is on PATH. Tests targeting the Claude
+    CLI path explicitly delete this env var.
     """
     home = tmp_path / "home"
     home.mkdir()
@@ -26,6 +31,7 @@ def server(monkeypatch, tmp_path):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("TRUEMEMORY_DISABLE_CLAUDE_CLI", "1")
     import truememory.mcp_server as ms
     monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
     monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
@@ -149,3 +155,124 @@ def test_all_providers_fail_sets_none_and_records_all(server, monkeypatch):
     assert fn is None
     assert set(server._llm_last_error.keys()) == {"anthropic", "openrouter", "openai"}
     assert server._current_llm_provider_name is None
+
+
+# ---------------------------------------------------------------------------
+# Claude CLI provider (priority 1, no API key — subscription auth)
+# ---------------------------------------------------------------------------
+
+
+def test_claude_cli_builder_returns_callable_when_on_path(server, monkeypatch):
+    """`_build_claude_cli_llm` returns a `(prompt) -> str` closure when
+    the `claude` binary is on PATH. The closure wraps
+    `_complete_claude_cli` from the extraction-pipeline models module."""
+    import truememory.ingest.models as models
+
+    monkeypatch.setattr(models, "_claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        models, "_complete_claude_cli",
+        lambda config, prompt, system: f"echo:{prompt}",
+    )
+
+    fn = server._build_claude_cli_llm("")
+    assert callable(fn)
+    assert fn("hi") == "echo:hi"
+
+
+def test_claude_cli_builder_raises_when_not_on_path(server, monkeypatch):
+    """`_build_claude_cli_llm` raises RuntimeError when `claude` isn't on
+    PATH — lets `_build_llm_fn` fall through to the next provider."""
+    import truememory.ingest.models as models
+
+    monkeypatch.setattr(models, "_claude_cli_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="claude CLI not on PATH"):
+        server._build_claude_cli_llm("")
+
+
+def test_build_llm_fn_returns_claude_cli_when_available_no_keys(server, monkeypatch):
+    """Priority 1: with no API keys set and CLI on PATH, `_build_llm_fn`
+    returns the Claude CLI closure without ever consulting api_key env vars."""
+    monkeypatch.delenv("TRUEMEMORY_DISABLE_CLAUDE_CLI", raising=False)
+    import truememory.ingest.models as models
+
+    monkeypatch.setattr(models, "_claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        models, "_complete_claude_cli",
+        lambda config, prompt, system: "ok",
+    )
+
+    fn = server._build_llm_fn()
+    assert fn is not None
+    assert fn("test") == "ok"
+    assert server._current_llm_provider_name == "claude_cli"
+
+
+def test_build_llm_fn_claude_cli_wins_over_openrouter_key(server, monkeypatch):
+    """Priority 1 means Claude CLI wins even when OPENROUTER_API_KEY is set
+    — this is the deliberate behavior change for users with both. Opt out
+    via `TRUEMEMORY_DISABLE_CLAUDE_CLI=1`."""
+    monkeypatch.delenv("TRUEMEMORY_DISABLE_CLAUDE_CLI", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-fake")
+    import truememory.ingest.models as models
+
+    monkeypatch.setattr(models, "_claude_cli_available", lambda: True)
+    monkeypatch.setattr(
+        models, "_complete_claude_cli",
+        lambda config, prompt, system: "from-cli",
+    )
+    # OpenRouter builder would also succeed if reached — but it must NOT
+    # be reached. Sentinel error if so.
+    def _openrouter_must_not_be_called(api_key):
+        raise AssertionError("OpenRouter builder called despite Claude CLI win")
+    monkeypatch.setattr(server, "_build_openrouter_llm", _openrouter_must_not_be_called)
+
+    fn = server._build_llm_fn()
+    assert fn is not None
+    assert fn("x") == "from-cli"
+    assert server._current_llm_provider_name == "claude_cli"
+
+
+def test_build_llm_fn_disable_claude_cli_env_falls_through_to_openrouter(server, monkeypatch):
+    """`TRUEMEMORY_DISABLE_CLAUDE_CLI=1` (already set by fixture) skips the
+    Claude CLI provider even when CLI is on PATH, falling through to
+    OpenRouter (or whatever API key is set)."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-real")
+    import truememory.ingest.models as models
+
+    # CLI is "available" but kill switch is on (from fixture)
+    monkeypatch.setattr(models, "_claude_cli_available", lambda: True)
+
+    def _ok_openrouter(api_key):
+        def _fn(prompt: str) -> str:
+            return "from-openrouter"
+        return _fn
+    monkeypatch.setattr(server, "_build_openrouter_llm", _ok_openrouter)
+
+    fn = server._build_llm_fn()
+    assert fn is not None
+    assert fn("y") == "from-openrouter"
+    assert server._current_llm_provider_name == "openrouter"
+
+
+def test_build_llm_fn_claude_cli_init_error_falls_through(server, monkeypatch):
+    """If `_build_claude_cli_llm` raises (e.g., CLI not on PATH on this
+    machine), the loop records the error and falls through to the next
+    provider. Mirrors the API-key provider error-handling pattern."""
+    monkeypatch.delenv("TRUEMEMORY_DISABLE_CLAUDE_CLI", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-real")
+    import truememory.ingest.models as models
+
+    monkeypatch.setattr(models, "_claude_cli_available", lambda: False)
+
+    def _ok_openrouter(api_key):
+        def _fn(prompt: str) -> str:
+            return "from-openrouter"
+        return _fn
+    monkeypatch.setattr(server, "_build_openrouter_llm", _ok_openrouter)
+
+    fn = server._build_llm_fn()
+    assert fn is not None
+    assert fn("z") == "from-openrouter"
+    assert server._current_llm_provider_name == "openrouter"
+    assert "claude_cli" in server._llm_last_error

--- a/tests/test_turn_based_injection.py
+++ b/tests/test_turn_based_injection.py
@@ -122,6 +122,44 @@ def test_already_injected_unknown_session_is_false(truememory_home):
 # ---------------------------------------------------------------------------
 # is_subagent_invocation — guard semantics
 # ---------------------------------------------------------------------------
+#
+# DESIGN NOTE for upstream reviewers
+# ----------------------------------
+# Per the canonical Claude Code hooks docs (code.claude.com/docs/en/hooks),
+# sub-agents spawned via the Task tool fire SessionStart, UserPromptSubmit,
+# and SessionEnd hooks in their own session context — same as the main
+# thread. This is intentional behavior on Anthropic's side.
+#
+# This PR adds a runtime guard (`is_subagent_invocation` in `_shared.py`)
+# that causes all three TrueMemory hooks to early-return when invoked
+# inside a sub-agent. Two reasons:
+#
+#   1. Sub-agent prompts are orchestrator-generated, not real user input.
+#      Ingesting them into TrueMemory pollutes the memory store with
+#      task-context strings rather than user facts.
+#   2. On Windows, every sub-agent spawn produces 1-3 hook subprocess
+#      fires, each of which causes a console window flash (Claude Code's
+#      Node spawn omits `windowsHide: true` and there is no settings.json
+#      escape hatch). The guard collapses each fire into a <10ms no-op so
+#      the user-visible noise is minimized.
+#
+# This is a Hunter-specific design preference and may disagree with
+# upstream's intent. If you (upstream maintainer) want the canonical
+# "sub-agents fire hooks normally" behavior, the guard can be made
+# opt-in via a `TRUEMEMORY_SKIP_SUBAGENT_HOOKS` env var (default off).
+# Happy to refactor as a follow-up commit if you'd prefer that shape.
+#
+# Detection uses two signals (either sufficient):
+#   - `agent_id` field in hook stdin — the canonical sub-agent signal
+#     per docs ("Present only when the hook fires inside a subagent call").
+#   - `/subagents/` directory component in `transcript_path` — fallback
+#     for older Claude Code versions (pre-v2.1.69) and any event where
+#     `agent_id` might be absent.
+#
+# Crucially, `agent_type` is NOT used as a signal — it's also set for
+# user-launched `--agent <name>` main sessions where the user IS the
+# speaker. Using it would silently skip real user prompts. The tests
+# below lock that decision in.
 
 
 def test_subagent_guard_agent_id_present(truememory_home):

--- a/tests/test_turn_based_injection.py
+++ b/tests/test_turn_based_injection.py
@@ -120,6 +120,58 @@ def test_already_injected_unknown_session_is_false(truememory_home):
 
 
 # ---------------------------------------------------------------------------
+# is_subagent_invocation — guard semantics
+# ---------------------------------------------------------------------------
+
+
+def test_subagent_guard_agent_id_present(truememory_home):
+    """agent_id in stdin is the canonical sub-agent signal — must trigger guard."""
+    shared = truememory_home["shared"]
+    assert shared.is_subagent_invocation({"agent_id": "agent-xyz"}) is True
+
+
+def test_subagent_guard_subagents_path(truememory_home, tmp_path):
+    """transcript_path containing /subagents/ is the fallback signal — must trigger guard."""
+    shared = truememory_home["shared"]
+    sub_tp = str(tmp_path / "sess-abc" / "subagents" / "agent-y.jsonl")
+    assert shared.is_subagent_invocation({}, transcript_path=sub_tp) is True
+    # Windows backslash form must also match
+    win_tp = r"C:\Users\x\.claude\projects\proj\sess\subagents\agent-y.jsonl"
+    assert shared.is_subagent_invocation({}, transcript_path=win_tp) is True
+
+
+def test_subagent_guard_agent_type_alone_is_NOT_subagent(truememory_home):
+    """agent_type without agent_id and without /subagents/ in path is the
+    `--agent <name>` main-session case. The user IS the speaker; their
+    prompts are real user input and must be ingested. The guard must NOT
+    trigger here."""
+    shared = truememory_home["shared"]
+    main_session_tp = r"C:\Users\x\.claude\projects\proj\sess-abc.jsonl"
+    assert shared.is_subagent_invocation(
+        {"agent_type": "novius-clinical-advisor"},
+        transcript_path=main_session_tp,
+    ) is False
+
+
+def test_subagent_guard_main_session_is_not_subagent(truememory_home):
+    """Plain main-thread fire with no agent_id, no agent_type, no /subagents/ path."""
+    shared = truememory_home["shared"]
+    assert shared.is_subagent_invocation({"session_id": "abc"}) is False
+    assert shared.is_subagent_invocation(
+        {"session_id": "abc", "transcript_path": "C:/proj/sess.jsonl"}
+    ) is False
+
+
+def test_subagent_guard_empty_input(truememory_home):
+    """No input at all → safe default: not a sub-agent (don't false-positive
+    on init failures that produce empty stdin)."""
+    shared = truememory_home["shared"]
+    assert shared.is_subagent_invocation() is False
+    assert shared.is_subagent_invocation(None) is False
+    assert shared.is_subagent_invocation({}) is False
+
+
+# ---------------------------------------------------------------------------
 # _build_turn_based_query tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_turn_based_injection.py
+++ b/tests/test_turn_based_injection.py
@@ -1,0 +1,319 @@
+"""Tests for turn-based memory injection on UserPromptSubmit.
+
+Covers the gate (turn count OR prompt length), marker-file dedup,
+``INJECT_DISABLED`` kill switch, graceful degradation on bad inputs,
+and the helpers in ``_shared.py`` (count_user_turns, already_injected,
+mark_injected) plus ``user_prompt_submit._build_turn_based_query``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def truememory_home(monkeypatch, tmp_path):
+    """Scope TURN_INJECTED_DIR and EXTRACTED_DIR into tmp_path.
+
+    Critical: must monkeypatch BEFORE importing _shared so the module-level
+    Path.home() / ".truememory" / "turn_injected" resolves under tmp_path.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    fake_truememory = home / ".truememory"
+    fake_truememory.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # Windows
+
+    # Force reimport with patched home
+    import importlib
+    import truememory.ingest.hooks._shared as shared_mod
+    importlib.reload(shared_mod)
+    monkeypatch.setattr(shared_mod, "TURN_INJECTED_DIR", fake_truememory / "turn_injected")
+    monkeypatch.setattr(shared_mod, "EXTRACTED_DIR", fake_truememory / "extracted")
+
+    import truememory.ingest.hooks.user_prompt_submit as ups_mod
+    importlib.reload(ups_mod)
+    yield {"home": home, "truememory": fake_truememory, "shared": shared_mod, "ups": ups_mod}
+
+
+def _make_transcript(path: Path, user_turn_count: int, msg_body: str = "hi") -> None:
+    """Write a JSONL transcript with ``user_turn_count`` user entries."""
+    lines = []
+    for i in range(user_turn_count):
+        lines.append(json.dumps({"type": "user", "content": f"{msg_body} {i}"}))
+        # Add an assistant turn between users (not counted)
+        lines.append(json.dumps({"type": "assistant", "content": "ok"}))
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# _shared.py helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_count_user_turns_jsonl(truememory_home, tmp_path):
+    shared = truememory_home["shared"]
+    t = tmp_path / "transcript.jsonl"
+    _make_transcript(t, user_turn_count=7)
+    assert shared.count_user_turns(str(t)) == 7
+
+
+def test_count_user_turns_empty_file(truememory_home, tmp_path):
+    shared = truememory_home["shared"]
+    t = tmp_path / "empty.jsonl"
+    t.write_text("", encoding="utf-8")
+    assert shared.count_user_turns(str(t)) == 0
+
+
+def test_count_user_turns_missing_file_returns_zero(truememory_home, tmp_path):
+    shared = truememory_home["shared"]
+    assert shared.count_user_turns(str(tmp_path / "does-not-exist.jsonl")) == 0
+
+
+def test_count_user_turns_json_array_format(truememory_home, tmp_path):
+    """Some Claude Code versions serialize the transcript as a single JSON array."""
+    shared = truememory_home["shared"]
+    t = tmp_path / "array.json"
+    arr = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply"},
+        {"role": "user", "content": "second"},
+    ]
+    t.write_text(json.dumps(arr), encoding="utf-8")
+    assert shared.count_user_turns(str(t)) == 2
+
+
+def test_already_injected_round_trip(truememory_home):
+    shared = truememory_home["shared"]
+    sid = "session-abc-123"
+    assert shared.already_injected(sid) is False
+    shared.mark_injected(sid, {"trigger": "turns", "n_results": 5})
+    assert shared.already_injected(sid) is True
+    # Marker file content sanity check
+    marker = truememory_home["truememory"] / "turn_injected" / "session-abc-123"
+    data = json.loads(marker.read_text(encoding="utf-8"))
+    assert data["trigger"] == "turns"
+    assert data["n_results"] == 5
+    assert "timestamp" in data
+
+
+def test_mark_injected_unknown_session_no_op(truememory_home):
+    shared = truememory_home["shared"]
+    shared.mark_injected("unknown", {"trigger": "turns"})
+    shared.mark_injected("", {"trigger": "turns"})
+    # No marker dir created, no exception
+    assert not (truememory_home["truememory"] / "turn_injected" / "unknown").exists()
+
+
+def test_already_injected_unknown_session_is_false(truememory_home):
+    shared = truememory_home["shared"]
+    assert shared.already_injected("unknown") is False
+    assert shared.already_injected("") is False
+
+
+# ---------------------------------------------------------------------------
+# _build_turn_based_query tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_query_takes_last_k_turns(truememory_home, tmp_path):
+    ups = truememory_home["ups"]
+    t = tmp_path / "t.jsonl"
+    _make_transcript(t, user_turn_count=10, msg_body="msg")
+    q = ups._build_turn_based_query(str(t), k=3)
+    # last 3 user messages should be "msg 7", "msg 8", "msg 9"
+    assert "msg 7" in q
+    assert "msg 8" in q
+    assert "msg 9" in q
+    assert "msg 0" not in q  # earliest turns excluded
+
+
+def test_build_query_truncates_each_turn(truememory_home, tmp_path, monkeypatch):
+    ups = truememory_home["ups"]
+    monkeypatch.setattr(ups, "INJECT_QUERY_TURN_CHARS", 10)
+    t = tmp_path / "t.jsonl"
+    huge = "X" * 5000
+    t.write_text(json.dumps({"type": "user", "content": huge}), encoding="utf-8")
+    q = ups._build_turn_based_query(str(t), k=6)
+    # Truncated to 10 chars per turn
+    assert q == "X" * 10
+
+
+def test_build_query_empty_transcript_returns_empty(truememory_home, tmp_path):
+    ups = truememory_home["ups"]
+    t = tmp_path / "t.jsonl"
+    t.write_text("", encoding="utf-8")
+    assert ups._build_turn_based_query(str(t), k=6) == ""
+
+
+# ---------------------------------------------------------------------------
+# _try_turn_based_injection — the gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_memory_search(truememory_home, monkeypatch):
+    """Stub Memory + _get_llm_fn so tests don't touch the real DB or LLM."""
+    ups = truememory_home["ups"]
+
+    class _StubMemory:
+        def __init__(self, path=None):
+            self.path = path
+
+        def search_deep(self, query, user_id=None, limit=10, llm_fn=None):
+            # Return a deterministic shape the formatter can ingest
+            return [
+                {"content": f"memory-{i} for query={query[:20]}"}
+                for i in range(min(3, limit))
+            ]
+
+    import truememory.client as client_mod
+    monkeypatch.setattr(client_mod, "Memory", _StubMemory)
+
+    # Stub _get_llm_fn so we don't touch the real provider chain
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms, "_get_llm_fn", lambda: (lambda p: "stub-hyde"))
+
+    return ups
+
+
+def test_gate_not_crossed_no_inject(mock_memory_search, tmp_path):
+    """turns=12 + chars=100 → below both thresholds → no inject, no marker."""
+    ups = mock_memory_search
+    t = tmp_path / "t.jsonl"
+    _make_transcript(t, user_turn_count=12)
+    prompt = "x" * 100
+    result = ups._try_turn_based_injection(
+        prompt, "sess-1", str(t), user_id="hunter", db_path="",
+    )
+    assert result is None
+
+
+def test_turn_trigger_fires_at_13_turns(mock_memory_search, tmp_path):
+    """turns=13 + short prompt → turn trigger fires."""
+    ups = mock_memory_search
+    t = tmp_path / "t.jsonl"
+    _make_transcript(t, user_turn_count=13)
+    prompt = "x" * 100
+    result = ups._try_turn_based_injection(
+        prompt, "sess-2", str(t), user_id="hunter", db_path="",
+    )
+    assert result is not None
+    assert "<truememory-context>" in result
+    assert "trigger=turns" in result
+
+
+def test_length_trigger_fires_at_334_chars(mock_memory_search, tmp_path):
+    """turns=1 + chars=334 → length trigger fires before turn-count branch."""
+    ups = mock_memory_search
+    t = tmp_path / "t.jsonl"
+    _make_transcript(t, user_turn_count=1)
+    prompt = "x" * 334
+    result = ups._try_turn_based_injection(
+        prompt, "sess-3", str(t), user_id="hunter", db_path="",
+    )
+    assert result is not None
+    assert "<truememory-context>" in result
+    assert "trigger=length" in result
+
+
+def test_marker_dedup_blocks_second_fire(mock_memory_search, tmp_path):
+    """Once marker file exists, subsequent calls return None."""
+    ups = mock_memory_search
+    t = tmp_path / "t.jsonl"
+    _make_transcript(t, user_turn_count=13)
+    prompt = "x" * 100
+    first = ups._try_turn_based_injection(prompt, "sess-4", str(t), "hunter", "")
+    second = ups._try_turn_based_injection(prompt, "sess-4", str(t), "hunter", "")
+    assert first is not None
+    assert second is None
+
+
+def test_inject_disabled_env_kill_switch(mock_memory_search, tmp_path, monkeypatch):
+    """INJECT_DISABLED=1 short-circuits before any work."""
+    ups = mock_memory_search
+    monkeypatch.setattr(ups, "INJECT_DISABLED", True)
+    t = tmp_path / "t.jsonl"
+    _make_transcript(t, user_turn_count=13)
+    result = ups._try_turn_based_injection(
+        "x" * 334, "sess-5", str(t), "hunter", "",
+    )
+    assert result is None
+
+
+def test_empty_transcript_graceful_no_inject(mock_memory_search, tmp_path):
+    """Empty transcript can't trigger turn count → no inject from turn branch.
+    Length branch can still fire — verify with a short prompt."""
+    ups = mock_memory_search
+    t = tmp_path / "t.jsonl"
+    t.write_text("", encoding="utf-8")
+    result = ups._try_turn_based_injection(
+        "x" * 100, "sess-6", str(t), "hunter", "",
+    )
+    assert result is None
+
+
+def test_missing_session_id_no_inject(mock_memory_search, tmp_path):
+    ups = mock_memory_search
+    t = tmp_path / "t.jsonl"
+    _make_transcript(t, user_turn_count=13)
+    result = ups._try_turn_based_injection(
+        "x" * 100, "", str(t), "hunter", "",
+    )
+    assert result is None
+
+
+def test_no_results_still_writes_marker(mock_memory_search, tmp_path, monkeypatch):
+    """When search returns [], marker file is still written so we don't
+    re-pay the search cost on every subsequent prompt."""
+    ups = mock_memory_search
+
+    class _EmptyMemory:
+        def __init__(self, path=None):
+            pass
+
+        def search_deep(self, query, user_id=None, limit=10, llm_fn=None):
+            return []
+
+    import truememory.client as client_mod
+    monkeypatch.setattr(client_mod, "Memory", _EmptyMemory)
+
+    t = tmp_path / "t.jsonl"
+    _make_transcript(t, user_turn_count=13)
+    result = ups._try_turn_based_injection(
+        "x" * 100, "sess-7", str(t), "hunter", "",
+    )
+    assert result is None
+    # Marker should exist despite zero results
+    import truememory.ingest.hooks._shared as shared
+    assert shared.already_injected("sess-7") is True
+
+
+def test_search_exception_does_not_crash(mock_memory_search, tmp_path, monkeypatch):
+    """If Memory.search_deep raises, the function returns None (hook can't crash)."""
+    ups = mock_memory_search
+
+    class _BoomMemory:
+        def __init__(self, path=None):
+            pass
+
+        def search_deep(self, *a, **kw):
+            raise RuntimeError("boom")
+
+    import truememory.client as client_mod
+    monkeypatch.setattr(client_mod, "Memory", _BoomMemory)
+
+    t = tmp_path / "t.jsonl"
+    _make_transcript(t, user_turn_count=13)
+    result = ups._try_turn_based_injection(
+        "x" * 100, "sess-8", str(t), "hunter", "",
+    )
+    assert result is None

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -22,6 +22,7 @@ except ImportError:  # pragma: no cover — Windows path
 log = logging.getLogger(__name__)
 
 EXTRACTED_DIR = Path.home() / ".truememory" / "extracted"
+TURN_INJECTED_DIR = Path.home() / ".truememory" / "turn_injected"
 
 _BUDGET_FILE = Path.home() / ".truememory" / ".extraction_budget"
 _MAX_EXTRACTIONS_PER_HOUR = int(os.environ.get("TRUEMEMORY_MAX_EXTRACTIONS_PER_HOUR", "20"))
@@ -202,5 +203,97 @@ def mark_session_extracted(session_id: str, transcript_path: str, spawned_pid: i
             "timestamp": time.time(),
             "pid": spawned_pid or os.getpid(),
         }), encoding="utf-8")
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Turn-based memory injection (UserPromptSubmit) — per-session one-shot dedup
+# ---------------------------------------------------------------------------
+
+
+def count_user_turns(transcript_path: str) -> int:
+    """Count user turns in a Claude Code transcript file.
+
+    Mirrors the two-path parsing of ``stop._has_enough_messages`` but
+    returns the count instead of a bool gate. The "user" role is anything
+    with ``type``/``role`` set to ``"human"`` or ``"user"`` — string
+    substring counting is avoided so transcripts that mention the literal
+    words ``"human"``/``"user"`` in content don't inflate the total.
+    """
+    try:
+        content = Path(transcript_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return 0
+
+    if not content.strip():
+        return 0
+
+    # Try JSON array first (Claude Code may serialize as one array)
+    try:
+        if content.lstrip().startswith("["):
+            data = json.loads(content)
+            if isinstance(data, list):
+                count = 0
+                for entry in data:
+                    if isinstance(entry, dict):
+                        role = entry.get("type") or entry.get("role") or ""
+                        if role in ("human", "user"):
+                            count += 1
+                return count
+    except json.JSONDecodeError:
+        pass
+
+    # Fall back to JSONL (one JSON object per line — the common Claude Code shape)
+    count = 0
+    for line in content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(entry, dict):
+            role = entry.get("type") or entry.get("role") or ""
+            if role in ("human", "user"):
+                count += 1
+    return count
+
+
+def _turn_injected_marker(session_id: str) -> Path:
+    safe_id = _safe_session_id(session_id)
+    return TURN_INJECTED_DIR / safe_id
+
+
+def already_injected(session_id: str) -> bool:
+    """Return True iff turn-based injection has already fired for this session."""
+    if not session_id or session_id == "unknown":
+        return False
+    safe_id = _safe_session_id(session_id)
+    if not safe_id:
+        return False
+    return _turn_injected_marker(session_id).exists()
+
+
+def mark_injected(session_id: str, meta: dict) -> None:
+    """Atomically record that turn-based injection has fired for this session.
+
+    Writes via tempfile + rename so partial writes can't corrupt the marker.
+    The ``meta`` dict records the trigger reason, query size, and result
+    count — useful for debugging via ``cat ~/.truememory/turn_injected/<id>``.
+    """
+    if not session_id or session_id == "unknown":
+        return
+    safe_id = _safe_session_id(session_id)
+    if not safe_id:
+        return
+    try:
+        TURN_INJECTED_DIR.mkdir(parents=True, exist_ok=True)
+        marker = _turn_injected_marker(session_id)
+        tmp = marker.with_suffix(".tmp")
+        payload = {**meta, "timestamp": time.time()}
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        tmp.replace(marker)
     except OSError:
         pass

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -1,11 +1,23 @@
 """Shared utilities for TrueMemory hooks."""
 
 from pathlib import Path
-import fcntl
 import json
 import logging
 import os
 import time
+
+# fcntl is POSIX-only — Windows has no equivalent file-range locking primitive.
+# Without this guard the entire module fails to import on Windows, which in
+# turn breaks every Claude Code hook that imports from here (session_start,
+# user_prompt_submit, stop). The Windows code path falls back to non-atomic
+# read/write for the extraction budget; the worst-case race window allows
+# 1-2 extra extractions per hour, which is acceptable given the alternative
+# is no enforcement at all.
+try:
+    import fcntl  # type: ignore[import-not-found]
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover — Windows path
+    _HAS_FCNTL = False
 
 log = logging.getLogger(__name__)
 
@@ -88,14 +100,23 @@ def check_extraction_budget() -> bool:
     """Check if the hourly extraction budget allows another extraction.
 
     Returns True if extraction is allowed, False if budget is exhausted.
-    Uses flock for atomicity across concurrent processes.
+
+    On POSIX, uses ``fcntl.flock`` for atomic read-modify-write — the only
+    safe way to coordinate this across the concurrent ingest processes the
+    backlog drainer spawns. On Windows (no ``fcntl``), falls back to a
+    non-atomic read-modify-write with a narrow race window: two processes
+    could both pass the check before either writes, briefly exceeding the
+    cap by 1-2 extractions per hour. This is acceptable given the
+    alternative is either no enforcement or a Windows-specific named-mutex
+    implementation whose complexity dwarfs the rare overshoot.
     """
     if _MAX_EXTRACTIONS_PER_HOUR <= 0:
         return True
     try:
         _BUDGET_FILE.parent.mkdir(parents=True, exist_ok=True)
         fd = os.open(str(_BUDGET_FILE), os.O_RDWR | os.O_CREAT)
-        fcntl.flock(fd, fcntl.LOCK_EX)
+        if _HAS_FCNTL:
+            fcntl.flock(fd, fcntl.LOCK_EX)
         try:
             raw = os.read(fd, 4096).decode("utf-8", errors="replace").strip()
             data = json.loads(raw) if raw else {}

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -38,22 +38,34 @@ def _safe_session_id(session_id: str) -> str:
 def is_subagent_invocation(input_data: dict | None = None, transcript_path: str = "") -> bool:
     """Detect whether this hook fire is from a Claude Code sub-agent (Task tool).
 
-    Hooks fire per-session, and sub-agents are separate sessions from the
-    orchestrator. Without a guard, every sub-agent spawn produces 1-3 hook
-    fires, which floods the user with terminal flashes and pollutes the
-    memory store with orchestrator-generated prompts (not real user input).
+    Sub-agents are separate sessions from the orchestrator. Without a guard,
+    every sub-agent spawn produces 1-3 hook fires, which pollutes the memory
+    store with orchestrator-generated prompts (not real user input).
 
-    Two detection paths, either is sufficient:
-    1. ``input_data["agent_id"]`` or ``input_data["agent_type"]`` is present
-       (newer Claude Code versions include these fields in hook stdin JSON).
-    2. The transcript path contains ``/subagents/`` — Claude Code stores
-       sub-agent transcripts under
-       ``<project>/<session_id>/subagents/agent-<id>.jsonl``. Robust fallback
-       for older Claude Code versions that don't emit the agent_id field.
+    Two detection signals, either is sufficient:
+
+    1. ``input_data["agent_id"]`` is present. Per the canonical Claude Code
+       hooks docs: "agent_id — Unique identifier for the subagent. Present
+       only when the hook fires inside a subagent call." This is the
+       authoritative signal — Claude Code emits it specifically to let
+       hooks distinguish sub-agent fires from main-thread fires.
+
+    2. The transcript path contains ``subagents`` as a directory component.
+       Claude Code stores sub-agent transcripts at
+       ``~/.claude/projects/<project>/<session_id>/subagents/agent-<id>.jsonl``.
+       Robust fallback for older Claude Code versions (pre-v2.1.69 didn't
+       emit ``agent_id``) and for any event where the field might be absent
+       (e.g., ``SessionStart`` in some SDK paths).
+
+    Importantly: ``agent_type`` is NOT a sub-agent signal. It is also set
+    for ``--agent <name>`` main sessions where the user is running a
+    custom-agent persona AS the main thread — those prompts ARE real user
+    input and must be ingested. Using ``agent_type`` would false-positive
+    on that case.
     """
+    if isinstance(input_data, dict) and input_data.get("agent_id"):
+        return True
     if isinstance(input_data, dict):
-        if input_data.get("agent_id") or input_data.get("agent_type"):
-            return True
         tp = transcript_path or input_data.get("transcript_path", "")
     else:
         tp = transcript_path

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -35,6 +35,33 @@ def _safe_session_id(session_id: str) -> str:
     return "".join(c for c in session_id if c.isalnum() or c in "-_")[:64]
 
 
+def is_subagent_invocation(input_data: dict | None = None, transcript_path: str = "") -> bool:
+    """Detect whether this hook fire is from a Claude Code sub-agent (Task tool).
+
+    Hooks fire per-session, and sub-agents are separate sessions from the
+    orchestrator. Without a guard, every sub-agent spawn produces 1-3 hook
+    fires, which floods the user with terminal flashes and pollutes the
+    memory store with orchestrator-generated prompts (not real user input).
+
+    Two detection paths, either is sufficient:
+    1. ``input_data["agent_id"]`` or ``input_data["agent_type"]`` is present
+       (newer Claude Code versions include these fields in hook stdin JSON).
+    2. The transcript path contains ``/subagents/`` — Claude Code stores
+       sub-agent transcripts under
+       ``<project>/<session_id>/subagents/agent-<id>.jsonl``. Robust fallback
+       for older Claude Code versions that don't emit the agent_id field.
+    """
+    if isinstance(input_data, dict):
+        if input_data.get("agent_id") or input_data.get("agent_type"):
+            return True
+        tp = transcript_path or input_data.get("transcript_path", "")
+    else:
+        tp = transcript_path
+    if not tp:
+        return False
+    return "/subagents/" in tp.replace("\\", "/")
+
+
 def should_extract_session(session_id: str, transcript_path: str) -> bool:
     """Check if a session's transcript has new content since last extraction.
 

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -21,12 +21,24 @@ Output (stdout JSON):
 """
 
 import argparse
-import fcntl
 import json
 import logging
 import os
 import sys
 from pathlib import Path
+
+# fcntl is POSIX-only — Windows has no equivalent file-range locking. Without
+# this guard, every Claude Code session-start hook crashes on Windows with
+# ModuleNotFoundError before ever running. Only the orphaned-session scan
+# uses fcntl (advisory lock to prevent concurrent scans); the Windows path
+# skips the lock and proceeds — worst case is two processes scanning
+# simultaneously and queueing the same sessions, which the backlog drainer's
+# atomic rename already deduplicates.
+try:
+    import fcntl  # type: ignore[import-not-found]
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover — Windows path
+    _HAS_FCNTL = False
 
 log = logging.getLogger(__name__)
 
@@ -284,7 +296,13 @@ def _scan_stale_sessions() -> None:
     _SCAN_MARKER.parent.mkdir(parents=True, exist_ok=True)
     try:
         scan_fd = os.open(str(_SCAN_MARKER), os.O_RDWR | os.O_CREAT)
-        fcntl.flock(scan_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        if _HAS_FCNTL:
+            # POSIX: non-blocking advisory lock prevents concurrent scans.
+            # If another scan is in progress, exit early.
+            fcntl.flock(scan_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        # Windows: no advisory lock — concurrent scans may run simultaneously.
+        # The backlog drainer's atomic .json → .processing rename deduplicates
+        # any overlapping work, so the worst case is wasted CPU, not corruption.
     except (BlockingIOError, OSError):
         return
 

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -400,6 +400,16 @@ def main():
     except (json.JSONDecodeError, EOFError):
         input_data = {}
 
+    # Skip sub-agent (Task tool) invocations entirely — sub-agents shouldn't
+    # get the blanket recall + first-run banner; both are oriented to the
+    # human user opening Claude Code, not orchestrator-spawned helpers.
+    try:
+        from truememory.ingest.hooks._shared import is_subagent_invocation
+        if is_subagent_invocation(input_data):
+            return
+    except ImportError:
+        pass
+
     try:
         if _is_first_run():
             context = _first_run_context()

--- a/truememory/ingest/hooks/stop.py
+++ b/truememory/ingest/hooks/stop.py
@@ -132,6 +132,16 @@ def main():
     except (json.JSONDecodeError, EOFError):
         input_data = {}
 
+    # Skip sub-agent (Task tool) invocations entirely — their transcripts are
+    # orchestrator-generated, not real user input. Ingesting them pollutes
+    # the memory store with task-context strings rather than user facts.
+    try:
+        from truememory.ingest.hooks._shared import is_subagent_invocation
+        if is_subagent_invocation(input_data):
+            return
+    except ImportError:
+        pass
+
     transcript_path = input_data.get("transcript_path", "")
     session_id = input_data.get("session_id", "unknown")
 

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -1,24 +1,36 @@
 #!/usr/bin/env python3
 """
-UserPromptSubmit Hook — Lightweight Message Buffer
-===================================================
+UserPromptSubmit Hook — Buffer + Recall + Turn-Based Injection
+==============================================================
 
-Fires on every user message submission. Appends a one-line JSON record
-to a per-session buffer so debugging tools can see what the user said
-even if the transcript is corrupted or truncated.
+Fires on every user message submission. Five things happen:
 
-Design notes:
-- The Stop hook reads `transcript_path` directly, not the buffer, so
-  this is defensive / diagnostic rather than load-bearing.
-- Uses `fcntl.flock` to make concurrent writes from overlapping sessions
-  safe (previously could interleave).
-- Automatically prunes buffer files older than 7 days on each invocation
-  so they don't grow unbounded.
+1. **Buffer write** — appends a one-line JSON record to a per-session
+   buffer (defensive snapshot in case the transcript file corrupts).
+2. **Email capture** — opportunistic scrape of the user's email into
+   ``~/.truememory/config.json`` when first observed.
+3. **Background-ingestion trigger** — when transcript has ≥10 user
+   messages and isn't already mid-extraction, spawns the cold-path
+   extractor (mirrors SessionEnd, catches sessions that don't terminate
+   cleanly).
+4. **Explicit-recall injection** (``_try_auto_recall``) — regex-gated
+   path that fires when the prompt matches a question pattern
+   (``"what's"``, ``"do you remember"``, etc.). Searches TrueMemory
+   with the raw prompt, emits a ``<truememory-recall>`` block.
+5. **Turn-based injection** (``_try_turn_based_injection``) — once per
+   session, when conversation has signal: ``turns >= 13`` OR
+   ``len(prompt) > 333``. Uses the last K user turns as a richer query,
+   runs ``Memory.search_deep`` with HyDE expansion (Claude CLI llm_fn),
+   emits a ``<truememory-context>`` block. Marker file dedupes re-fires.
+
+Both injection paths can emit on the same turn; combined output goes
+out as a single ``additionalContext`` JSON line to avoid double-emit.
 
 Input (stdin JSON):
     {"session_id": "...", "prompt": "...", "transcript_path": "..."}
 
-Output: None (silent hook, no additionalContext)
+Output (stdout): either nothing, or a single JSON line with
+    ``additionalContext`` containing the concatenated recall blocks.
 """
 
 import argparse
@@ -48,6 +60,26 @@ BUFFER_DIR = Path(os.environ.get(
 RETENTION_DAYS = int(os.environ.get("TRUEMEMORY_BUFFER_RETENTION_DAYS", "7"))
 # Max size per buffer file (bytes) before we rotate
 MAX_BUFFER_SIZE = int(os.environ.get("TRUEMEMORY_BUFFER_MAX_BYTES", str(10 * 1024 * 1024)))
+
+
+# ---------------------------------------------------------------------------
+# Turn-based memory injection — once-per-session targeted recall
+# ---------------------------------------------------------------------------
+
+# Fire injection when user turns reach this count (whichever trigger first wins).
+INJECT_AFTER_TURNS = int(os.environ.get("TRUEMEMORY_INJECT_AFTER_TURNS", "13"))
+# Fire injection when current prompt exceeds this character count (one substantive prompt is enough signal).
+INJECT_AFTER_CHARS = int(os.environ.get("TRUEMEMORY_INJECT_AFTER_CHARS", "333"))
+# Number of recent user turns to concatenate as the search query (richer semantic context than raw prompt alone).
+INJECT_QUERY_TURNS = int(os.environ.get("TRUEMEMORY_INJECT_QUERY_TURNS", "6"))
+# Per-turn truncation when joining turns into the query — prevents 100K-char pasted code from blowing up the embedding input.
+INJECT_QUERY_TURN_CHARS = int(os.environ.get("TRUEMEMORY_INJECT_QUERY_TURN_CHARS", "500"))
+# How many memories to fetch and inject.
+INJECT_RECALL_LIMIT = int(os.environ.get("TRUEMEMORY_INJECT_RECALL_LIMIT", "15"))
+# Per-bullet truncation in the emitted block (200 in the existing recall path; bumped to 300 for the once-per-session budget).
+INJECT_BULLET_CHARS = int(os.environ.get("TRUEMEMORY_INJECT_BULLET_CHARS", "300"))
+# Kill switch — set TRUEMEMORY_INJECT_DISABLED=1 to disable turn-based injection entirely.
+INJECT_DISABLED = os.environ.get("TRUEMEMORY_INJECT_DISABLED", "").lower() in ("1", "true", "yes")
 
 
 def _parse_args() -> argparse.Namespace:
@@ -144,6 +176,161 @@ def _try_capture_email(prompt: str) -> None:
         pass
 
 
+def _build_turn_based_query(transcript_path: str, k: int) -> str:
+    """Return the last ``k`` user turns concatenated as a single search query.
+
+    Reads the transcript JSONL, collects user-role entries' content,
+    truncates each turn to ``INJECT_QUERY_TURN_CHARS`` so a single pasted
+    code block can't blow the embedding input to 100K chars, joins with
+    ``"\\n---\\n"`` so the vector encoder sees them as distinct passages.
+    Returns ``""`` if the transcript can't be parsed.
+    """
+    try:
+        content = Path(transcript_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    if not content.strip():
+        return ""
+
+    entries: list[str] = []
+    # Try JSON array first
+    try:
+        if content.lstrip().startswith("["):
+            data = json.loads(content)
+            if isinstance(data, list):
+                for entry in data:
+                    if not isinstance(entry, dict):
+                        continue
+                    role = entry.get("type") or entry.get("role") or ""
+                    if role not in ("human", "user"):
+                        continue
+                    msg = entry.get("content") or entry.get("message") or ""
+                    if isinstance(msg, list):  # Claude Code: content blocks
+                        msg = " ".join(
+                            b.get("text", "") for b in msg
+                            if isinstance(b, dict) and b.get("type") == "text"
+                        )
+                    if isinstance(msg, str) and msg.strip():
+                        entries.append(msg.strip()[:INJECT_QUERY_TURN_CHARS])
+    except json.JSONDecodeError:
+        pass
+
+    if not entries:
+        # JSONL fallback
+        for line in content.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(entry, dict):
+                continue
+            role = entry.get("type") or entry.get("role") or ""
+            if role not in ("human", "user"):
+                continue
+            msg = entry.get("content") or entry.get("message") or ""
+            if isinstance(msg, dict):
+                msg = msg.get("content") or msg.get("text") or ""
+            if isinstance(msg, list):
+                msg = " ".join(
+                    b.get("text", "") for b in msg
+                    if isinstance(b, dict) and b.get("type") == "text"
+                )
+            if isinstance(msg, str) and msg.strip():
+                entries.append(msg.strip()[:INJECT_QUERY_TURN_CHARS])
+
+    if not entries:
+        return ""
+
+    return "\n---\n".join(entries[-k:])
+
+
+def _try_turn_based_injection(
+    prompt: str,
+    session_id: str,
+    transcript_path: str,
+    user_id: str,
+    db_path: str,
+) -> str | None:
+    """One-shot per session: when the conversation has signal, search with
+    the last K user turns as a richer query and emit a
+    ``<truememory-context>`` block. Marker file prevents re-fire.
+    """
+    if INJECT_DISABLED:
+        return None
+    if not session_id or session_id == "unknown":
+        return None
+    if not transcript_path:
+        return None
+
+    try:
+        from truememory.ingest.hooks._shared import (
+            already_injected, mark_injected, count_user_turns,
+        )
+    except ImportError:
+        return None
+
+    if already_injected(session_id):
+        return None
+
+    # Gate — length first (cheap), then turn count (transcript I/O)
+    if len(prompt) > INJECT_AFTER_CHARS:
+        trigger = "length"
+    else:
+        try:
+            turns = count_user_turns(transcript_path)
+        except Exception:
+            return None
+        if turns < INJECT_AFTER_TURNS:
+            return None
+        trigger = "turns"
+
+    query = _build_turn_based_query(transcript_path, INJECT_QUERY_TURNS)
+    if not query.strip():
+        return None
+
+    # search_deep with llm_fn — HyDE expansion on Pro tier (Claude CLI).
+    # Gracefully degrades if mcp_server / Memory not importable in this env.
+    try:
+        from truememory.client import Memory
+        from truememory.mcp_server import _get_llm_fn  # singleton, cached
+        m = Memory(path=db_path or None)
+        llm_fn = _get_llm_fn()
+        results = m.search_deep(
+            query, user_id=user_id or None,
+            limit=INJECT_RECALL_LIMIT, llm_fn=llm_fn,
+        )
+    except Exception:
+        return None
+
+    if not results:
+        # Still mark — don't re-pay the search cost on every subsequent prompt
+        mark_injected(session_id, {
+            "trigger": trigger, "query_chars": len(query), "n_results": 0,
+        })
+        return None
+
+    lines = [
+        f"- {(r.get('content') or '')[:INJECT_BULLET_CHARS]}"
+        for r in results[:INJECT_RECALL_LIMIT]
+    ]
+    out = (
+        "<truememory-context>\n"
+        f"Relevant memories (turn-based injection, trigger={trigger}):\n"
+        + "\n".join(lines)
+        + "\n</truememory-context>"
+    )
+
+    mark_injected(session_id, {
+        "trigger": trigger,
+        "query_chars": len(query),
+        "n_results": len(results),
+    })
+    return out
+
+
 def main():
     if os.environ.get("TRUEMEMORY_EXTRACTION"):
         return
@@ -188,9 +375,20 @@ def main():
         except Exception:
             pass
 
+    # Two injection paths, both can fire on the same turn. We MUST emit at most
+    # one `additionalContext` JSON line — Claude Code reads exactly one stdout
+    # JSON from the hook, so concat both blocks if both fire.
     recall_context = _try_auto_recall(prompt, args.user, args.db)
-    if recall_context:
+    turn_context = _try_turn_based_injection(
+        prompt, session_id, transcript_path, args.user, args.db,
+    )
+    if recall_context and turn_context:
+        combined = recall_context + "\n\n" + turn_context
+        print(json.dumps({"additionalContext": combined}))
+    elif recall_context:
         print(json.dumps({"additionalContext": recall_context}))
+    elif turn_context:
+        print(json.dumps({"additionalContext": turn_context}))
 
 
 def buffer_message(session_id: str, prompt: str):

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -342,6 +342,16 @@ def main():
     except (json.JSONDecodeError, EOFError):
         return
 
+    # Skip sub-agent (Task tool) invocations entirely — their prompts are
+    # orchestrator-generated, not real user input, and the per-spawn hook
+    # cost is wasted. See _shared.is_subagent_invocation for detection.
+    try:
+        from truememory.ingest.hooks._shared import is_subagent_invocation
+        if is_subagent_invocation(input_data):
+            return
+    except ImportError:
+        pass
+
     prompt = input_data.get("prompt", "").strip()
     session_id = input_data.get("session_id", "unknown")
 

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -298,10 +298,46 @@ def _build_openai_llm(api_key: str):
     return _openai_llm
 
 
+def _build_claude_cli_llm(_unused_key: str = ""):
+    """Build llm_fn that calls the local ``claude`` CLI binary via subprocess.
+
+    Uses Claude Code subscription auth (OAuth/keychain) — no API key required.
+    Wraps the extraction-pipeline helper at
+    ``truememory.ingest.models._complete_claude_cli`` in a
+    ``(prompt: str) -> str`` closure compatible with search_deep's ``llm_fn``.
+
+    Default model is ``claude-haiku-4-5`` (cheap, fast, sufficient for HyDE
+    doc generation); override via ``TRUEMEMORY_HYDE_CLAUDE_MODEL``. Raises
+    ``RuntimeError`` if the CLI binary is not on PATH so the
+    ``_build_llm_fn`` loop can fall through to the next provider.
+    """
+    from truememory.ingest.models import (
+        _claude_cli_available,
+        _complete_claude_cli,
+        LLMConfig,
+    )
+
+    if not _claude_cli_available():
+        raise RuntimeError("claude CLI not on PATH")
+
+    model = os.environ.get("TRUEMEMORY_HYDE_CLAUDE_MODEL", "claude-haiku-4-5")
+    config = LLMConfig(provider="claude_cli", model=model)
+
+    def _claude_cli_llm(prompt: str) -> str:
+        return _complete_claude_cli(config, prompt, system="")
+
+    return _claude_cli_llm
+
+
 # Provider table — builders are looked up dynamically via module-level name
 # so tests can monkeypatch ``_build_anthropic_llm`` etc. without having to
 # reimport the module or mutate a frozen tuple of captured references.
+#
+# Priority 1: ``claude_cli`` — PATH-detected, uses Claude Code subscription
+# auth (no API key, zero cash spend). Falls through to the API-key providers
+# if the binary is missing or ``TRUEMEMORY_DISABLE_CLAUDE_CLI=1`` is set.
 _LLM_PROVIDERS = (
+    ("claude_cli", "", "", "_build_claude_cli_llm"),
     ("anthropic", "ANTHROPIC_API_KEY", "anthropic_api_key", "_build_anthropic_llm"),
     ("openrouter", "OPENROUTER_API_KEY", "openrouter_api_key", "_build_openrouter_llm"),
     ("openai", "OPENAI_API_KEY", "openai_api_key", "_build_openai_llm"),
@@ -309,24 +345,41 @@ _LLM_PROVIDERS = (
 
 
 def _build_llm_fn():
-    """Build an llm_fn from available API keys.
+    """Build an llm_fn from available providers.
 
-    Resolution order for each provider:
-      1. Environment variable (ANTHROPIC_API_KEY / OPENROUTER_API_KEY / OPENAI_API_KEY)
-      2. Persistent config (~/.truememory/config.json, written by ``truememory-ingest setup``)
+    Resolution order:
+      1. Claude CLI subscription (priority 1) — PATH-detected via
+         ``shutil.which("claude")``. Skipped when
+         ``TRUEMEMORY_DISABLE_CLAUDE_CLI=1`` is set.
+      2. Anthropic / OpenRouter / OpenAI — each by env var
+         (``ANTHROPIC_API_KEY`` / ``OPENROUTER_API_KEY`` / ``OPENAI_API_KEY``)
+         or ``~/.truememory/config.json`` key.
 
-    Provider priority: Anthropic direct → OpenRouter → OpenAI. On init
-    failure the error is logged at WARNING and stored in
+    On init failure the error is logged at WARNING and stored in
     ``_llm_last_error[provider]`` so ``truememory_stats.health`` (F07) can
     surface the degradation instead of silently returning None.
     """
     global _current_llm_provider_name
     config = _load_config()
+    cli_disabled = os.environ.get(
+        "TRUEMEMORY_DISABLE_CLAUDE_CLI", ""
+    ).lower() in ("1", "true", "yes")
     for provider, env_var, config_key, builder_name in _LLM_PROVIDERS:
+        builder = globals()[builder_name]
+        if provider == "claude_cli":
+            if cli_disabled:
+                continue
+            try:
+                fn = builder("")  # PATH-detected, no key arg used
+            except Exception as e:
+                _record_llm_error(provider, e)
+                continue
+            _clear_llm_error(provider)
+            _current_llm_provider_name = provider
+            return fn
         api_key = os.environ.get(env_var) or config.get(config_key)
         if not api_key:
             continue
-        builder = globals()[builder_name]
         try:
             fn = builder(api_key)
             _clear_llm_error(provider)


### PR DESCRIPTION
## Summary

Three coupled changes targeting Pro-tier subscription users on Windows.

**Turn-based injection (`UserPromptSubmit`)** — fires once per session when user-turn count ≥ 13 OR current prompt length > 333 chars (whichever first). Query = last 6 user turns concatenated, separated by `\n---\n`, giving the vector pipeline richer semantic context than the existing raw-prompt path. Marker file at `~/.truememory/turn_injected/<safe_session_id>` dedupes re-fires; pattern mirrors `should_extract_session` / `mark_session_extracted`. The existing `_detect_recall` regex path is untouched and still fires every turn for explicit recall questions — both paths can emit on the same prompt, combined into one `additionalContext` JSON line.

**Claude CLI priority-1 `_build_llm_fn` provider** — `_build_claude_cli_llm` wraps the existing `truememory.ingest.models._complete_claude_cli` helper into the `(prompt) -> str` shape `search_deep` expects. Pro tier now gets HyDE for free on subscription auth — no API key required. Opt out via `TRUEMEMORY_DISABLE_CLAUDE_CLI=1`.

**Sub-agent hook skip** — new `is_subagent_invocation()` helper in `_shared.py`; all 3 hooks early-return for Claude Code Task-tool sub-agents (detected via `agent_id` field in stdin OR `/subagents/` in `transcript_path`). Stops per-sub-agent terminal flash + orchestrator-prompt memory pollution.

Depends on #345 (fcntl Windows portability) — cherry-picked into this branch; will dedupe on rebase once #345 merges.

## Changes

| File | Change |
|---|---|
| `truememory/mcp_server.py` | `+_build_claude_cli_llm`, prepend `claude_cli` to `_LLM_PROVIDERS`, add no-key path + `TRUEMEMORY_DISABLE_CLAUDE_CLI` kill-switch in `_build_llm_fn` |
| `truememory/ingest/hooks/_shared.py` | `+is_subagent_invocation`, `+TURN_INJECTED_DIR`, `+count_user_turns`, `+already_injected`, `+mark_injected` |
| `truememory/ingest/hooks/user_prompt_submit.py` | `+_build_turn_based_query`, `+_try_turn_based_injection`, sub-agent guard in `main()`, single-emit restructure so explicit-recall + turn-based combine into one `additionalContext` line |
| `truememory/ingest/hooks/session_start.py` | Sub-agent guard at top of `main()` |
| `truememory/ingest/hooks/stop.py` | Sub-agent guard at top of `main()` |
| `tests/test_llm_fn_init.py` | +6 Claude CLI cases; fixture defaults `TRUEMEMORY_DISABLE_CLAUDE_CLI=1` so legacy API-key tests don't pick up the new priority-1 provider |
| `tests/test_turn_based_injection.py` | NEW — 19 cases covering helpers, gate logic, marker dedup, kill switch, search-exception graceful-degrade |
| `tests/ingest/test_hooks_windows_portability.py` | From #345 cherry-pick — will dedupe on rebase |

## New env vars (all overridable, sensible defaults)

| Var | Default | Effect |
|---|---|---|
| `TRUEMEMORY_INJECT_AFTER_TURNS` | `13` | Turn-count trigger threshold |
| `TRUEMEMORY_INJECT_AFTER_CHARS` | `333` | Prompt-length trigger threshold |
| `TRUEMEMORY_INJECT_QUERY_TURNS` | `6` | Recent turns concatenated into the query |
| `TRUEMEMORY_INJECT_QUERY_TURN_CHARS` | `500` | Per-turn truncation in the query (prevents pasted code blowing up the embedding input) |
| `TRUEMEMORY_INJECT_RECALL_LIMIT` | `15` | Memories fetched |
| `TRUEMEMORY_INJECT_BULLET_CHARS` | `300` | Per-bullet truncation in the emitted block |
| `TRUEMEMORY_INJECT_DISABLED` | unset | Kill switch — disables turn-based injection entirely |
| `TRUEMEMORY_DISABLE_CLAUDE_CLI` | unset | Force `_build_llm_fn` to skip Claude CLI and fall through to API-key providers |
| `TRUEMEMORY_HYDE_CLAUDE_MODEL` | `claude-haiku-4-5` | Model used for HyDE doc generation via Claude CLI |

## Test plan

- [x] `pytest tests/test_llm_fn_init.py tests/test_turn_based_injection.py tests/ingest/test_hooks_windows_portability.py -v` → 37 pass / 1 skip (`fcntl.flock` path, Linux-only)
- [x] Sub-agent detection: 6/6 cases pass (`agent_id`, `agent_type`, `/subagents/` path, mixed-slash Windows paths, empty input)
- [x] In-process smoke of `_try_turn_based_injection` with stubbed `Memory` — emits `<truememory-context>` block at `trigger=turns`, writes marker, re-fire returns `None`
- [ ] On a machine with `claude.exe` + `OPENROUTER_API_KEY` set: `truememory_search_deep` selects `claude_cli` provider; verify `_current_llm_provider_name == "claude_cli"` and zero OpenRouter spend
- [ ] End-to-end manual smoke in a fresh Claude Code session: type a 350-char prompt → `<truememory-context>` emitted (~500ms HyDE pause); subsequent prompts → no re-fire; marker at `~/.truememory/turn_injected/<session_id>` exists with `trigger`, `query_chars`, `n_results`, `timestamp`
- [ ] Sub-agent Task spawn: hooks exit in <10ms, no recall / buffer write / ingestion side effects, no terminal flash

## Breaking changes

Provider priority shift for users with both Claude CLI on PATH **and** an API key set:

```diff
- _LLM_PROVIDERS = (
-     ("anthropic", "ANTHROPIC_API_KEY", ...),
-     ("openrouter", "OPENROUTER_API_KEY", ...),
-     ("openai", "OPENAI_API_KEY", ...),
- )
+ _LLM_PROVIDERS = (
+     ("claude_cli", "", "", "_build_claude_cli_llm"),   # NEW — priority 1
+     ("anthropic", "ANTHROPIC_API_KEY", ...),
+     ("openrouter", "OPENROUTER_API_KEY", ...),
+     ("openai", "OPENAI_API_KEY", ...),
+ )
```

Old behavior: API key wins → user pays per HyDE call.
New behavior: Claude CLI wins → user pays nothing (subscription auth).

Users who deliberately want the API-key path (e.g., centralized billing, rate-limit isolation, paid Anthropic plan for HyDE consistency) set `TRUEMEMORY_DISABLE_CLAUDE_CLI=1`. Documented in the new env-var table above.

Users without `claude.exe` on PATH see **identical** behavior — the new provider falls through to the existing API-key chain.

Co-Authored-By: claude-opus-4-7 <wontreply@getfucked.ai>
