### PR TITLE
fix: guard fcntl import for Windows compatibility (supersedes #345)

### DIFF
--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -1,11 +1,16 @@
 """Shared utilities for TrueMemory hooks."""
 
 from pathlib import Path
-import fcntl
 import json
 import logging
 import os
 import time
+
+try:
+    import fcntl
+    _HAS_FCNTL = True
+except ImportError:
+    _HAS_FCNTL = False
 
 log = logging.getLogger(__name__)
 
@@ -95,7 +100,8 @@ def check_extraction_budget() -> bool:
     try:
         _BUDGET_FILE.parent.mkdir(parents=True, exist_ok=True)
         fd = os.open(str(_BUDGET_FILE), os.O_RDWR | os.O_CREAT)
-        fcntl.flock(fd, fcntl.LOCK_EX)
+        if _HAS_FCNTL:
+            fcntl.flock(fd, fcntl.LOCK_EX)
         try:
             raw = os.read(fd, 4096).decode("utf-8", errors="replace").strip()
             data = json.loads(raw) if raw else {}

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -21,12 +21,17 @@ Output (stdout JSON):
 """
 
 import argparse
-import fcntl
 import json
 import logging
 import os
 import sys
 from pathlib import Path
+
+try:
+    import fcntl
+    _HAS_FCNTL = True
+except ImportError:
+    _HAS_FCNTL = False
 
 log = logging.getLogger(__name__)
 
@@ -284,7 +289,8 @@ def _scan_stale_sessions() -> None:
     _SCAN_MARKER.parent.mkdir(parents=True, exist_ok=True)
     try:
         scan_fd = os.open(str(_SCAN_MARKER), os.O_RDWR | os.O_CREAT)
-        fcntl.flock(scan_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        if _HAS_FCNTL:
+            fcntl.flock(scan_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except (BlockingIOError, OSError):
         return
 


### PR DESCRIPTION
## Summary
Guards bare `import fcntl` in `_shared.py` and `session_start.py` with try/except ImportError. Without this, every hook subprocess crashes on Windows.

## Changes
- `truememory/ingest/hooks/_shared.py`: fcntl import guard + `_HAS_FCNTL` flag, flock call gated
- `truememory/ingest/hooks/session_start.py`: same pattern

## What this is
Clean rewrite of Huntehhh's PR #345 — same fix, stripped of verbose comments, CHANGELOG bloat, and 230-line test file. Hunter gets Co-Author credit.

Supersedes #345.