### PR TITLE
fix: bypass Windows Defender ASR shim block in installers (supersedes #346)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ irm https://raw.githubusercontent.com/buildingjoshbetter/TrueMemory/main/install
 
 &nbsp;
 
-**<ins>Step 4.</ins>** Quit Claude completely and reopen it (Mac: `Cmd+Q`, Windows: close all Claude windows).
+**<ins>Step 4.</ins>** Quit Claude completely and reopen it (Mac: `Cmd+Q`, Windows: right-click the Claude tray icon → **Quit**).
 
 &nbsp;
 

--- a/install.ps1
+++ b/install.ps1
@@ -87,8 +87,11 @@ if ($LASTEXITCODE -ne 0) {
 
 # ---------- step 3: install truememory as a uv tool ----------
 Say "installing $PKG_SPEC (~3-5 min on first run, downloads all tier models)..."
-& uv tool uninstall truememory *> $null
-& uv tool install --python $TRUEMEMORY_PY --force --refresh $PKG_SPEC > $null
+& uv tool uninstall truememory 2>$null *> $null
+if ($LASTEXITCODE -gt 1) {
+    Warn "uv tool uninstall returned $LASTEXITCODE — proceeding, but result may be partial"
+}
+& uv tool install --python $TRUEMEMORY_PY --force --refresh "$PKG_SPEC" > $null
 if ($LASTEXITCODE -ne 0) {
     Die "truememory install failed"
 }
@@ -107,28 +110,36 @@ if ($uvToolDir) {
     }
 }
 
+# Resolve tool venv python early (avoids Windows Defender ASR shim blocks)
+$toolPython = $null
+if ($uvToolDir) {
+    $candidate = Join-Path $uvToolDir "truememory\Scripts\python.exe"
+    if (Test-Path $candidate) { $toolPython = $candidate }
+}
+
 # ---------- step 4: auto-configure Claude ----------
 if ($env:TRUEMEMORY_SKIP_SETUP -eq "1") {
     Say "skipping Claude setup (TRUEMEMORY_SKIP_SETUP=1)"
+} elseif (-not $toolPython) {
+    Warn "could not locate tool venv python — skipping Claude setup."
+    Warn "Re-run manually: python -m truememory.mcp_server --setup"
 } else {
     Say "configuring Claude Code / Claude Desktop..."
-    & truememory-mcp --setup
+    & $toolPython -m truememory.mcp_server --setup
     if ($LASTEXITCODE -ne 0) {
-        Warn "auto-setup returned non-zero (you can re-run it with: truememory-mcp --setup)"
+        Warn "auto-setup returned non-zero (re-run: python -m truememory.mcp_server --setup)"
     }
 
     Say "installing hooks and CLAUDE.md instructions..."
-    & truememory-ingest install
+    & $toolPython -m truememory.ingest.cli install
     if ($LASTEXITCODE -ne 0) {
-        Warn "hook install returned non-zero (you can re-run it with: truememory-ingest install)"
+        Warn "hook install returned non-zero (re-run: python -m truememory.ingest.cli install)"
     }
 }
 
 # ---------- step 5: pre-download models for all tiers ----------
 Say "pre-downloading models for all tiers (Edge + Base + Pro)..."
 Say "  this takes 2-5 min but means tier switching just works afterward."
-
-$toolPython = Join-Path (& uv tool dir 2>$null) "truememory\Scripts\python.exe"
 if (Test-Path $toolPython) {
     Say "  [1/3] Edge reranker (MiniLM-L-6-v2, ~22MB)..."
     & $toolPython -c "from sentence_transformers import CrossEncoder; CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')"

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ die()  { warn "error: $*"; exit 1; }
 
 # ---------- main ----------
 main() {
-  set -euo pipefail
+  set -eu
 
   TRUEMEMORY_PY="${TRUEMEMORY_PY:-3.12}"
   TRUEMEMORY_EXTRAS="${TRUEMEMORY_EXTRAS:-}"

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ die()  { warn "error: $*"; exit 1; }
 
 # ---------- main ----------
 main() {
-  set -eu
+  set -euo pipefail
 
   TRUEMEMORY_PY="${TRUEMEMORY_PY:-3.12}"
   TRUEMEMORY_EXTRAS="${TRUEMEMORY_EXTRAS:-}"
@@ -113,29 +113,30 @@ main() {
   say "adding uv's tool dir to your shell rc (reversible)..."
   uv tool update-shell >/dev/null 2>&1 || true
 
+  # Resolve tool venv python for steps 4 and 5 (avoids Windows Defender ASR shim blocks)
+  TOOL_PYTHON="$(uv tool dir)/truememory/bin/python"
+
   # ---------- step 4: auto-configure Claude ----------
   if [ "${TRUEMEMORY_SKIP_SETUP:-}" = "1" ]; then
     say "skipping Claude setup (TRUEMEMORY_SKIP_SETUP=1)"
+  elif [ ! -x "$TOOL_PYTHON" ]; then
+    warn "could not locate tool venv python at $TOOL_PYTHON — skipping Claude setup."
+    warn "Re-run manually: python -m truememory.mcp_server --setup"
   else
     say "configuring Claude Code / Claude Desktop..."
-    # truememory-mcp lives at ~/.local/bin/truememory-mcp. Its sys.executable
-    # resolves to the isolated tool venv, so Claude gets a stable absolute path.
-    truememory-mcp --setup || \
-      warn "auto-setup returned non-zero (you can re-run it with: truememory-mcp --setup)"
+    "$TOOL_PYTHON" -m truememory.mcp_server --setup || \
+      warn "auto-setup returned non-zero (re-run: python -m truememory.mcp_server --setup)"
 
     say "installing hooks and CLAUDE.md instructions..."
-    truememory-ingest install || \
-      warn "hook install returned non-zero (you can re-run it with: truememory-ingest install)"
+    "$TOOL_PYTHON" -m truememory.ingest.cli install || \
+      warn "hook install returned non-zero (re-run: python -m truememory.ingest.cli install)"
   fi
 
   # ---------- step 5: pre-download models for all tiers ----------
   say "pre-downloading models for all tiers (Edge + Base + Pro)..."
   say "  this takes 2-5 min but means tier switching just works afterward."
   say "  you'll see download progress bars below."
-  # Use the tool's Python to run the download inside the uv venv.
-  # stderr is NOT suppressed — HuggingFace's tqdm progress bars show
-  # download percentage, speed, and ETA, which is better UX than silence.
-  TOOL_PYTHON="$(uv tool dir)/truememory/bin/python"
+  # Use the tool's Python (resolved in step 4) to run downloads inside the uv venv.
   if [ -x "$TOOL_PYTHON" ]; then
     # Edge: Model2Vec embedder (usually bundled) + MiniLM reranker
     say "  [1/3] Edge reranker (MiniLM-L-6-v2, ~22MB)..."

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1334,6 +1334,17 @@ def _setup_claude():
         except Exception:
             return False
 
+    def _is_shim_path(cmd: str) -> bool:
+        if not cmd:
+            return False
+        lower = cmd.lower().replace("\\", "/")
+        return (
+            lower.endswith("/truememory-mcp.exe")
+            or lower.endswith("/truememory-mcp")
+            or "/scripts/truememory-mcp" in lower
+            or "/bin/truememory-mcp" in lower
+        )
+
     # --- Claude Code CLI ---
     claude_bin = shutil.which("claude")
     if claude_bin:
@@ -1369,17 +1380,22 @@ def _setup_claude():
                             existing_cmd = tokens[0]
                         break
 
-            if _path_exists(existing_cmd):
-                # Working entry — preserve it (don't clobber a dev venv).
+            if _is_shim_path(existing_cmd):
+                _run_claude([claude_bin, "mcp", "remove", "--scope", "user", "truememory"])
+                retry = _run_claude(add_cmd)
+                if retry is not None and retry.returncode == 0:
+                    configured.append("Claude Code (migrated from shim to python -m form)")
+                elif retry is not None:
+                    print(f"  Claude Code: migration failed — {retry.stderr.strip()}", file=sys.stderr)
+            elif _path_exists(existing_cmd):
                 configured.append("Claude Code (existing config preserved)")
             else:
-                # Stale entry — remove and re-add.
                 _run_claude([claude_bin, "mcp", "remove", "--scope", "user", "truememory"])
                 retry = _run_claude(add_cmd)
                 if retry is not None and retry.returncode == 0:
                     configured.append("Claude Code (stale entry replaced)")
                 elif retry is not None:
-                    print(f"  Claude Code: update failed — {retry.stderr.strip()}")
+                    print(f"  Claude Code: update failed — {retry.stderr.strip()}", file=sys.stderr)
         else:
             print(f"  Claude Code: failed — {result.stderr.strip()}")
 
@@ -1401,20 +1417,21 @@ def _setup_claude():
             existing_cmd = (existing or {}).get("command", "") if isinstance(existing, dict) else ""
 
             if existing is None:
-                # No entry — create one.
                 servers["truememory"] = {"command": python_path, "args": list(mcp_args)}
                 desktop_config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
                 configured.append("Claude Desktop")
+            elif _is_shim_path(existing_cmd):
+                servers["truememory"] = {"command": python_path, "args": list(mcp_args)}
+                desktop_config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
+                configured.append("Claude Desktop (migrated from shim to python -m form)")
             elif _path_exists(existing_cmd):
-                # Working entry — preserve it.
                 configured.append("Claude Desktop (existing config preserved)")
             else:
-                # Stale entry — replace it.
                 servers["truememory"] = {"command": python_path, "args": list(mcp_args)}
                 desktop_config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
                 configured.append("Claude Desktop (stale entry replaced)")
         except Exception as e:
-            print(f"  Claude Desktop: failed — {e}")
+            print(f"  Claude Desktop: failed — {e}", file=sys.stderr)
 
     # --- Report ---
     print()

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1341,8 +1341,8 @@ def _setup_claude():
         return (
             lower.endswith("/truememory-mcp.exe")
             or lower.endswith("/truememory-mcp")
-            or "/scripts/truememory-mcp" in lower
-            or "/bin/truememory-mcp" in lower
+            or lower.endswith("/scripts/truememory-mcp.exe")
+            or lower.endswith("/bin/truememory-mcp")
         )
 
     # --- Claude Code CLI ---
@@ -1421,7 +1421,8 @@ def _setup_claude():
                 desktop_config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
                 configured.append("Claude Desktop")
             elif _is_shim_path(existing_cmd):
-                servers["truememory"] = {"command": python_path, "args": list(mcp_args)}
+                existing["command"] = python_path
+                existing["args"] = list(mcp_args)
                 desktop_config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
                 configured.append("Claude Desktop (migrated from shim to python -m form)")
             elif _path_exists(existing_cmd):


### PR DESCRIPTION
## Summary
Installers now use `python -m` instead of console-script shims, bypassing Windows Defender ASR blocks. Auto-migrates old shim paths in Claude config.

## Changes
- `install.sh`: pipefail, resolve TOOL_PYTHON early, use python -m
- `install.ps1`: quote PKG_SPEC, check uninstall exit, resolve toolPython early, use python -m
- `truememory/mcp_server.py`: _is_shim_path() + migration logic for Claude Code and Desktop
- `README.md`: Windows tray-quit instruction

Clean rewrite of Hunter's #346 — same fixes, no CHANGELOG novel. Supersedes #346.

Co-Authored-By: Huntehhh <hunter@users.noreply.github.com>