### PR TITLE
docs: Windows Defender ASR troubleshooting (supersedes #350)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,6 +2,8 @@
 
 TrueMemory provides two CLI tools: `truememory-mcp` (MCP server) and `truememory-ingest` (ingestion and management).
 
+> **Windows Defender ASR**: If commands are blocked, use `python -m truememory.mcp_server` / `python -m truememory.ingest.cli` instead. See [debugging guide](guides/debugging.md#windows-defender-asr-blocks-truememory-mcpexe).
+
 ---
 
 ## truememory-mcp

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -44,6 +44,19 @@ You're running the command from a shell that doesn't have the uv tool directory 
 - Mac/Linux: `export PATH="$HOME/.local/bin:$PATH"`
 - Windows PowerShell: close and reopen PowerShell, or run `$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "User") + ";" + $env:Path`
 
+### Windows: Defender ASR blocks truememory-mcp.exe
+
+If Microsoft Defender's ASR rule `01443614` is in **Block** mode, the `truememory-mcp.exe` and `truememory-ingest.exe` shims are silently killed at launch. Use the module form instead:
+
+```powershell
+python -m truememory.mcp_server --setup
+python -m truememory.ingest.cli install
+python -m truememory.ingest.cli status
+python -m truememory.ingest.cli logs
+```
+
+The `--setup` command auto-migrates existing Claude configs from shim to module form.
+
 ### Memories not being stored
 
 1. Check that the session had at least 5 user messages (configurable via `TRUEMEMORY_MIN_MESSAGES`)

--- a/docs/setup-codex.md
+++ b/docs/setup-codex.md
@@ -71,3 +71,4 @@ truememory-ingest status
 - **MCP not connecting**: Verify the Python path in `config.toml` points to the environment with TrueMemory installed.
 - **Existing config**: TrueMemory uses additive merges — your existing Codex config is preserved.
 - **Hooks not firing**: Check that the hook script paths are absolute and the Python executable is correct.
+- **Windows Defender ASR**: If commands are blocked, use `python -m` form instead. See [debugging guide](guides/debugging.md#windows-defender-asr-blocks-truememory-mcpexe).

--- a/docs/setup-cursor.md
+++ b/docs/setup-cursor.md
@@ -93,3 +93,4 @@ truememory-ingest status
 - **Hooks not firing**: Check that event names are camelCase (`sessionStart`, `stop`, `preCompact`). PascalCase will silently fail.
 - **Two config files**: MCP lives in `~/.cursor/mcp.json`, hooks live in `~/.cursor/hooks.json`. They are separate files.
 - **Version key**: `hooks.json` requires `"version": 1` at the top level.
+- **Windows Defender ASR**: If commands are blocked, use `python -m` form instead. See [debugging guide](guides/debugging.md#windows-defender-asr-blocks-truememory-mcpexe).

--- a/docs/setup-gemini.md
+++ b/docs/setup-gemini.md
@@ -81,3 +81,4 @@ truememory-ingest status
 - **MCP not connecting**: Verify the Python path in `settings.json` points to the environment with TrueMemory installed.
 - **Existing config**: TrueMemory uses additive merges — your existing Gemini config is preserved.
 - **Hooks not firing**: Check that the hook script paths are absolute and the Python executable is correct. Event names are PascalCase: `SessionStart`, `SessionEnd`, `PreCompress`.
+- **Windows Defender ASR**: If commands are blocked, use `python -m` form instead. See [debugging guide](guides/debugging.md#windows-defender-asr-blocks-truememory-mcpexe).

--- a/docs/setup-hermes.md
+++ b/docs/setup-hermes.md
@@ -67,3 +67,4 @@ truememory-ingest status
 - **Plugins not loading**: Check that `cli-config.yaml` is valid YAML (no tab characters).
 - **MCP not connecting**: Verify the Python path in `config.yaml`.
 - **Gateway users**: For Telegram/Discord/etc., a separate `handler.py` gateway hook is needed (see architecture docs).
+- **Windows Defender ASR**: If commands are blocked, use `python -m` form instead. See [debugging guide](guides/debugging.md#windows-defender-asr-blocks-truememory-mcpexe).

--- a/docs/setup-kimi.md
+++ b/docs/setup-kimi.md
@@ -72,3 +72,4 @@ truememory-ingest status
 - **Hooks not firing**: Kimi hooks are in beta. Check `kimi --version` for compatibility.
 - **MCP not connecting**: Verify the Python path in `mcp.json` points to the environment with TrueMemory installed.
 - **Existing config**: TrueMemory uses additive merges — your existing Kimi config is preserved.
+- **Windows Defender ASR**: If commands are blocked, use `python -m` form instead. See [debugging guide](guides/debugging.md#windows-defender-asr-blocks-truememory-mcpexe).

--- a/docs/setup-openclaw.md
+++ b/docs/setup-openclaw.md
@@ -75,3 +75,4 @@ truememory-ingest status
 - **Plugin not loading**: Verify `~/.openclaw/plugins/truememory/plugin.json` exists and is valid JSON.
 - **Python not found**: Set the `TRUEMEMORY_PYTHON` environment variable to your Python path.
 - **JSON5 config**: OpenClaw uses JSON5. TrueMemory reads it but writes standard JSON — comments may be stripped on config updates.
+- **Windows Defender ASR**: If commands are blocked, use `python -m` form instead. See [debugging guide](guides/debugging.md#windows-defender-asr-blocks-truememory-mcpexe).


### PR DESCRIPTION
## Summary
Adds ASR troubleshooting to debugging.md + one-line references in cli.md and all adapter setup pages.

Clean rewrite of Hunter's #350 — canonical docs section instead of copy-pasting the full block 9 times. Supersedes #350.

Co-Authored-By: Huntehhh <hunter@users.noreply.github.com>