### PR TITLE
fix: log parallel search failures + close Popen file handle (supersedes #349)

### DIFF
--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -522,8 +522,8 @@ def _parallel_search(queries, user_id, internal_limit, llm_fn, output_limit):
                     if rid not in seen_ids:
                         merged.append(r)
                         seen_ids.add(rid)
-            except Exception:
-                pass  # Individual query failure or timeout doesn't kill the batch
+            except Exception as e:
+                log.debug("parallel search query failed: %s", e)
 
     merged.sort(key=lambda x: -x.get("score", 0))
     return merged[:output_limit]
@@ -1217,14 +1217,16 @@ def _drain_batch_from_backlog(markers: list[Path]) -> None:
                     _log_dir / f"{_safe_sid}.log",
                     "a", encoding="utf-8",
                 )
-                proc = _subprocess.Popen(
-                    cmd,
-                    stdout=_log_file,
-                    stderr=_subprocess.STDOUT,
-                    stdin=_subprocess.DEVNULL,
-                    start_new_session=True,
-                )
-                _log_file.close()
+                try:
+                    proc = _subprocess.Popen(
+                        cmd,
+                        stdout=_log_file,
+                        stderr=_subprocess.STDOUT,
+                        stdin=_subprocess.DEVNULL,
+                        start_new_session=True,
+                    )
+                finally:
+                    _log_file.close()
                 register_spawned_pid(proc.pid)
                 record_stale_processing_pid(claimed_path, proc.pid)
 


### PR DESCRIPTION
## Summary
1. `_parallel_search`: bare `except Exception: pass` → `log.debug("parallel search query failed: %s", e)`
2. `_drain_batch_from_backlog`: Popen wrapped in try/finally so log file handle closes on spawn failure

## What this is
Clean rewrite of Huntehhh's PR #349 — same fixes, no CHANGELOG bloat, no 195-line test file. Hunter gets Co-Author credit.

Supersedes #349.