### PR TITLE
fix: cap BLAS/OpenMP threads — concurrency fix (#316)

### DIFF
--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1485,6 +1485,10 @@ def main():
     os.environ.setdefault("HF_HUB_OFFLINE", "1")
     os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
     os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+    os.environ.setdefault("MKL_NUM_THREADS", "1")
+    os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+    os.environ.setdefault("NUMEXPR_MAX_THREADS", "1")
     if not os.environ.get("PYTORCH_MPS_HIGH_WATERMARK_RATIO"):
         try:
             import psutil

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -17,7 +17,11 @@ except ImportError:
 
 
 def _set_mps_memory_cap():
-    """Set MPS memory cap BEFORE torch is imported."""
+    """Set MPS memory cap and BLAS thread limits BEFORE torch is imported."""
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+    os.environ.setdefault("MKL_NUM_THREADS", "1")
+    os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+    os.environ.setdefault("NUMEXPR_MAX_THREADS", "1")
     if os.environ.get("PYTORCH_MPS_HIGH_WATERMARK_RATIO"):
         return
     if psutil is not None:


### PR DESCRIPTION
## Summary
- Sets `OMP_NUM_THREADS=1`, `MKL_NUM_THREADS=1`, `OPENBLAS_NUM_THREADS=1`, `NUMEXPR_MAX_THREADS=1` via `setdefault` in both `model_server.py` and `mcp_server.py`
- Placed before any torch/numpy imports
- Uses `setdefault` so user overrides are respected

## What this fixes
N concurrent MCP processes × N BLAS threads = N² context switches. With 6 sessions: 60 threads fighting for 10 cores. Measured 200,000x slowdown with 19-minute hangs on `m.add()`.

## Test evidence
- Custom validation tests: 3/3 passed (thread caps set, source verified, user overrides respected)
- Sacred parameters: verified unchanged (MPS watermark, FTS5 tokenizer, vector dims all intact)
- Only 2 files changed, 9 insertions, 1 deletion

## Risk
Single-threaded BLAS is slightly slower for large batch operations (tier switch vector rebuild). Negligible for normal single-query inference.

Closes #316