### PR TITLE
fix: guard POSIX-only child reap on Windows

### DIFF
--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1154,7 +1154,14 @@ def _reap_children() -> None:
     Without this, Popen'd ingest processes become <defunct> zombies after
     they finish, and os.kill(pid, 0) / ps still sees them as alive —
     permanently blocking spawn gate slots.
+
+    POSIX-only: os.waitpid / os.WNOHANG do not exist on Windows. There,
+    finished child processes are reaped by the OS automatically (no zombie
+    state), so this is a no-op. Guarding here prevents an AttributeError
+    that would otherwise crash every _backlog_drainer tick on Windows.
     """
+    if not (hasattr(os, "waitpid") and hasattr(os, "WNOHANG")):
+        return
     try:
         while True:
             pid, _ = os.waitpid(-1, os.WNOHANG)


### PR DESCRIPTION
`_reap_children()` calls `os.waitpid(-1, os.WNOHANG)`. Neither `os.waitpid` nor `os.WNOHANG` exists on Windows, so the call raises `AttributeError` and crashes every `_backlog_drainer` tick — the drainer logs `LOOP-ERROR AttributeError: module 'os' has no attribute 'WNOHANG'` and the reap never runs.

Windows reaps finished children automatically (no zombie state), so this short-circuits `_reap_children` to a no-op when those attributes are absent.

## Changes
- 2-line `hasattr(os, "waitpid") and hasattr(os, "WNOHANG")` guard at the top of `_reap_children`, plus a docstring note.

## Test plan
- On Windows: the backlog drainer no longer raises; reap is a clean no-op.
- On POSIX: unchanged — the reap loop runs exactly as before.

Additive; no behavior change on POSIX.