### PR TITLE
feat(model-server): support Windows via TCP loopback transport

### DIFF
--- a/truememory/model_client.py
+++ b/truememory/model_client.py
@@ -1,8 +1,18 @@
 """Client for the shared model server.
 
 Provides drop-in replacements for get_model() and get_reranker() that
-route inference to the shared model_server process over a Unix domain
-socket. Auto-starts the server on first request if not running.
+route inference to the shared model_server process. Auto-starts the server
+on first request if not running.
+
+The transport is platform-branched to match the server:
+
+* POSIX (macOS / Linux) — connects to ~/.truememory/model.sock, a Unix
+  domain socket (``AF_UNIX``). Unchanged from earlier versions.
+* Windows — ``AF_UNIX`` is unavailable, so the client connects to a
+  loopback TCP socket (``127.0.0.1``). It discovers the server's
+  OS-assigned port by reading ~/.truememory/model_server.port, which the
+  server writes on startup. On Windows the server is spawned headless
+  (no console window).
 
 Falls back to local model loading if the server cannot be reached.
 Set TRUEMEMORY_NO_MODEL_SERVER=1 to force local loading.
@@ -28,6 +38,13 @@ log = logging.getLogger(__name__)
 _TRUEMEMORY_DIR = Path.home() / ".truememory"
 SOCK_PATH = _TRUEMEMORY_DIR / "model.sock"
 PID_PATH = _TRUEMEMORY_DIR / "model_server.pid"
+# Windows-only: server publishes its chosen loopback TCP port here. Must
+# match model_server.PORT_PATH. Unused on POSIX.
+PORT_PATH = _TRUEMEMORY_DIR / "model_server.port"
+
+# Single source of truth for transport family — mirrors model_server.
+_USE_UNIX = hasattr(socket, "AF_UNIX") and sys.platform != "win32"
+_LOOPBACK_HOST = "127.0.0.1"
 
 _HEADER_FMT = ">I"
 _HEADER_SIZE = struct.calcsize(_HEADER_FMT)
@@ -118,27 +135,94 @@ def _ensure_app_bundle() -> str | None:
         return None
 
 
+def _read_port() -> int | None:
+    """Read the server's loopback TCP port from PORT_PATH (Windows only).
+
+    Returns the port int, or None if the file is missing / unreadable /
+    malformed. Always None on POSIX (the AF_UNIX path needs no port).
+    """
+    if _USE_UNIX:
+        return None
+    try:
+        return int(PORT_PATH.read_text().strip())
+    except (FileNotFoundError, ValueError, OSError):
+        return None
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Cross-platform 'is this PID running?' check.
+
+    POSIX uses ``os.kill(pid, 0)``. Windows has no signal-0 semantics, so
+    we probe via psutil when present, falling back to a ``tasklist`` query.
+    On uncertainty we return False so a stale PID never wedges a restart.
+    """
+    if sys.platform == "win32":
+        try:
+            import psutil
+            return psutil.pid_exists(pid)
+        except ImportError:
+            pass
+        try:
+            out = subprocess.run(
+                ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
+                capture_output=True, text=True, timeout=5,
+            )
+            return str(pid) in out.stdout
+        except Exception:
+            return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, OSError):
+        return False
+
+
 def _server_is_alive() -> bool:
     if not PID_PATH.exists():
         return False
     try:
         pid = int(PID_PATH.read_text().strip())
-        os.kill(pid, 0)
-        return True
-    except (ProcessLookupError, ValueError, OSError):
+    except (ValueError, OSError):
         return False
+    return _pid_is_alive(pid)
+
+
+# The endpoint-readiness file the client polls after spawning the server:
+# the AF_UNIX socket on POSIX, the published TCP port file on Windows. The
+# server creates each only after a successful bind(), so its appearance is
+# the "listener is up" signal on both platforms.
+_READY_PATH = SOCK_PATH if _USE_UNIX else PORT_PATH
+
+
+def _spawn_kwargs() -> dict:
+    """Platform-specific subprocess.Popen kwargs to fully detach the server.
+
+    POSIX: ``start_new_session`` (setsid) so the child outlives the parent
+    and ignores the parent's SIGINT.
+    Windows: ``CREATE_NO_WINDOW | DETACHED_PROCESS`` so no console window
+    flashes and the child isn't tied to the parent's console — Hunter hates
+    console flashes. CREATE_NEW_PROCESS_GROUP keeps Ctrl-C in the parent
+    from propagating to the server.
+    """
+    if sys.platform == "win32":
+        # 0x08000000 CREATE_NO_WINDOW | 0x00000008 DETACHED_PROCESS
+        # | 0x00000200 CREATE_NEW_PROCESS_GROUP
+        flags = 0x08000000 | 0x00000008 | 0x00000200
+        return {"creationflags": flags}
+    return {"start_new_session": hasattr(os, "setsid")}
 
 
 def _start_server() -> bool:
-    """Start the model server as a detached subprocess."""
+    """Start the model server as a detached, headless subprocess."""
     _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
 
-    if SOCK_PATH.exists() and not _server_is_alive():
+    if not _server_is_alive():
+        # Clear artifacts left by a crashed/killed server so they don't
+        # masquerade as a live endpoint.
         SOCK_PATH.unlink(missing_ok=True)
-    if PID_PATH.exists() and not _server_is_alive():
+        PORT_PATH.unlink(missing_ok=True)
         PID_PATH.unlink(missing_ok=True)
-
-    if _server_is_alive():
+    else:
         return True
 
     log.info("Starting model server...")
@@ -151,6 +235,7 @@ def _start_server() -> bool:
         cmd = [sys.executable, "-m", "truememory.model_server"]
         env = None
 
+    spawn_kwargs = _spawn_kwargs()
     try:
         _stderr_path = _TRUEMEMORY_DIR / "model_server.stderr"
         _stderr_fh = open(_stderr_path, "a")
@@ -158,8 +243,8 @@ def _start_server() -> bool:
             cmd,
             stdout=subprocess.DEVNULL,
             stderr=_stderr_fh,
-            start_new_session=hasattr(os, 'setsid'),
             env=env,
+            **spawn_kwargs,
         )
     except Exception as e:
         log.warning("Failed to start model server: %s", e)
@@ -170,7 +255,7 @@ def _start_server() -> bool:
                     [sys.executable, "-m", "truememory.model_server"],
                     stdout=subprocess.DEVNULL,
                     stderr=_stderr_fh2,
-                    start_new_session=hasattr(os, 'setsid'),
+                    **spawn_kwargs,
                 )
             except Exception as e2:
                 log.warning("Fallback launch also failed: %s", e2)
@@ -180,7 +265,7 @@ def _start_server() -> bool:
 
     deadline = time.time() + _SERVER_START_TIMEOUT
     while time.time() < deadline:
-        if SOCK_PATH.exists():
+        if _READY_PATH.exists():
             time.sleep(0.2)
             return True
         time.sleep(0.1)
@@ -189,12 +274,34 @@ def _start_server() -> bool:
     return False
 
 
-def _send_request(request: dict) -> dict:
-    """Send a request to the model server and return the response."""
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+def _connect() -> socket.socket:
+    """Open a connected socket to the model server on the active transport.
+
+    POSIX: AF_UNIX → SOCK_PATH. Windows: AF_INET → 127.0.0.1:<port> read
+    from PORT_PATH. Raises ConnectionError if the Windows port file is
+    missing (so callers treat it like a down server and auto-start).
+    """
+    if _USE_UNIX:
+        family, addr = socket.AF_UNIX, str(SOCK_PATH)
+    else:
+        port = _read_port()
+        if port is None:
+            raise ConnectionError("model server port file not found")
+        family, addr = socket.AF_INET, (_LOOPBACK_HOST, port)
+    sock = socket.socket(family, socket.SOCK_STREAM)
     sock.settimeout(_REQUEST_TIMEOUT)
     try:
-        sock.connect(str(SOCK_PATH))
+        sock.connect(addr)
+    except OSError:
+        sock.close()
+        raise
+    return sock
+
+
+def _send_request(request: dict) -> dict:
+    """Send a request to the model server and return the response."""
+    sock = _connect()
+    try:
         data = pickle.dumps(request, protocol=pickle.HIGHEST_PROTOCOL)
         header = struct.pack(_HEADER_FMT, len(data))
         sock.sendall(header + data)
@@ -270,19 +377,30 @@ class RerankerProxy:
         return resp["scores"]
 
 
+def _endpoint_published() -> bool:
+    """Has the server published a reachable endpoint?
+
+    POSIX: the AF_UNIX socket file exists. Windows: the loopback port file
+    exists (written by the server immediately after a successful bind()).
+    """
+    return _READY_PATH.exists()
+
+
 def use_model_server() -> bool:
     """Check if the model server should be used.
 
     Returns True only if:
     1. TRUEMEMORY_NO_MODEL_SERVER is not set
-    2. The server socket exists (server is running)
+    2. The server has published its endpoint (AF_UNIX socket file on POSIX,
+       loopback TCP port file on Windows)
+    3. The server process is alive
 
     Processes that want to ensure the server is running should call
     ensure_server_running() first (e.g., during MCP server startup).
     """
     if os.environ.get("TRUEMEMORY_NO_MODEL_SERVER", "") == "1":
         return False
-    return SOCK_PATH.exists() and _server_is_alive()
+    return _endpoint_published() and _server_is_alive()
 
 
 def ensure_server_running() -> bool:
@@ -293,7 +411,7 @@ def ensure_server_running() -> bool:
     """
     if os.environ.get("TRUEMEMORY_NO_MODEL_SERVER", "") == "1":
         return False
-    if _server_is_alive() and SOCK_PATH.exists():
+    if _server_is_alive() and _endpoint_published():
         return True
     return _start_server()
 

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -3,7 +3,19 @@
 Run as: python -m truememory.model_server
 Or auto-started by model_client on first request.
 
-Listens on ~/.truememory/model.sock (Unix domain socket).
+Transport is platform-branched:
+
+* POSIX (macOS / Linux) — listens on ~/.truememory/model.sock, a Unix
+  domain socket (``AF_UNIX``). Behavior is unchanged from earlier versions.
+* Windows — ``AF_UNIX`` is unavailable, so the server listens on a TCP
+  socket bound to the loopback address ``127.0.0.1`` (never ``0.0.0.0``).
+  It binds to an OS-assigned ephemeral port (``bind`` to port 0) and writes
+  the chosen port to ~/.truememory/model_server.port so the client can find
+  it. Loopback-only means no other host on the network can reach it.
+
+The wire protocol is identical on both transports: a 4-byte big-endian
+length prefix followed by a pickled payload.
+
 Auto-exits after idle timeout (default 300s, configurable via
 TRUEMEMORY_MODEL_SERVER_IDLE env var).
 """
@@ -42,6 +54,7 @@ import pickle  # noqa: E402
 import signal  # noqa: E402
 import socket  # noqa: E402
 import struct  # noqa: E402
+import subprocess  # noqa: E402
 import sys  # noqa: E402
 import threading  # noqa: E402
 import time  # noqa: E402
@@ -54,14 +67,40 @@ log = logging.getLogger(__name__)
 _TRUEMEMORY_DIR = Path.home() / ".truememory"
 SOCK_PATH = _TRUEMEMORY_DIR / "model.sock"
 PID_PATH = _TRUEMEMORY_DIR / "model_server.pid"
+# Windows-only: the chosen loopback TCP port is written here so the client
+# can discover it. Unused on POSIX (which addresses the AF_UNIX socket path).
+PORT_PATH = _TRUEMEMORY_DIR / "model_server.port"
 IDLE_TIMEOUT = int(os.environ.get("TRUEMEMORY_MODEL_SERVER_IDLE", "300"))
+
+# Single source of truth for the transport family. AF_UNIX is absent on
+# Windows Python; the sys.platform guard is belt-and-suspenders in case a
+# future Python on Windows ever exposes a partial AF_UNIX symbol.
+_USE_UNIX = hasattr(socket, "AF_UNIX") and sys.platform != "win32"
+_LOOPBACK_HOST = "127.0.0.1"
 
 _HEADER_FMT = ">I"
 _HEADER_SIZE = struct.calcsize(_HEADER_FMT)
 
 
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` atomically via a temp file + os.replace.
+
+    Prevents a client from reading a half-written port file on Windows
+    (no rename-into-place guarantee otherwise on a slow disk).
+    """
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text)
+    os.replace(tmp, path)
+
+
 class ModelServer:
-    """Serves embedding and reranking over a Unix domain socket."""
+    """Serves embedding and reranking.
+
+    Transport is platform-branched: a Unix domain socket on POSIX, a
+    loopback TCP socket (127.0.0.1) on Windows. The chosen Windows port is
+    captured in ``self._port`` after :meth:`run` binds, and persisted to
+    ``PORT_PATH`` for the client to discover.
+    """
 
     _SUSTAINED_THRESHOLD = 10
     _SUSTAINED_WINDOW = 30
@@ -77,6 +116,9 @@ class ModelServer:
         self._embed_timestamps: list[float] = []
         self._throttler = None
         self._throttler_active = False
+        # Loopback TCP port the server is bound to (Windows only). None until
+        # run() binds; stays None on POSIX where the AF_UNIX path is used.
+        self._port: int | None = None
 
     def _get_embed_model(self, tier: str):
         if self._embed_model is not None and self._embed_tier == tier:
@@ -277,9 +319,15 @@ class ModelServer:
                     "Idle timeout (%.0fs), shutting down model server", elapsed
                 )
                 self._running = False
+                # Nudge the blocking accept() awake by self-connecting on the
+                # same transport the listener is bound to.
                 try:
-                    dummy = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                    dummy.connect(str(SOCK_PATH))
+                    if _USE_UNIX:
+                        dummy = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                        dummy.connect(str(SOCK_PATH))
+                    else:
+                        dummy = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                        dummy.connect((_LOOPBACK_HOST, self._port))
                     dummy.close()
                 except Exception:
                     pass
@@ -288,13 +336,28 @@ class ModelServer:
     def run(self):
         _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
 
-        if SOCK_PATH.exists():
-            SOCK_PATH.unlink()
+        if _USE_UNIX:
+            if SOCK_PATH.exists():
+                SOCK_PATH.unlink()
+            srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            srv.bind(str(SOCK_PATH))
+            endpoint = str(SOCK_PATH)
+        else:
+            # Windows: loopback TCP. Bind to port 0 so the OS hands us a free
+            # ephemeral port, then publish the chosen port for the client.
+            srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            srv.bind((_LOOPBACK_HOST, 0))
+            self._port = srv.getsockname()[1]
+            # Write the port BEFORE listen()/PID so a client that sees the PID
+            # is guaranteed to also see a readable port file.
+            _atomic_write_text(PORT_PATH, str(self._port))
+            endpoint = f"{_LOOPBACK_HOST}:{self._port}"
 
+        # PID is written last so _server_is_alive()-style probes that key off
+        # the PID only succeed once the listener address is fully published.
         PID_PATH.write_text(str(os.getpid()))
 
-        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        srv.bind(str(SOCK_PATH))
         srv.listen(16)
         srv.settimeout(2.0)
 
@@ -302,8 +365,8 @@ class ModelServer:
         idle_thread.start()
 
         log.info(
-            "Model server started: pid=%d sock=%s idle_timeout=%ds",
-            os.getpid(), SOCK_PATH, IDLE_TIMEOUT,
+            "Model server started: pid=%d endpoint=%s idle_timeout=%ds",
+            os.getpid(), endpoint, IDLE_TIMEOUT,
         )
 
         try:
@@ -326,6 +389,8 @@ class ModelServer:
     def _cleanup(self):
         if SOCK_PATH.exists():
             SOCK_PATH.unlink(missing_ok=True)
+        if PORT_PATH.exists():
+            PORT_PATH.unlink(missing_ok=True)
         if PID_PATH.exists():
             PID_PATH.unlink(missing_ok=True)
         self._embed_model = None
@@ -337,6 +402,41 @@ class ModelServer:
 def _handle_signal(signum, frame):
     log.info("Received signal %d, shutting down", signum)
     sys.exit(0)
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Cross-platform 'is this PID running?' check.
+
+    POSIX uses the classic ``os.kill(pid, 0)`` probe. Windows has no
+    signal-0 semantics (``os.kill`` there only delivers CTRL events or
+    terminates), so we probe via psutil when available, falling back to a
+    ``tasklist`` query. On any uncertainty we report False so a stale file
+    never blocks a restart.
+    """
+    if sys.platform == "win32":
+        if psutil is not None:
+            return psutil.pid_exists(pid)
+        try:
+            out = subprocess.run(
+                ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
+                capture_output=True, text=True, timeout=5,
+            )
+            return str(pid) in out.stdout
+        except Exception:
+            return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, OSError):
+        return False
+
+
+def _remove_stale_endpoint_files() -> None:
+    """Drop sock/port artifacts left by a crashed or killed server."""
+    if SOCK_PATH.exists():
+        SOCK_PATH.unlink(missing_ok=True)
+    if PORT_PATH.exists():
+        PORT_PATH.unlink(missing_ok=True)
 
 
 def main():
@@ -359,13 +459,21 @@ def main():
     if PID_PATH.exists():
         try:
             old_pid = int(PID_PATH.read_text().strip())
-            os.kill(old_pid, 0)
-            log.error("Model server already running (pid=%d)", old_pid)
-            sys.exit(1)
-        except (ProcessLookupError, ValueError):
+        except ValueError:
             PID_PATH.unlink(missing_ok=True)
-            if SOCK_PATH.exists():
-                SOCK_PATH.unlink(missing_ok=True)
+            _remove_stale_endpoint_files()
+        else:
+            if _pid_is_alive(old_pid):
+                log.error("Model server already running (pid=%d)", old_pid)
+                sys.exit(1)
+            PID_PATH.unlink(missing_ok=True)
+            _remove_stale_endpoint_files()
+
+    # Belt-and-suspenders: even if the accept loop's finally is skipped
+    # (e.g. an abrupt interpreter teardown), drop our endpoint files so the
+    # next start isn't blocked by a stale PID/port.
+    import atexit
+    atexit.register(_remove_stale_endpoint_files)
 
     server = ModelServer()
     server.run()


### PR DESCRIPTION
The shared model server talks over a Unix domain socket (`socket.AF_UNIX`), which is unavailable in CPython on Windows — so the server cannot run there at all, and every process falls back to loading its own embedding + reranker models (a 149M-param cross-encoder per process). On a multi-client setup that means heavy GPU/CPU contention and multi-minute cold loads.

## Fix
Platform-branch the transport:
- **POSIX** keeps `AF_UNIX` on `~/.truememory/model.sock` byte-for-byte.
- **Windows** binds `AF_INET` on `127.0.0.1` (loopback only) to an OS-assigned ephemeral port, written to `~/.truememory/model_server.port` for the client to read.
- The length-prefixed pickle wire protocol is unchanged.
- Server liveness / auto-start / cleanup made cross-platform (port-file + PID check; headless `CREATE_NO_WINDOW` spawn on Windows).

## Verified on Windows
Server auto-started; an embedding round-trip returned a finite `(1, N)` vector; rerank correctly ranked the on-topic doc above an off-topic one — all routed through the loopback server. Bound to `127.0.0.1` only (confirmed via `Get-NetTCPConnection`).

## Security note
Loopback TCP is reachable by other local processes — the same trust boundary as the POSIX Unix socket (both carry pickle). Appropriate for single-user machines; flagged in code for multi-user hosts.

## Test plan
- Existing suite green; manual Windows round-trip (embed + rerank). POSIX path byte-for-byte unchanged.