### PR TITLE
fix: engine hardening — chunked deletes, rebuild race, TOCTOU fix (supersedes #347)

### DIFF
--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -61,6 +61,17 @@ _ALLOWED_COLUMNS = frozenset({
     "source_message_id", "cause_msg_id", "effect_msg_id",
 })
 
+_SQLITE_IN_CHUNK = 500
+
+
+def _delete_in_chunks(conn, table: str, col: str, ids: list[int], chunk_size: int = _SQLITE_IN_CHUNK) -> None:
+    if not ids:
+        return
+    for i in range(0, len(ids), chunk_size):
+        chunk = ids[i:i + chunk_size]
+        placeholders = ",".join("?" * len(chunk))
+        conn.execute(f"DELETE FROM {table} WHERE {col} IN ({placeholders})", chunk)
+
 # ───────────────────────────────────────────────────────────────────────────
 # Optional modules — each import is wrapped so missing deps don't break
 # the engine.  Capability flags track what's available at runtime.
@@ -343,8 +354,10 @@ class TrueMemoryEngine:
                     except Exception:
                         logger.debug("Legacy vec table migration skipped", exc_info=True)
                     self._has_vectors = True
-                except Exception:
-                    logger.debug("Failed to load sqlite-vec extension", exc_info=True)
+                except Exception as exc:
+                    global _vectors_load_error
+                    _vectors_load_error = f"{type(exc).__name__}: {exc}"
+                    logger.warning("Failed to load sqlite-vec — FTS-only mode: %s", exc)
                     self._has_vectors = False
 
             self._has_hybrid = _HAS_HYBRID and self._has_vectors
@@ -525,10 +538,9 @@ class TrueMemoryEngine:
                 )
                 deleted = cursor.rowcount > 0
 
-                # Clean up related tables scoped to this user
+                # Clean up related tables scoped to this user (chunked
+                # to avoid SQLite's 999-variable limit on large datasets)
                 if msg_ids:
-                    placeholders = ",".join("?" * len(msg_ids))
-
                     for table, col in [
                         ("fact_timeline", "source_message_id"),
                         ("landmark_events", "source_message_id"),
@@ -540,10 +552,7 @@ class TrueMemoryEngine:
                         if col not in _ALLOWED_COLUMNS:
                             raise ValueError(f"Invalid column name: {col}")
                         try:
-                            self.conn.execute(
-                                f"DELETE FROM {table} WHERE {col} IN ({placeholders})",
-                                msg_ids,
-                            )
+                            _delete_in_chunks(self.conn, table, col, msg_ids)
                         except Exception:
                             logger.warning("Failed to clean %s for user %s", table, user_id, exc_info=True)
 
@@ -580,14 +589,9 @@ class TrueMemoryEngine:
                 except Exception:
                     logger.warning("Failed to clean summaries for user %s", user_id, exc_info=True)
 
-                # Clean episodes linked to this user's messages
                 if episode_ids:
-                    ep_placeholders = ",".join("?" * len(episode_ids))
                     try:
-                        self.conn.execute(
-                            f"DELETE FROM episodes WHERE id IN ({ep_placeholders})",
-                            episode_ids,
-                        )
+                        _delete_in_chunks(self.conn, "episodes", "id", episode_ids)
                     except Exception:
                         logger.warning("Failed to clean episodes for user %s", user_id, exc_info=True)
 
@@ -597,10 +601,7 @@ class TrueMemoryEngine:
                         if vec_table not in _ALLOWED_TABLES:
                             raise ValueError(f"Invalid table name: {vec_table}")
                         try:
-                            self.conn.execute(
-                                f"DELETE FROM {vec_table} WHERE rowid IN ({placeholders})",
-                                msg_ids,
-                            )
+                            _delete_in_chunks(self.conn, vec_table, "rowid", msg_ids)
                         except Exception:
                             logger.warning("Failed to clean %s for user %s", vec_table, user_id, exc_info=True)
 

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -169,11 +169,13 @@ def get_reranker(model_name: str | None = None, device: str | None = None):
     global _model, _model_name
 
     name = model_name or get_current_reranker_name()
-    if _model is not None and name == _model_name:
-        return _model  # Fast path, no lock needed
+    cached_model, cached_name = _model, _model_name
+    if cached_model is not None and name == cached_name:
+        return cached_model
     with _lock:
-        if _model is not None and name == _model_name:
-            return _model  # Another thread loaded it
+        cached_model, cached_name = _model, _model_name
+        if cached_model is not None and name == cached_name:
+            return cached_model
 
         from truememory.model_client import use_model_server, get_reranker_proxy
         if use_model_server():

--- a/truememory/tier_switch/manager.py
+++ b/truememory/tier_switch/manager.py
@@ -85,6 +85,7 @@ class RebuildManager:
         self._active_worker: RebuildWorker | None = None
         self._active_thread: threading.Thread | None = None
         self._active_status_id: int = 0
+        self._state_lock = threading.Lock()
 
     def start_rebuild(
         self,
@@ -97,8 +98,10 @@ class RebuildManager:
 
         Returns a status_id for progress queries.
         """
-        if self._active_thread and self._active_thread.is_alive():
-            return self._active_status_id
+        with self._state_lock:
+            if self._active_thread and self._active_thread.is_alive():
+                return self._active_status_id
+            self._active_thread = threading.current_thread()
 
         conn = _open_db(db_path)
         to_group = tier_group(target_tier)
@@ -133,7 +136,8 @@ class RebuildManager:
             daemon=True,
             name=f"tier-switch-{to_group}",
         )
-        self._active_thread = thread
+        with self._state_lock:
+            self._active_thread = thread
         thread.start()
 
         return status_id
@@ -232,8 +236,10 @@ class RebuildManager:
 
     def cancel(self, status_id: int = 0):
         """Signal the active worker to stop."""
-        if self._active_worker:
-            self._active_worker.cancel()
+        with self._state_lock:
+            worker = self._active_worker
+        if worker is not None:
+            worker.cancel()
 
     def _rebuild_thread(
         self,
@@ -260,7 +266,8 @@ class RebuildManager:
                 throttler=throttler,
                 status_id=status_id,
             )
-            self._active_worker = worker
+            with self._state_lock:
+                self._active_worker = worker
 
             success, processed = worker.run(messages, is_full)
 
@@ -273,8 +280,9 @@ class RebuildManager:
         except Exception:
             log.exception("Background rebuild thread error")
         finally:
-            self._active_worker = None
-            self._active_thread = None
+            with self._state_lock:
+                self._active_worker = None
+                self._active_thread = None
             conn.close()
 
     def _finalize_rebuild(

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -826,7 +826,7 @@ def embed_single(conn: sqlite3.Connection, message_id: int, content: str) -> Non
                 (message_id, serialize_f32(sep_embedding)),
             )
     except Exception:
-        logger.debug("Failed to create separation vector for message %d", message_id, exc_info=True)
+        logger.warning("Failed to create separation vector for message %d", message_id, exc_info=True)
     # Caller is responsible for committing
 
 


### PR DESCRIPTION
## Summary
5 correctness/concurrency fixes across 4 files:
1. `engine.py`: Chunked IN-clause deletes (prevents silent failure on >999 messages)
2. `engine.py`: sqlite-vec load failure at WARNING + module-level error tracking
3. `vector_search.py`: Separation vector failure at WARNING (was DEBUG)
4. `reranker.py`: Atomic tuple unpack for TOCTOU-safe model cache check
5. `tier_switch/manager.py`: _state_lock prevents concurrent rebuild races

Clean rewrite of Hunter's #347 — 5 of 6 fixes applied (skipped search_agentic degraded fallthrough which depends on closed #344). No CHANGELOG, no 370-line test file. Supersedes #347.

Co-Authored-By: Huntehhh <hunter@users.noreply.github.com>