### PR TITLE
fix: setup hygiene — parse-miss preservation, atomic writes, timestamped backups (supersedes #348)

### DIFF
--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -971,7 +971,13 @@ def _run_install(args):
             if not already_present:
                 existing["hooks"][event].append(hook)
 
-    settings_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    settings_tmp = settings_path.with_suffix(".json.tmp")
+    settings_tmp.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    try:
+        settings_tmp.replace(settings_path)
+    except OSError:
+        settings_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+        settings_tmp.unlink(missing_ok=True)
     print(f"Hooks installed in {settings_path}")
     print(f"Events configured: {', '.join(settings['hooks'].keys())}")
 
@@ -1037,7 +1043,8 @@ def _merge_claude_md(template_path: Path, target_path: Path) -> None:
 
     # Back up the existing file before mutating it
     if existing and target_path.exists():
-        backup_path = target_path.with_suffix(".md.bak")
+        import time as _time
+        backup_path = target_path.with_name(f"CLAUDE.md.bak.{int(_time.time())}")
         try:
             backup_path.write_text(existing, encoding="utf-8")
         except OSError:

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1389,15 +1389,18 @@ def _setup_claude():
                     print(f"  Claude Code: migration failed — {retry.stderr.strip()}", file=sys.stderr)
             elif _path_exists(existing_cmd):
                 configured.append("Claude Code (existing config preserved)")
-            else:
+            elif existing_cmd:
                 _run_claude([claude_bin, "mcp", "remove", "--scope", "user", "truememory"])
                 retry = _run_claude(add_cmd)
                 if retry is not None and retry.returncode == 0:
                     configured.append("Claude Code (stale entry replaced)")
                 elif retry is not None:
                     print(f"  Claude Code: update failed — {retry.stderr.strip()}", file=sys.stderr)
+            else:
+                configured.append("Claude Code (existing config preserved — parse miss)")
+                print("  Claude Code: could not parse existing entry, preserving config", file=sys.stderr)
         else:
-            print(f"  Claude Code: failed — {result.stderr.strip()}")
+            print(f"  Claude Code: failed — {result.stderr.strip()}", file=sys.stderr)
 
     # --- Claude Desktop ---
     # pre-PR49, this path was hardcoded to the macOS
@@ -1427,10 +1430,12 @@ def _setup_claude():
                 configured.append("Claude Desktop (migrated from shim to python -m form)")
             elif _path_exists(existing_cmd):
                 configured.append("Claude Desktop (existing config preserved)")
-            else:
+            elif existing_cmd:
                 servers["truememory"] = {"command": python_path, "args": list(mcp_args)}
                 desktop_config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
                 configured.append("Claude Desktop (stale entry replaced)")
+            else:
+                configured.append("Claude Desktop (existing config preserved — empty command)")
         except Exception as e:
             print(f"  Claude Desktop: failed — {e}", file=sys.stderr)
 


### PR DESCRIPTION
## Summary
1. `mcp_server.py`: Parse-miss on `claude mcp list` preserves existing config instead of clobbering
2. `cli.py`: Atomic settings.json write via tmp + rename
3. `cli.py`: Timestamped CLAUDE.md.bak prevents overwrite on re-install

2 files, +17/-5. Clean rewrite of Hunter's #348 (stripped #346 duplication and 300-line test file). Supersedes #348.

Co-Authored-By: Huntehhh <hunter@users.noreply.github.com>