### PR TITLE
fix(mcp): load config tier before truememory imports

### DIFF
--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -40,10 +40,6 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
-from truememory import __version__
-from truememory.client import Memory
-from truememory.telemetry import tracked as _tracked
-
 log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -118,10 +114,17 @@ def _save_config(config: dict) -> None:
         )
 
 
-# Apply saved tier on startup (before any model loading)
+# Apply saved tier BEFORE importing truememory submodules — vector_search.py
+# reads TRUEMEMORY_EMBED_MODEL at import time to set its module-level
+# EMBEDDING_MODEL. If we import truememory.client first, the env var isn't
+# set yet and it defaults to "edge"/model2vec regardless of configured tier.
 _startup_config = _load_config()
 if "tier" in _startup_config:
     os.environ["TRUEMEMORY_EMBED_MODEL"] = _startup_config["tier"]
+
+from truememory import __version__  # noqa: E402
+from truememory.client import Memory  # noqa: E402
+from truememory.telemetry import tracked as _tracked  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Server setup


### PR DESCRIPTION
## Summary
- `vector_search.py` reads `TRUEMEMORY_EMBED_MODEL` at import time to set its module-level `EMBEDDING_MODEL`
- The old import order in `mcp_server.py` imported `truememory.client` (line 44) before the config-loading code (line 122) set the env var
- Since `truememory/__init__.py` imports `vector_search` at the top level, the env var defaulted to `"edge"` → `model2vec` on every MCP server restart, regardless of configured tier
- **All Base and Pro users** silently got `model2vec` embeddings instead of `qwen3_256`, triggering a `TrueMemoryMigrationError` degraded state on restart

## Fix
Move the config load + `TRUEMEMORY_EMBED_MODEL` env var assignment above the `truememory` submodule imports so `vector_search.py` sees the correct tier at import time.

## Test plan
- [ ] Start MCP server with `tier=base` in config.json → verify `truememory_stats` shows vectors `status: ok` (not degraded)
- [ ] Start MCP server with `tier=pro` → same check
- [ ] Start MCP server with `tier=edge` → same check
- [ ] Start MCP server with no config.json → defaults to edge, no crash
- [ ] Existing tests pass (`pytest tests/`)