### PR TITLE
fix: input validation, engine safety, docs, proactive search, OpenClaw (#301, #300, #309, #293, #292, #295, #281, #285, #363)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ title: "TrueMemory"
 authors:
   - name: "@Building_Josh"
     affiliation: "Sauron"
-version: "0.6.7"
-date-released: "2026-05-10"
+version: "0.7.0"
+date-released: "2026-05-21"
 url: "https://github.com/buildingjoshbetter/TrueMemory"
 license: AGPL-3.0
 keywords:

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Find me on X [@Building_Josh](https://x.com/Building_Josh) · Follow us [@Sauron
   organization = {Sauron},
   year = {2026},
   url = {https://github.com/buildingjoshbetter/TrueMemory},
-  version = {0.6.0}
+  version = {0.7.0}
 }
 ```
 

--- a/tests/test_memory_api_safety.py
+++ b/tests/test_memory_api_safety.py
@@ -169,14 +169,11 @@ def test_add_skip_marker_preserves_user_id():
 
 
 def test_add_skip_marker_on_none_like_input():
-    """None content is a programmer error but shouldn't crash."""
+    """None content is a programmer error — raises TypeError."""
     m = Memory(":memory:")
     try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            # `not None` is True, so the branch fires without even calling .strip()
-            result = m.add(None)  # type: ignore[arg-type]
-        assert result["id"] is None
+        with pytest.raises(TypeError, match="content must be a string"):
+            m.add(None)  # type: ignore[arg-type]
     finally:
         m.close()
 

--- a/truememory/client.py
+++ b/truememory/client.py
@@ -77,6 +77,8 @@ class Memory:
             NOT stored — a warning is issued and a skip-marker is
             returned (``id`` is ``None``, ``created_at`` is ``None``).
         """
+        if not isinstance(content, str):
+            raise TypeError(f"content must be a string, got {type(content).__name__}")
         # skip empty / whitespace-only content. Callers
         # passing through user-generated text (parsed transcripts,
         # partial JSON) used to pollute the DB with useless rows that

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -498,6 +498,8 @@ class TrueMemoryEngine:
         Returns:
             True if any rows were deleted from messages.
         """
+        if user_id is not None and not isinstance(user_id, str):
+            raise TypeError(f"user_id must be a string or None, got {type(user_id).__name__}")
         if isinstance(user_id, str) and not user_id.strip():
             raise ValueError("user_id cannot be an empty string")
 
@@ -1792,6 +1794,7 @@ class TrueMemoryEngine:
     # IN-clause parameter chunk size. SQLite default is 999 variables —
     # keep a healthy margin for any other bound params in the query.
     _SURPRISE_IN_CHUNK = 500
+    _warned_no_surprise = False
 
     def _source_is_blocked(self, source: str | None) -> bool:
         """True if any '+'-separated segment of `source` is in the
@@ -1888,10 +1891,12 @@ class TrueMemoryEngine:
             # Most likely surprise_scores table doesn't exist yet (cold
             # DB before first consolidate). Surface at WARNING once per
             # process so silent no-ops are visible.
-            logger.warning(
-                "L5 surprise boost unavailable: %s (run consolidate first)",
-                exc,
-            )
+            if not self._warned_no_surprise:
+                logger.warning(
+                    "L5 surprise boost unavailable: %s (run consolidate first)",
+                    exc,
+                )
+                self._warned_no_surprise = True
             return results
         except Exception:
             logger.warning(
@@ -2369,6 +2374,7 @@ Return ONLY the queries, one per line, no numbering or explanation:"""
 
     def get_stats(self) -> dict:
         """Return ingestion and search statistics."""
+        self._ensure_connection()
         stats = dict(self.stats)
 
         # Add live DB stats if connected.

--- a/truememory/hooks/adapters/openclaw.py
+++ b/truememory/hooks/adapters/openclaw.py
@@ -165,10 +165,11 @@ class OpenClawAdapter(CLIAdapter):
         return self._has_mcp_entry() and self._has_plugin()
 
     def get_system_prompt_path(self) -> Path | None:
-        return None
+        return _OPENCLAW_DIR / "truememory_prompt.md"
 
     def get_system_prompt_content(self) -> str:
-        return ""
+        from truememory.hooks.adapters.base import get_generic_system_prompt
+        return get_generic_system_prompt()
 
     # -- Private helpers --
 

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -767,8 +767,8 @@ def truememory_configure(
     if tier not in ("edge", "base", "pro"):
         return json.dumps({"error": "tier must be 'edge', 'base', or 'pro'"})
 
-    if api_key and len(api_key) > 256:
-        return json.dumps({"error": "api_key exceeds maximum length of 256 characters"})
+    if api_key and len(api_key) > 4096:
+        return json.dumps({"error": "api_key exceeds maximum length of 4096 characters"})
 
     # Validate API key + provider pairing
     if api_key and not api_provider:

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -170,6 +170,11 @@ Deep search (truememory_search_deep):
 - Also supports | separated parallel queries.
 - Retrieves 5x more candidates internally — best for questions requiring scattered evidence.
 
+Proactive search — BEFORE saying "I don't have":
+- Before saying you don't have credentials, API keys, passwords, SSH details, configuration, or infrastructure information, ALWAYS search TrueMemory first.
+- Common examples: API keys (OpenRouter, Anthropic, PyPI, GitHub tokens), SSH credentials and IP addresses, database passwords, service URLs, project configuration details.
+- If TrueMemory has the information, use it directly. Only say "I don't have X" after searching and confirming it's not stored.
+
 You should store and recall memories as naturally as a good assistant who remembers past conversations. Do not ask permission to remember things — just do it.""",
 )
 
@@ -672,6 +677,8 @@ def truememory_forget(memory_id: int) -> str:
     Args:
         memory_id: The integer ID of the memory to delete.
     """
+    if isinstance(memory_id, bool) or not isinstance(memory_id, int):
+        return json.dumps({"error": f"memory_id must be an integer, got {type(memory_id).__name__}"})
     m = _get_memory()
     deleted = m.delete(memory_id)
     return json.dumps({"deleted": deleted, "memory_id": memory_id})
@@ -759,6 +766,9 @@ def truememory_configure(
     tier = tier.lower().strip()
     if tier not in ("edge", "base", "pro"):
         return json.dumps({"error": "tier must be 'edge', 'base', or 'pro'"})
+
+    if api_key and len(api_key) > 256:
+        return json.dumps({"error": "api_key exceeds maximum length of 256 characters"})
 
     # Validate API key + provider pairing
     if api_key and not api_provider:


### PR DESCRIPTION
## Summary
- **mcp_server.py**: `truememory_forget()` rejects bool/non-int `memory_id`; `truememory_configure()` caps `api_key` at 256 chars; system prompt adds proactive search instructions (search before saying "I don't have credentials/keys/etc.")
- **engine.py**: `delete_all()` rejects non-string `user_id` with `TypeError`; `get_stats()` calls `_ensure_connection()` for cold-start safety; `_apply_surprise_boost()` warns only once per process on missing `surprise_scores` table
- **client.py**: `Memory.add()` rejects non-string `content` with `TypeError`
- **openclaw.py**: Returns generic system prompt content and `truememory_prompt.md` path (matches Kimi/Hermes adapters)
- **README.md + CITATION.cff**: Bump citation version to 0.7.0 and release date to 2026-05-21

Closes #301, closes #300, closes #309, closes #293, closes #292, closes #295, closes #281, closes #285, closes #363

## Test plan
- [ ] `truememory_forget(True)` returns error JSON instead of crashing
- [ ] `truememory_forget("abc")` returns error JSON instead of crashing
- [ ] `truememory_configure(tier="pro", api_key="x"*300)` returns length error
- [ ] `Memory.add(123)` raises `TypeError`
- [ ] `engine.delete_all(user_id=123)` raises `TypeError`
- [ ] `engine.get_stats()` works without prior `_ensure_connection()` call
- [ ] L5 surprise warning only appears once in logs, not on every search
- [ ] OpenClaw adapter returns non-empty system prompt content
- [ ] CITATION.cff parses as valid CFF