### PR TITLE
fix: auto-migrate legacy database schema on open (#286)

### DIFF
--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -14,8 +14,12 @@ Schema overview:
 """
 
 import json
+import logging
 import sqlite3
+import time
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -219,9 +223,58 @@ DEFAULT_BUSY_TIMEOUT_MS = 10_000
 # Database creation
 # ---------------------------------------------------------------------------
 
+_EXPECTED_COLUMNS = {
+    "recipient": "TEXT DEFAULT ''",
+    "category": "TEXT DEFAULT ''",
+    "modality": "TEXT DEFAULT ''",
+    "episode_id": "INTEGER DEFAULT NULL",
+    "emotional_valence": "REAL DEFAULT 0.0",
+    "embedding_separation": "BLOB DEFAULT NULL",
+}
+
+
+def _migrate_messages_schema(conn: sqlite3.Connection, db_path: str | Path) -> None:
+    """Add missing columns to an existing messages table (legacy DB upgrade).
+
+    Creates a backup of the database file before making any changes.
+    Only runs if the messages table already exists and is missing expected columns.
+    """
+    try:
+        existing = {row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()}
+    except Exception:
+        return
+    if not existing:
+        return
+
+    missing = {col: typedef for col, typedef in _EXPECTED_COLUMNS.items() if col not in existing}
+    if not missing:
+        return
+
+    if str(db_path) != ":memory:":
+        import shutil
+        backup = Path(str(db_path) + f".backup-pre-migration-{int(time.time())}")
+        try:
+            shutil.copy2(str(db_path), str(backup))
+            log.info("Legacy DB backup created: %s", backup)
+        except Exception as e:
+            log.warning("Could not back up database before migration: %s", e)
+            return
+
+    for col, typedef in missing.items():
+        try:
+            conn.execute(f"ALTER TABLE messages ADD COLUMN {col} {typedef}")
+            log.info("Migrated legacy DB: added column messages.%s", col)
+        except Exception as e:
+            log.warning("Failed to add column messages.%s: %s", col, e)
+
+
 def create_db(db_path: str | Path) -> sqlite3.Connection:
     """
     Create (or open) a TrueMemory database with the full schema.
+
+    If the database has an older schema (pre-v0.5), missing columns are
+    added automatically via ALTER TABLE. A timestamped backup is created
+    before any migration.
 
     Enables WAL mode for concurrent read/write performance and executes all
     CREATE TABLE / CREATE VIRTUAL TABLE / CREATE TRIGGER statements.
@@ -240,6 +293,7 @@ def create_db(db_path: str | Path) -> sqlite3.Connection:
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA cache_size=-64000")
     conn.execute("PRAGMA mmap_size=268435456")
+    _migrate_messages_schema(conn, db_path)
     conn.executescript(_SCHEMA_SQL)
     conn.commit()
     return conn

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -233,11 +233,43 @@ _EXPECTED_COLUMNS = {
 }
 
 
+def _backup_database(db_path: Path) -> Path | None:
+    """Create a complete backup of the database including WAL/SHM files.
+
+    Returns the backup path on success, None on failure.
+    """
+    import os
+    import shutil
+    import uuid
+
+    suffix = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    backup = Path(f"{db_path}.backup-pre-migration-{suffix}")
+
+    if backup.exists():
+        return None
+
+    try:
+        shutil.copy2(str(db_path), str(backup))
+        for ext in ("-wal", "-shm"):
+            wal_path = Path(f"{db_path}{ext}")
+            if wal_path.exists():
+                shutil.copy2(str(wal_path), str(backup) + ext)
+        log.info("Legacy DB backup created: %s", backup)
+        return backup
+    except Exception as e:
+        log.warning("Could not back up database before migration: %s", e)
+        return None
+
+
 def _migrate_messages_schema(conn: sqlite3.Connection, db_path: str | Path) -> None:
     """Add missing columns to an existing messages table (legacy DB upgrade).
 
-    Creates a backup of the database file before making any changes.
-    Only runs if the messages table already exists and is missing expected columns.
+    Safety measures:
+    - Creates a complete backup (DB + WAL + SHM) before any changes
+    - If backup fails, migration is skipped entirely
+    - All ALTER TABLE statements run inside a single transaction
+    - If any ALTER fails, the entire transaction is rolled back
+    - Only runs if the messages table already exists and is missing columns
     """
     try:
         existing = {row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()}
@@ -251,21 +283,23 @@ def _migrate_messages_schema(conn: sqlite3.Connection, db_path: str | Path) -> N
         return
 
     if str(db_path) != ":memory:":
-        import shutil
-        backup = Path(str(db_path) + f".backup-pre-migration-{int(time.time())}")
-        try:
-            shutil.copy2(str(db_path), str(backup))
-            log.info("Legacy DB backup created: %s", backup)
-        except Exception as e:
-            log.warning("Could not back up database before migration: %s", e)
+        backup = _backup_database(Path(str(db_path)))
+        if backup is None:
+            log.warning("Skipping legacy migration — backup failed")
             return
 
-    for col, typedef in missing.items():
-        try:
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        for col, typedef in missing.items():
             conn.execute(f"ALTER TABLE messages ADD COLUMN {col} {typedef}")
             log.info("Migrated legacy DB: added column messages.%s", col)
-        except Exception as e:
-            log.warning("Failed to add column messages.%s: %s", col, e)
+        conn.execute("COMMIT")
+    except Exception as e:
+        try:
+            conn.execute("ROLLBACK")
+        except Exception:
+            pass
+        log.warning("Legacy migration failed and was rolled back: %s", e)
 
 
 def create_db(db_path: str | Path) -> sqlite3.Connection:


### PR DESCRIPTION
## Summary
Opens pre-v0.5 databases without crashing by adding missing columns before the schema DDL runs. Creates a timestamped backup first.

## Changes
- `truememory/storage.py`: Added `_migrate_messages_schema()` and `_EXPECTED_COLUMNS` dict
- Migration runs inside `create_db()` before `executescript(_SCHEMA_SQL)`
- Adds `logging`, `time` imports

## Safety
- Backup created before any ALTER TABLE (`{db_path}.backup-pre-migration-{timestamp}`)
- If backup fails, migration is skipped entirely
- Current-schema databases: zero changes, no backup
- In-memory databases: works, no backup attempted
- ALTER TABLE ADD COLUMN in SQLite is atomic
- All new columns have DEFAULT values — existing rows unaffected

## Test evidence
- Legacy 5-column DB: migrated, data preserved, backup created
- Current schema DB: no-op, no backup
- In-memory DB: works
- Partially migrated DB: only missing columns added
- Sacred parameters (busy_timeout, FTS tokenizer): unchanged

Closes #286