### PR TITLE
fix: dedup punctuation + ingest model server startup (#305, #337)

### DIFF
--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -129,6 +129,12 @@ def _run_ingest(args):
     level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(level=level, format="%(levelname)s %(message)s")
 
+    try:
+        from truememory.model_client import ensure_server_running
+        ensure_server_running()
+    except Exception:
+        pass  # Non-fatal — pipeline still works, just slower (local model load)
+
     # Preflight: verify truememory is importable before we try to
     # construct a pipeline. This catches missing dependencies early with
     # an actionable error instead of a deep ModuleNotFoundError.

--- a/truememory/ingest/dedup.py
+++ b/truememory/ingest/dedup.py
@@ -23,6 +23,7 @@ new episodes or integrated into existing knowledge structures.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from enum import Enum
 
@@ -158,7 +159,6 @@ def _llm_dedup(
 
     # Parse response
     import json
-    import re
 
     response = response.strip()
     response = re.sub(r"^```(?:json)?\s*\n?", "", response)
@@ -206,8 +206,8 @@ def _llm_dedup(
 
 def _word_overlap(a: str, b: str) -> float:
     """Jaccard similarity on word sets."""
-    words_a = set(a.lower().split())
-    words_b = set(b.lower().split())
+    words_a = set(re.findall(r'\w+', a.lower()))
+    words_b = set(re.findall(r'\w+', b.lower()))
     union = words_a | words_b
     if not union:
         return 0.0


### PR DESCRIPTION
## Summary
- **#305 (P3):** `_word_overlap()` Jaccard tokenization uses `str.split()` which keeps punctuation attached (`"Austin," != "Austin"`). Fixed with `re.findall(r'\w+', ...)`.
- **#337 (P3):** Ingest subprocess (`_run_ingest()` in `cli.py`) never calls `ensure_server_running()`, so the encoding gate's PE computation falls back to loading the full Qwen3 model (~1.5GB) locally. Fixed by adding `ensure_server_running()` call at the top of `_run_ingest()`.

## Files changed
- `truememory/ingest/dedup.py` — `re.findall` tokenization, module-level `import re`, removed redundant local import
- `truememory/ingest/cli.py` — `ensure_server_running()` call in `_run_ingest()`

## Files NOT changed (intentionally)
- `truememory/ingest/encoding_gate.py` — PE computation fully preserved, gate weights unchanged
- `truememory/ingest/hooks/stop.py` — Popen untouched, spawn_gate untouched

## What this does NOT do
- Does NOT skip prediction error (PE is essential, w_prediction_error=0.30)
- Does NOT add TRUEMEMORY_GATE_NO_PE env var
- Does NOT modify encoding gate weights or threshold
- Does NOT touch stop.py or spawn_gate

## Test evidence
- Custom validation tests: 16/16 passed (punctuation stripping, Jaccard correctness, PE preservation, file integrity)
- Full test suite: 109 passed, 1 failed (pre-existing test_stop_hook_safety unrelated to these changes), 1 skipped
- Sacred parameters: verified unchanged (gate threshold 0.30, weights 0.25/0.20/0.30, dedup threshold 0.92)
- encoding_gate.py: verified zero diff
- stop.py: verified zero diff
- Ruff lint: clean
- Pre-fix consensus: 4/5 APPROVE (Grok API timeout)
- Post-fix consensus: 4/5 APPROVE (Grok API timeout)

## Risk
- Bug 1: `\w+` strips ALL non-word chars including hyphens in hyphenated words. Jaccard is a coarse heuristic — this is acceptable.
- Bug 2: `ensure_server_running()` may add ~1-2 seconds if it needs to start the model server. This is a one-time cost that saves 10-30 seconds of local model loading. Wrapped in try/except so failure is non-fatal.

Closes #305, closes #337