### PR TITLE
fix: simplify CLI test helper + propagate exit codes (supersedes #352)

### DIFF
--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -7,7 +7,6 @@ mcp.run(transport="stdio") which blocks on stdin forever, making
 """
 from __future__ import annotations
 
-import shutil
 import subprocess
 import sys
 
@@ -16,23 +15,8 @@ import pytest
 from truememory import __version__
 
 
-def _truememory_mcp_bin() -> str | None:
-    """Locate the installed truememory-mcp console script, or None.
-
-    Prefer the script installed by pip. Fall back to invoking via
-    `python -m truememory.mcp_server` — slower because it re-runs all
-    module-level imports, but works in any environment where truememory
-    is importable.
-    """
-    return shutil.which("truememory-mcp")
-
-
 def _run_cli(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
-    bin_path = _truememory_mcp_bin()
-    if bin_path:
-        cmd = [bin_path] + args
-    else:
-        cmd = [sys.executable, "-m", "truememory.mcp_server"] + args
+    cmd = [sys.executable, "-m", "truememory.mcp_server"] + args
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
 

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1583,4 +1583,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main() or 0)


### PR DESCRIPTION
## Summary
1. `tests/test_cli_help.py`: Remove shutil.which two-arm helper, always use `python -m` (avoids Windows Defender ASR block)
2. `truememory/mcp_server.py`: `main()` → `sys.exit(main() or 0)` in `__main__` block

2 files, -16 net lines. Clean rewrite of Hunter's #352. Supersedes #352.

Co-Authored-By: Huntehhh <hunter@users.noreply.github.com>