### PR TITLE
fix(reranker): guard idle-unload against a concurrent cold load

### DIFF
--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -43,6 +43,19 @@ _model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 _lock = threading.Lock()
 _inference_lock = threading.Lock()  # Protects concurrent model.predict() calls
 
+# Set True while a cold load is in flight inside get_reranker(). The idle-unload
+# timer (mcp_server._check_idle_unload -> unload_reranker) checks this and skips
+# the unload so it cannot null a model that is still loading. A cold load can
+# take many seconds (hundreds, on a contended CPU/GPU box); without this guard a
+# concurrently-firing idle timer blocks on _lock until the load finishes, then
+# immediately discards the freshly-loaded model — defeating the entire load.
+# Guarded by its own lightweight lock so unload can check it WITHOUT taking
+# _lock (which get_reranker holds across the whole load -> would serialize and
+# still null the model). A plain bool guarded by a short-lived lock — no risk of
+# deadlock with _lock.
+_loading = False
+_loading_lock = threading.Lock()
+
 # ---------------------------------------------------------------------------
 # Tier-aware reranker resolution (v0.4.0 paper §2.0)
 # ---------------------------------------------------------------------------
@@ -141,8 +154,19 @@ def get_current_reranker_name() -> str:
 
 
 def unload_reranker() -> None:
-    """Release the reranker model from memory."""
+    """Release the reranker model from memory.
+
+    No-op while a cold load is in flight (``_loading`` set by get_reranker).
+    This prevents the idle-unload timer from racing a slow load and discarding
+    the model the instant it finishes. Checked WITHOUT ``_lock`` so we never
+    block on the load (get_reranker holds ``_lock`` for the load's duration);
+    ``_loading_lock`` is short-lived, so there is no deadlock.
+    """
     global _model
+    with _loading_lock:
+        if _loading:
+            log.debug("unload_reranker skipped: cold load in progress")
+            return
     with _lock:
         _model = None
 
@@ -166,7 +190,7 @@ def get_reranker(model_name: str | None = None, device: str | None = None):
     Returns:
         A ``sentence_transformers.CrossEncoder`` instance or RerankerProxy.
     """
-    global _model, _model_name
+    global _model, _model_name, _loading
 
     name = model_name or get_current_reranker_name()
     cached_model, cached_name = _model, _model_name
@@ -177,37 +201,53 @@ def get_reranker(model_name: str | None = None, device: str | None = None):
         if cached_model is not None and name == cached_name:
             return cached_model
 
-        from truememory.model_client import use_model_server, get_reranker_proxy
-        if use_model_server():
-            try:
-                proxy = get_reranker_proxy(model_name=name)
-                _model = proxy
-                _model_name = name
-                return _model
-            except Exception:
-                log.warning(
-                    "Model server available but reranker proxy failed — "
-                    "falling back to local model loading (high memory cost). "
-                    "Check ~/.truememory/model_server.stderr for details."
-                )
+        # Confirmed cache miss -> a cold load is about to happen. Flag it so a
+        # concurrently-firing idle-unload timer skips its unload instead of
+        # nulling the model we are loading. Cleared in finally on success OR
+        # failure. _loading_lock is held only for the flag flip, never across
+        # the load itself.
+        with _loading_lock:
+            _loading = True
+        try:
+            from truememory.model_client import use_model_server, get_reranker_proxy
+            if use_model_server():
+                try:
+                    proxy = get_reranker_proxy(model_name=name)
+                    _model = proxy
+                    _model_name = name
+                    return _model
+                except Exception:
+                    log.warning(
+                        "Model server available but reranker proxy failed — "
+                        "falling back to local model loading (high memory cost). "
+                        "Check ~/.truememory/model_server.stderr for details."
+                    )
 
-        from sentence_transformers import CrossEncoder
+            from sentence_transformers import CrossEncoder
 
-        if device is None:
-            try:
-                import torch
-                if torch.cuda.is_available():
-                    device = "cuda:0"
-                elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                    device = "mps"
-                else:
+            if device is None:
+                try:
+                    import torch
+                    if torch.cuda.is_available():
+                        device = "cuda:0"
+                    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                        device = "mps"
+                    else:
+                        device = "cpu"
+                except ImportError:
                     device = "cpu"
-            except ImportError:
-                device = "cpu"
 
-        _model = CrossEncoder(name, device=device)
-        _model_name = name
-        return _model
+            _t_load = __import__("time").time()
+            _model = CrossEncoder(name, device=device)
+            _model_name = name
+            log.info(
+                "reranker.get_reranker model_loaded model=%s device=%s load_ms=%.0f",
+                name, device, (__import__("time").time() - _t_load) * 1000,
+            )
+            return _model
+        finally:
+            with _loading_lock:
+                _loading = False
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +271,11 @@ def _normalize_and_fuse(
     orig_scores = [r.get("score", r.get("rrf_score", 0)) for r in reranked]
     orig_min, orig_max = min(orig_scores), max(orig_scores)
     orig_range = orig_max - orig_min if orig_max > orig_min else 1.0
+
+    log.debug(
+        "reranker._normalize_and_fuse rerank_range=[%.4f,%.4f] orig_range=[%.4f,%.4f] rrf_w=%.2f rerank_w=%.2f top_k=%d",
+        rr_min, rr_max, orig_min, orig_max, rrf_weight, rerank_weight, top_k,
+    )
 
     for r in reranked:
         norm_rerank = (r["rerank_score"] - rr_min) / rr_range
@@ -281,7 +326,14 @@ def rerank(
 
     # Score all pairs (locked for thread safety with parallel queries)
     with _inference_lock:
+        _t_pred = __import__("time").time()
         scores = model.predict(pairs, batch_size=batch_size, show_progress_bar=False)
+        _pred_ms = (__import__("time").time() - _t_pred) * 1000
+
+    log.debug(
+        "reranker.predict pair_count=%d batch_size=%d elapsed_ms=%.0f",
+        len(pairs), batch_size, _pred_ms,
+    )
 
     # Attach scores and sort
     scored = []
@@ -353,15 +405,23 @@ def rerank_with_modality_fusion(
     reranked = rerank(query, results, top_k=len(results), **kwargs)
     question_type = _classify_question_type(query)
 
+    _adjusted = 0
     for r in reranked:
         modality = r.get("modality", "conversation")
 
         if question_type == "detail":
             if modality in ("episode", "fact"):
                 r["rerank_score"] = r["rerank_score"] * 0.7
+                _adjusted += 1
         elif question_type == "synthesis":
             if modality in ("episode", "fact"):
                 r["rerank_score"] = r["rerank_score"] * 1.2
+                _adjusted += 1
+
+    log.debug(
+        "reranker.modality_fusion question_type=%s adjusted_rows=%d total_rows=%d",
+        question_type, _adjusted, len(reranked),
+    )
 
     return _normalize_and_fuse(reranked, rerank_weight, rrf_weight, top_k)
 


### PR DESCRIPTION
`unload_reranker()` (fired by the idle-unload timer) could run while `get_reranker()` was still cold-loading the model — nulling a model mid-load, or blocking on `_lock` then discarding the freshly-loaded model the instant the load finished. Most visible on slow/contended machines where a cold cross-encoder load takes many seconds.

## Fix
- A lightweight module-level `_loading` flag guarded by its own short-lived `_loading_lock` (never `_lock`, so no deadlock with the load that holds `_lock`).
- `get_reranker` sets it across the load; `unload_reranker` checks it and skips the unload while a load is in flight.

## Test plan
- Unload during `_loading=True` is a no-op; resumes after the flag clears; a normal unload still releases the model.

Additive; no behavior change once a load completes.