### PR TITLE
fix: centralize tier resolution for Base/Pro users

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truememory"
-version = "0.7.1.2"
+version = "0.7.1.3"
 description = "SOTA-level agent memory at zero infrastructure cost."
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -85,6 +85,7 @@ try:
         build_separation_vectors,
         TrueMemoryMigrationError,
         _check_rebuild_allowed,
+        resolve_tier,
     )
     _HAS_VECTOR = True
 except (ImportError, ModuleNotFoundError):
@@ -367,7 +368,7 @@ class TrueMemoryEngine:
             import sys as _sys
             if _sys.platform == "darwin" and self._has_vectors:
                 try:
-                    _embed_model = os.environ.get("TRUEMEMORY_EMBED_MODEL", "edge")
+                    _embed_model = resolve_tier()
                     if _embed_model in ("base", "pro", "qwen3_256"):
                         _tables = {r[0] for r in self.conn.execute(
                             "SELECT name FROM sqlite_master WHERE type='table'"
@@ -889,7 +890,7 @@ class TrueMemoryEngine:
                 logger.warning(
                     "vec_messages table missing; attempting rebuild with "
                     "current model=%s",
-                    os.environ.get("TRUEMEMORY_EMBED_MODEL", "edge"),
+                    resolve_tier(),
                 )
                 if rebuild_vectors:
                     _check_rebuild_allowed(self.conn)  # raises on model drift
@@ -900,7 +901,7 @@ class TrueMemoryEngine:
                         logger.info(
                             "vec_messages rebuilt with %d vectors (model=%s)",
                             n,
-                            os.environ.get("TRUEMEMORY_EMBED_MODEL", "edge"),
+                            resolve_tier(),
                         )
                     except TrueMemoryMigrationError:
                         raise

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -103,19 +103,30 @@ def _resolve_model_name(name: str) -> str:
     return _TIER_ALIASES.get(lowered, name)
 
 
-def _default_tier() -> str:
-    """Read tier from config.json when env var is unset."""
+def resolve_tier() -> str:
+    """Resolve the active tier: env var → config.json → ``'edge'``.
+
+    Canonical tier resolver for the entire codebase.  Every call site
+    that formerly did ``os.environ.get("TRUEMEMORY_EMBED_MODEL", "edge")``
+    should call this instead so that ``~/.truememory/config.json`` is
+    honoured when the env var is absent.
+    """
+    env = os.environ.get("TRUEMEMORY_EMBED_MODEL", "").strip().lower()
+    if env:
+        return env
     try:
         import json
         from pathlib import Path
         _cfg = Path.home() / ".truememory" / "config.json"
         if _cfg.exists():
-            return json.loads(_cfg.read_text(encoding="utf-8")).get("tier", "edge")
+            tier = json.loads(_cfg.read_text(encoding="utf-8")).get("tier", "")
+            if tier:
+                return tier.strip().lower()
     except Exception:
         pass
     return "edge"
 
-_raw_env = os.environ.get("TRUEMEMORY_EMBED_MODEL") or _default_tier()
+_raw_env = resolve_tier()
 EMBEDDING_MODEL = _resolve_model_name(_raw_env)
 
 _model = None


### PR DESCRIPTION
## Summary

`engine.py` had 3 instances of `os.environ.get("TRUEMEMORY_EMBED_MODEL", "edge")` that silently defaulted to Edge tier when the env var was absent, ignoring `~/.truememory/config.json`. This caused the Qwen3 NaN fix (macOS SDPA kernel) to be skipped for Base/Pro users and incorrect tier names in log messages.

**Root cause:** Previous fixes (`015844f`, `1e819e6`) correctly addressed `vector_search.py` and `mcp_server.py` import ordering, but never touched `engine.py`.

**Fix:** Created `resolve_tier()` in `vector_search.py` as the canonical tier resolver (env var → config.json → "edge") and replaced all 3 hardcoded defaults in `engine.py`.

## Test results

```
TEST 1 PASS: Base tier -> qwen3_256
TEST 2 PASS: No model2vec migration error
TEST 3 PASS: Edge -> model2vec
TEST 4 PASS: Env var overrides config
TEST 5 PASS: No config -> edge fallback
TEST 6: 217 passed, 1 skipped (1 pre-existing failure: stale truememory-ingest binary version)
```

## OpenRouter consensus

**Round 1 (Code Review): 5/5 APPROVE**
- gpt-4.1: APPROVE (HIGH) — "No circular import risk"
- gemini-2.5-pro: APPROVE (HIGH)
- claude-sonnet-4: APPROVE (HIGH) — "Low risk, existing import structure maintained"
- qwen3-235b-a22b: APPROVE (HIGH)
- llama-4-maverick: APPROVE (HIGH) — "Minimal risk, consolidates logic"

**Round 2 (Adversarial Scenarios): 3/5 PASS**
All 9 scenarios (partial JSON, empty tier, uppercase, internal model names, deleted config, concurrent access, model_server, mid-session configure, upgrade) evaluated as SAFE or no-worse-than-status-quo.

## Files changed

- `truememory/vector_search.py` — `_default_tier()` → `resolve_tier()` (public, also checks env var)
- `truememory/engine.py` — Import `resolve_tier`, replace 3 instances at lines 370, 892, 903