### PR TITLE
feat(instrumentation): opt-in, sits-on-top SQLite telemetry overlay

### DIFF
--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -1,0 +1,333 @@
+"""Tests for the opt-in telemetry instrumentation overlay.
+
+Covers the two halves of the contract:
+
+1. With ``TRUEMEMORY_INSTRUMENTATION=1`` set, ``install()`` monkey-patches the
+   engine and the documented signals land in the ``telemetry`` table:
+     - a gate evaluation  -> gate_decision + salience + surprise rows
+     - a search           -> search_distance + memory_returned rows
+     - a delete           -> user_forget row
+     - the table schema matches the dashboard-mirror contract
+     - install() emits an instrumentation_start bootstrap row
+
+2. With the env var UNSET, ``install()`` is a no-op: no methods are patched and
+   the ``telemetry`` table is never created.
+
+Reload-safety: other test modules in the suite call ``importlib.reload`` on
+engine / encoding-gate modules, which swaps the *class objects*. So this file
+NEVER caches class references at import time. Every fixture and test resolves
+``Memory`` / ``EncodingGate`` / ``TrueMemoryEngine`` LIVE from their modules and
+snapshots the pristine method of whatever class is current. That keeps the
+assertions correct regardless of suite ordering — the class ``install()``
+patches is always the same class object the test inspects.
+"""
+from __future__ import annotations
+
+import importlib
+import sqlite3
+
+import pytest
+
+from truememory import Memory
+from truememory.instrumentation import patch as patch_mod
+from truememory.instrumentation import writer as writer_mod
+from truememory.instrumentation import log as log_mod
+
+# Method names install() may replace, keyed by the module + attribute that owns
+# them. Resolved live (never cached) so a reload elsewhere can't desync us.
+_PATCH_TARGETS = (
+    ("truememory.client", "Memory", ("add", "search", "search_deep", "get", "delete")),
+    ("truememory.ingest.encoding_gate", "EncodingGate", ("evaluate",)),
+    ("truememory.engine", "TrueMemoryEngine", ("add", "_ensure_connection")),
+)
+
+
+def _current_class(module_name: str, class_name: str):
+    """Return the class object that ``install()`` will actually patch right now."""
+    return getattr(importlib.import_module(module_name), class_name)
+
+
+def _snapshot_pristine() -> dict[tuple[str, str], object]:
+    """Snapshot the current method objects for every patch target, live."""
+    snap: dict[tuple[str, str], object] = {}
+    for module_name, class_name, methods in _PATCH_TARGETS:
+        cls = _current_class(module_name, class_name)
+        for meth in methods:
+            if hasattr(cls, meth):
+                snap[(class_name, meth)] = getattr(cls, meth)
+    return snap
+
+
+def _restore(snapshot: dict[tuple[str, str], object]) -> None:
+    """Restore every snapshotted method onto its current class + reset state."""
+    for module_name, class_name, methods in _PATCH_TARGETS:
+        cls = _current_class(module_name, class_name)
+        for meth in methods:
+            key = (class_name, meth)
+            if key in snapshot:
+                setattr(cls, meth, snapshot[key])
+    patch_mod._installed = False
+    writer_mod.close()  # drop any cached connection so a fresh DB path is honored
+
+
+@pytest.fixture
+def clean_overlay():
+    """Snapshot pristine methods, guarantee an unpatched + latch-reset overlay
+    before and after each test. Yields the pristine snapshot so tests can do
+    identity comparisons against the exact objects they started from."""
+    snapshot = _snapshot_pristine()
+    _restore(snapshot)
+    yield snapshot
+    _restore(snapshot)
+
+
+@pytest.fixture
+def enabled_db(tmp_path, monkeypatch, clean_overlay):
+    """Enable the overlay and point both the engine and the telemetry writer at
+    one shared temp memories.db. Returns (db_path, pristine_snapshot)."""
+    db_path = tmp_path / "memories.db"
+    monkeypatch.setenv("TRUEMEMORY_INSTRUMENTATION", "1")
+    monkeypatch.setenv("TRUEMEMORY_DB_PATH", str(db_path))
+    assert log_mod.is_enabled() is True
+    return db_path, clean_overlay
+
+
+def _read_signals(db_path) -> dict[str, int]:
+    """Return {signal: count} from the telemetry table, or {} if no table."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        tables = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        if "telemetry" not in tables:
+            return {}
+        rows = conn.execute(
+            "SELECT signal, COUNT(*) FROM telemetry GROUP BY signal"
+        ).fetchall()
+        return {signal: count for signal, count in rows}
+    finally:
+        conn.close()
+
+
+def _telemetry_columns(db_path) -> list[str]:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        return [row[1] for row in conn.execute("PRAGMA table_info(telemetry)")]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# ENABLED — install() patches and signals land
+# ---------------------------------------------------------------------------
+
+
+def test_install_patches_methods(enabled_db):
+    """install() replaces the targeted class methods when enabled."""
+    _, pristine = enabled_db
+    patch_mod.install()
+    # Compare against the live classes install() actually patched.
+    gate = _current_class("truememory.ingest.encoding_gate", "EncodingGate")
+    mem = _current_class("truememory.client", "Memory")
+    eng = _current_class("truememory.engine", "TrueMemoryEngine")
+    assert gate.evaluate is not pristine[("EncodingGate", "evaluate")]
+    assert mem.search is not pristine[("Memory", "search")]
+    assert mem.delete is not pristine[("Memory", "delete")]
+    assert eng.add is not pristine[("TrueMemoryEngine", "add")]
+
+
+def test_install_is_idempotent(enabled_db):
+    """A second install() does not re-wrap (latch holds)."""
+    patch_mod.install()
+    gate = _current_class("truememory.ingest.encoding_gate", "EncodingGate")
+    after_first = gate.evaluate
+    patch_mod.install()
+    assert gate.evaluate is after_first
+
+
+def test_install_emits_bootstrap_row(enabled_db):
+    """install() writes an instrumentation_start row, creating the table."""
+    db_path, _ = enabled_db
+    patch_mod.install()
+    signals = _read_signals(db_path)
+    assert signals.get("instrumentation_start", 0) >= 1
+
+
+def test_telemetry_schema_matches_contract(enabled_db):
+    """The telemetry table columns are byte-for-byte the dashboard contract."""
+    db_path, _ = enabled_db
+    patch_mod.install()
+    cols = _telemetry_columns(db_path)
+    assert cols == [
+        "id",
+        "ts",
+        "pid",
+        "signal",
+        "memory_id",
+        "value_num",
+        "value_text",
+        "context_json",
+    ]
+
+
+def test_telemetry_indices_exist(enabled_db):
+    """Both documented indices are created."""
+    db_path, _ = enabled_db
+    patch_mod.install()
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        idx = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            )
+        }
+    finally:
+        conn.close()
+    assert "idx_telemetry_signal_ts" in idx
+    assert "idx_telemetry_memory_id" in idx
+
+
+def test_gate_eval_emits_gate_salience_surprise(enabled_db):
+    """A gate evaluation emits gate_decision + salience + surprise."""
+    db_path, _ = enabled_db
+    patch_mod.install()
+
+    EncodingGate = _current_class("truememory.ingest.encoding_gate", "EncodingGate")
+
+    class _FakeMemory:
+        def search(self, query, limit=5, user_id=None):
+            return []
+
+    gate = EncodingGate(_FakeMemory(), threshold=0.30)
+    decision = gate.evaluate("Alice moved to Seattle in March 2026", category="personal")
+    # The wrapped evaluate must still return the genuine decision unchanged.
+    assert hasattr(decision, "should_encode")
+    assert hasattr(decision, "salience")
+
+    signals = _read_signals(db_path)
+    assert signals.get("gate_decision", 0) >= 1
+    assert signals.get("salience", 0) >= 1
+    assert signals.get("surprise", 0) >= 1
+
+
+def test_search_emits_distance_and_returned(enabled_db):
+    """A search that returns hits emits search_distance + memory_returned."""
+    db_path, _ = enabled_db
+    patch_mod.install()
+    m = Memory(path=str(db_path))
+    try:
+        m.add("Alice likes espresso in the morning", user_id="alice")
+        m.add("Alice enjoys a flat white after lunch", user_id="alice")
+        results = m.search("coffee espresso", user_id="alice")
+    finally:
+        m.close()
+
+    signals = _read_signals(db_path)
+    # search_distance fires once per search call (even if 0 results).
+    assert signals.get("search_distance", 0) >= 1
+    # memory_returned fires once per returned hit; we stored two relevant rows.
+    if results:
+        assert signals.get("memory_returned", 0) >= 1
+
+
+def test_delete_emits_user_forget(enabled_db):
+    """An explicit delete emits a user_forget row."""
+    db_path, _ = enabled_db
+    patch_mod.install()
+    m = Memory(path=str(db_path))
+    try:
+        added = m.add("Temporary fact to be forgotten", user_id="alice")
+        assert added["id"] is not None
+        m.delete(added["id"])
+    finally:
+        m.close()
+
+    signals = _read_signals(db_path)
+    assert signals.get("user_forget", 0) >= 1
+
+
+def test_engine_add_emits_category(enabled_db):
+    """Storing a memory with a category emits a category row."""
+    db_path, _ = enabled_db
+    patch_mod.install()
+    m = Memory(path=str(db_path))
+    try:
+        # Drive engine.add directly with a category so the category signal fires
+        # (Memory.add does not forward a category, but engine.add accepts one).
+        m._engine.add(
+            content="Bob switched jobs to Acme Corp",
+            sender="bob",
+            category="decision",
+        )
+    finally:
+        m.close()
+
+    signals = _read_signals(db_path)
+    assert signals.get("category", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# DISABLED — install() is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_install_is_noop(tmp_path, monkeypatch, clean_overlay):
+    """With the env var unset, install() patches nothing and writes nothing."""
+    pristine = clean_overlay
+    db_path = tmp_path / "memories.db"
+    monkeypatch.delenv("TRUEMEMORY_INSTRUMENTATION", raising=False)
+    monkeypatch.setenv("TRUEMEMORY_DB_PATH", str(db_path))
+    assert log_mod.is_enabled() is False
+
+    patch_mod.install()
+
+    # No methods were replaced (compare against the live classes).
+    gate = _current_class("truememory.ingest.encoding_gate", "EncodingGate")
+    mem = _current_class("truememory.client", "Memory")
+    eng = _current_class("truememory.engine", "TrueMemoryEngine")
+    assert mem.search is pristine[("Memory", "search")]
+    assert mem.delete is pristine[("Memory", "delete")]
+    assert gate.evaluate is pristine[("EncodingGate", "evaluate")]
+    assert eng.add is pristine[("TrueMemoryEngine", "add")]
+
+
+def test_disabled_no_telemetry_table(tmp_path, monkeypatch, clean_overlay):
+    """With the env var unset, ordinary engine use never creates a telemetry table."""
+    db_path = tmp_path / "memories.db"
+    monkeypatch.delenv("TRUEMEMORY_INSTRUMENTATION", raising=False)
+    monkeypatch.setenv("TRUEMEMORY_DB_PATH", str(db_path))
+
+    patch_mod.install()  # no-op
+
+    m = Memory(path=str(db_path))
+    try:
+        added = m.add("A fact stored with instrumentation off", user_id="alice")
+        m.search("fact", user_id="alice")
+        if added["id"] is not None:
+            m.delete(added["id"])
+    finally:
+        m.close()
+
+    # The DB file exists (engine created it) but holds no telemetry table.
+    assert db_path.exists()
+    assert _read_signals(db_path) == {}
+
+
+def test_disabled_install_does_not_trip_latch(tmp_path, monkeypatch, clean_overlay):
+    """A disabled install() must not burn the idempotency latch — a later
+    enabled install() in the same process still patches."""
+    pristine = clean_overlay
+    db_path = tmp_path / "memories.db"
+    monkeypatch.delenv("TRUEMEMORY_INSTRUMENTATION", raising=False)
+    monkeypatch.setenv("TRUEMEMORY_DB_PATH", str(db_path))
+    patch_mod.install()  # disabled no-op
+    assert patch_mod._installed is False
+
+    # Now enable and install for real.
+    monkeypatch.setenv("TRUEMEMORY_INSTRUMENTATION", "1")
+    patch_mod.install()
+    assert patch_mod._installed is True
+    gate = _current_class("truememory.ingest.encoding_gate", "EncodingGate")
+    assert gate.evaluate is not pristine[("EncodingGate", "evaluate")]

--- a/truememory/instrumentation/__init__.py
+++ b/truememory/instrumentation/__init__.py
@@ -1,0 +1,40 @@
+"""truememory.instrumentation — opt-in, self-contained telemetry overlay.
+
+This package emits structured telemetry to a ``telemetry`` table inside the
+user's ``memories.db`` so dashboards can plot per-memory salience, retrieval
+quality, gate decisions, and the model lifecycle. TrueMemory's engine does
+NOT emit any of this natively today.
+
+Design — sits on TOP of the engine (does not modify it):
+
+- ``install()`` monkey-patches a handful of engine + MCP-server methods at
+  runtime. There are no ``emit_*`` calls woven into the core. If the core
+  changes (a method is renamed or moved), the corresponding patch simply
+  no-ops — it can never break the host. Each patch is applied independently
+  inside its own ``try/except`` so one failure cannot disturb the others.
+- **Opt-in.** ``install()`` is a no-op unless the environment variable
+  ``TRUEMEMORY_INSTRUMENTATION`` is set to ``"1"``. Default off → zero
+  monkey-patching, zero writes, zero overhead, no behavior change.
+
+The ONLY core-file footprint is a single guarded call in
+``truememory.mcp_server.main()`` near where models preload::
+
+    try:
+        from truememory.instrumentation import install as _install_instrumentation
+        _install_instrumentation()
+    except Exception:
+        pass
+
+Everything else lives here and patches at runtime.
+
+Public API:
+
+- ``install()`` — apply all telemetry patches (idempotent, opt-in gated).
+- ``is_enabled()`` — True when ``TRUEMEMORY_INSTRUMENTATION=1``.
+"""
+from __future__ import annotations
+
+from truememory.instrumentation.patch import install
+from truememory.instrumentation.log import is_enabled
+
+__all__ = ["install", "is_enabled"]

--- a/truememory/instrumentation/log.py
+++ b/truememory/instrumentation/log.py
@@ -1,0 +1,61 @@
+"""Internal debug log + opt-in gate for the instrumentation overlay.
+
+``is_enabled()`` is the single opt-in switch for the whole package: every
+public emit and every monkey-patch checks it, so when
+``TRUEMEMORY_INSTRUMENTATION`` is unset the overlay is inert.
+
+The gate is read **live** from the environment on every call (not cached at
+import) so a host or a test can toggle ``TRUEMEMORY_INSTRUMENTATION`` after
+the module has been imported and have it take effect immediately.
+
+``dlog()`` appends a timestamped line to
+``~/.truememory/logs/instrumentation.log`` — a human-readable trace of which
+patches applied and which signals fired. All writes are exception-swallowed
+so a logging failure can never bring down the MCP server. When the overlay
+is disabled, ``dlog()`` is a no-op.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from datetime import datetime
+from pathlib import Path
+
+_LOG_PATH = Path.home() / ".truememory" / "logs" / "instrumentation.log"
+_write_lock = threading.Lock()
+_dir_created = False
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def is_enabled() -> bool:
+    """Return True when ``TRUEMEMORY_INSTRUMENTATION`` is set to a truthy value.
+
+    This is the opt-in gate for the entire instrumentation package. Read live
+    so the host/tests can flip it after import. Default (unset) → disabled.
+    """
+    return os.environ.get("TRUEMEMORY_INSTRUMENTATION", "").strip().lower() in _TRUTHY
+
+
+def dlog(msg: str) -> None:
+    """Append a timestamped, pid-tagged line to the instrumentation log.
+
+    No-op when the overlay is disabled. Never raises.
+    """
+    if not is_enabled():
+        return
+    global _dir_created
+    try:
+        if not _dir_created:
+            try:
+                _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+                _dir_created = True
+            except Exception:
+                pass
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:23]
+        line = f"{ts} pid={os.getpid()} tid={threading.get_ident()} {msg}\n"
+        with _write_lock:
+            with open(_LOG_PATH, "a", encoding="utf-8") as f:
+                f.write(line)
+    except Exception:
+        pass

--- a/truememory/instrumentation/patch.py
+++ b/truememory/instrumentation/patch.py
@@ -1,0 +1,546 @@
+"""Runtime monkey-patches that wire telemetry onto the TrueMemory engine.
+
+This is the "sits on top" core of the overlay. ``install()`` replaces a handful
+of engine + MCP-server methods with thin wrappers that call the ``signals``
+emitters and then delegate to the original. There are NO emit calls woven into
+the engine source — everything is applied here at runtime.
+
+Robustness contract:
+
+- **Opt-in.** ``install()`` is a no-op unless ``TRUEMEMORY_INSTRUMENTATION=1``
+  (checked via ``is_enabled()``). Default off → nothing is patched.
+- **Idempotent.** A module-level latch means a second ``install()`` call does
+  nothing.
+- **Independently isolated.** Each patch is applied inside its own
+  ``try/except``. If an upstream method has been renamed or moved (Josh changes
+  the core), that one patch logs a miss and is skipped — it can neither break
+  the other patches nor disturb the host. A patched method that moves simply
+  stops being wrapped; the engine keeps working.
+
+Patches stay applied for the life of the process; there is no uninstall hook.
+"""
+from __future__ import annotations
+
+import functools
+import time
+import os
+
+from truememory.instrumentation.log import dlog, is_enabled
+from truememory.instrumentation import signals
+
+_installed = False
+
+
+def _timed_phase(label: str):
+    """Decorator: log ENTER + EXIT/ERROR with elapsed ms. Falls through when
+    disabled."""
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            if not is_enabled():
+                return fn(*args, **kwargs)
+            t = time.time()
+            dlog(f"{label} ENTER")
+            try:
+                result = fn(*args, **kwargs)
+                dlog(f"{label} EXIT total {(time.time() - t) * 1000:.0f}ms")
+                return result
+            except Exception as exc:
+                dlog(
+                    f"{label} ERROR after {(time.time() - t) * 1000:.0f}ms: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+                raise
+
+        return wrapper
+
+    return decorator
+
+
+def _wrap_engine_add(original_add):
+    """Wrap TrueMemoryEngine.add with phase timing, WAL-checkpoint logging, and
+    a per-memory category signal."""
+
+    @functools.wraps(original_add)
+    def patched_add(self, content, sender="", recipient="", timestamp="", category="", metadata=None):
+        if not is_enabled():
+            return original_add(
+                self, content, sender=sender, recipient=recipient,
+                timestamp=timestamp, category=category, metadata=metadata,
+            )
+        t_total = time.time()
+        dlog(f"engine.add ENTER content_len={len(content)} sender={sender!r}")
+        try:
+            result = original_add(
+                self, content, sender=sender, recipient=recipient,
+                timestamp=timestamp, category=category, metadata=metadata,
+            )
+            elapsed = (time.time() - t_total) * 1000
+            new_id = result.get("id") if isinstance(result, dict) else None
+            dlog(f"engine.add EXIT total {elapsed:.0f}ms id={new_id}")
+            # WAL checkpoint snapshot AFTER commit (commit happens inside original_add)
+            try:
+                signals.log_wal_checkpoint(self.conn)
+            except Exception as exc:
+                dlog(f"wal_checkpoint hook failed: {type(exc).__name__}: {exc}")
+            # category signal — fires once per stored memory that has a category.
+            # salience/surprise/gate_decision are emitted from the encoding gate
+            # patch below (they're computed there, before a memory_id exists).
+            if new_id is not None and category:
+                try:
+                    signals.emit_category(new_id, category)
+                except Exception as exc:
+                    dlog(f"emit_category failed: {type(exc).__name__}: {exc}")
+            return result
+        except Exception as exc:
+            elapsed = (time.time() - t_total) * 1000
+            dlog(
+                f"engine.add ERROR after {elapsed:.0f}ms: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            raise
+
+    return patched_add
+
+
+def _wrap_embed_single(original_embed):
+    """Wrap vector_search.embed_single with cold-vs-warm classification."""
+
+    @functools.wraps(original_embed)
+    def patched_embed(*args, **kwargs):
+        if not is_enabled():
+            return original_embed(*args, **kwargs)
+        cold = signals.is_model_cold()
+        t = time.time()
+        try:
+            result = original_embed(*args, **kwargs)
+            elapsed = (time.time() - t) * 1000
+            dlog(f"embed_single cold={cold} done in {elapsed:.0f}ms")
+            if cold:
+                signals.mark_model_warm()
+            return result
+        except Exception as exc:
+            elapsed = (time.time() - t) * 1000
+            dlog(
+                f"embed_single ERROR cold={cold} after {elapsed:.0f}ms: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            raise
+
+    return patched_embed
+
+
+def install() -> None:
+    """Apply all telemetry monkey-patches to TrueMemory. Idempotent, opt-in.
+
+    No-op unless ``TRUEMEMORY_INSTRUMENTATION=1``. Each patch is independently
+    exception-isolated, so a renamed/moved upstream method only disables that
+    one patch — never the host.
+    """
+    # Opt-in gate FIRST — a disabled call must not trip the idempotency latch,
+    # so a later enabled call in the same process (e.g. a test) still installs.
+    if not is_enabled():
+        return
+
+    global _installed
+    if _installed:
+        return
+    _installed = True
+
+    dlog(
+        f"=== instrumentation installing (pid={os.getpid()}, "
+        f"ppid={os.getppid()}) ==="
+    )
+    signals.log_spawner_classification()
+    signals.install_hf_hub_intercept()
+
+    # Engine: replace add() with phase-timed version that also logs WAL state +
+    # emits the category signal.
+    try:
+        from truememory.engine import TrueMemoryEngine
+        TrueMemoryEngine.add = _wrap_engine_add(TrueMemoryEngine.add)
+        TrueMemoryEngine._ensure_connection = _timed_phase("engine._ensure_connection")(
+            TrueMemoryEngine._ensure_connection
+        )
+        dlog("patched truememory.engine.TrueMemoryEngine.add + _ensure_connection")
+    except Exception as exc:
+        dlog(f"engine patch failed: {type(exc).__name__}: {exc}")
+
+    # Memory client class methods — the layer MCP tools delegate to. Patching
+    # at the class level catches every call regardless of how FastMCP stores
+    # its tool references, because instance attribute lookup always resolves
+    # through the class.
+    try:
+        from truememory.client import Memory
+        for name in ("add", "search", "search_deep", "get", "delete"):
+            if hasattr(Memory, name):
+                fn = getattr(Memory, name)
+                setattr(Memory, name, _timed_phase(f"Memory.{name}")(fn))
+        dlog("patched truememory.client.Memory methods (add/search/search_deep/get/delete)")
+    except Exception as exc:
+        dlog(f"Memory patch failed: {type(exc).__name__}: {exc}")
+
+    # MCP server tool functions — best-effort. May or may not fire depending on
+    # whether FastMCP stored a direct reference at decoration time. Harmless if
+    # it doesn't fire; the Memory.* patches above provide redundant coverage.
+    try:
+        from truememory import mcp_server as _mcp
+        tool_names = (
+            "truememory_store",
+            "truememory_search",
+            "truememory_search_deep",
+            "truememory_get",
+            "truememory_forget",
+            "truememory_stats",
+            "truememory_entity_profile",
+            "truememory_configure",
+        )
+        for name in tool_names:
+            if hasattr(_mcp, name):
+                fn = getattr(_mcp, name)
+                setattr(_mcp, name, _timed_phase(f"mcp.{name}")(fn))
+        dlog(f"patched truememory.mcp_server tool functions (best-effort): {tool_names}")
+    except Exception as exc:
+        dlog(f"mcp_server patch failed: {type(exc).__name__}: {exc}")
+
+    # vector_search.embed_single — cold-vs-warm tracking
+    try:
+        from truememory import vector_search as _vs
+        if hasattr(_vs, "embed_single"):
+            _vs.embed_single = _wrap_embed_single(_vs.embed_single)
+            dlog("patched truememory.vector_search.embed_single")
+    except Exception as exc:
+        dlog(f"vector_search patch failed: {type(exc).__name__}: {exc}")
+
+    # ---- Model-lifecycle + semantic-signal patches (telemetry table writes) ----
+    _install_model_lifecycle_patches()
+    _install_semantic_signal_patches()
+
+    # Bootstrap: emit instrumentation_start so the telemetry table is created
+    # immediately, even before any store/search call fires. (Renamed from the
+    # overlay's "diag_install" — there is no diag install upstream.)
+    try:
+        from truememory.instrumentation import writer
+        writer.emit("instrumentation_start", context={"pid": os.getpid()})
+        dlog("telemetry writer bootstrap emit done (table created)")
+    except Exception as exc:
+        dlog(f"telemetry writer bootstrap failed: {type(exc).__name__}: {exc}")
+
+    # Close the instrumentation connection cleanly at process exit so we don't
+    # leak the WAL handle. atexit is best-effort but works for normal shutdown.
+    try:
+        import atexit
+        from truememory.instrumentation import writer
+        atexit.register(writer.close)
+    except Exception as exc:
+        dlog(f"telemetry writer atexit hook failed: {type(exc).__name__}: {exc}")
+
+    dlog("=== instrumentation installed ===")
+
+
+def _install_model_lifecycle_patches() -> None:
+    """Wire the preload / degraded / unload lifecycle telemetry.
+
+    Each patch is independent and exception-isolated — if the upstream function
+    doesn't exist (older TrueMemory, or a future rename), we log the miss and
+    continue. The rest of the overlay stays functional.
+    """
+    # _preload_models entry: emit preload_start so the dashboard can pair it
+    # with a later preload_complete row.
+    try:
+        from truememory import mcp_server as _mcp
+        if hasattr(_mcp, "_preload_models"):
+            _original_preload = _mcp._preload_models
+
+            @functools.wraps(_original_preload)
+            def _patched_preload(*args, **kwargs):
+                try:
+                    signals.emit_preload_start()
+                except Exception as exc:
+                    dlog(f"emit_preload_start failed: {type(exc).__name__}: {exc}")
+                return _original_preload(*args, **kwargs)
+
+            _mcp._preload_models = _patched_preload
+            dlog("patched truememory.mcp_server._preload_models (+ emit_preload_start)")
+    except Exception as exc:
+        dlog(f"_preload_models patch failed: {type(exc).__name__}: {exc}")
+
+    # reranker.get_reranker: emit preload_complete on cold load (when the
+    # module-level singleton transitions from None to loaded).
+    try:
+        from truememory import reranker as _rr
+        if hasattr(_rr, "get_reranker"):
+            _original_get_reranker = _rr.get_reranker
+
+            @functools.wraps(_original_get_reranker)
+            def _patched_get_reranker(*args, **kwargs):
+                was_cold = getattr(_rr, "_model", None) is None
+                t = time.time()
+                result = _original_get_reranker(*args, **kwargs)
+                if was_cold and getattr(_rr, "_model", None) is not None:
+                    load_ms = (time.time() - t) * 1000
+                    try:
+                        signals.emit_preload_complete("reranker", load_ms)
+                    except Exception as exc:
+                        dlog(
+                            f"emit_preload_complete failed: "
+                            f"{type(exc).__name__}: {exc}"
+                        )
+                return result
+
+            _rr.get_reranker = _patched_get_reranker
+            dlog("patched truememory.reranker.get_reranker (+ emit_preload_complete)")
+    except Exception as exc:
+        dlog(f"get_reranker patch failed: {type(exc).__name__}: {exc}")
+
+    # model_client.get_reranker_proxy: the observable "reranker degraded" event
+    # in the current architecture is the shared model-server proxy failing and
+    # forcing an expensive local fallback load. reranker.get_reranker re-imports
+    # this name on every call, catches the proxy's Exception, and loads
+    # CrossEncoder locally. We patch the proxy getter to emit reranker_degraded
+    # the moment it raises — then re-raise so get_reranker's own fallback path
+    # runs exactly as before. Fully isolated: any failure here is swallowed.
+    try:
+        from truememory import model_client as _mc
+        if hasattr(_mc, "get_reranker_proxy"):
+            _original_get_reranker_proxy = _mc.get_reranker_proxy
+
+            @functools.wraps(_original_get_reranker_proxy)
+            def _patched_get_reranker_proxy(*args, **kwargs):
+                try:
+                    return _original_get_reranker_proxy(*args, **kwargs)
+                except Exception as exc:
+                    try:
+                        signals.emit_reranker_degraded(
+                            f"model_server_proxy_failed:{type(exc).__name__}"
+                        )
+                    except Exception as exc2:
+                        dlog(
+                            f"emit_reranker_degraded failed: "
+                            f"{type(exc2).__name__}: {exc2}"
+                        )
+                    raise
+
+            _mc.get_reranker_proxy = _patched_get_reranker_proxy
+            dlog(
+                "patched truememory.model_client.get_reranker_proxy "
+                "(+ emit_reranker_degraded on proxy-fail fallback)"
+            )
+        else:
+            dlog(
+                "model_client.get_reranker_proxy not found — reranker_degraded "
+                "stays unwired (model-server path unavailable in this build)."
+            )
+    except Exception as exc:
+        dlog(f"get_reranker_proxy patch failed: {type(exc).__name__}: {exc}")
+
+    # reranker.unload_reranker: emit model_unload when the idle timer fires.
+    try:
+        from truememory import reranker as _rr
+        if hasattr(_rr, "unload_reranker"):
+            _original_unload = _rr.unload_reranker
+
+            @functools.wraps(_original_unload)
+            def _patched_unload(*args, **kwargs):
+                try:
+                    signals.emit_model_unload("reranker")
+                except Exception as exc:
+                    dlog(
+                        f"emit_model_unload failed: "
+                        f"{type(exc).__name__}: {exc}"
+                    )
+                return _original_unload(*args, **kwargs)
+
+            _rr.unload_reranker = _patched_unload
+            dlog("patched truememory.reranker.unload_reranker (+ emit_model_unload)")
+    except Exception as exc:
+        dlog(f"unload_reranker patch failed: {type(exc).__name__}: {exc}")
+
+
+def _install_semantic_signal_patches() -> None:
+    """Wire the per-memory semantic telemetry signals.
+
+    Wired signals:
+    - user_forget     — Memory.delete (1 row per explicit delete call)
+    - gate_decision   — EncodingGate.evaluate (1 row per candidate fact, pass or reject)
+    - salience        — EncodingGate.evaluate (1 row per candidate fact)
+    - surprise        — EncodingGate.evaluate (1 row per candidate fact; the
+                        instrumentation layer's novelty-ratio heuristic, NOT
+                        the engine's consolidation-based surprise_scores)
+    - search_distance — Memory.search + Memory.search_deep (1 row per call,
+                        score spread + n_results)
+    - memory_returned — Memory.search + Memory.search_deep (1 row per result in
+                        the returned list, 0-based rank)
+    """
+    # Memory.delete: emit user_forget.
+    try:
+        from truememory.client import Memory
+        if hasattr(Memory, "delete"):
+            _original_delete = Memory.delete
+
+            @functools.wraps(_original_delete)
+            def _patched_delete(self, memory_id: int, *args, **kwargs):
+                result = _original_delete(self, memory_id, *args, **kwargs)
+                try:
+                    # match_count is 1 if delete returned True (single-id delete),
+                    # 0 if False.
+                    match_count = 1 if result else 0
+                    signals.emit_user_forget(
+                        memory_id=memory_id if result else None,
+                        requested_text=f"id={memory_id}",
+                        match_count=match_count,
+                    )
+                except Exception as exc:
+                    dlog(
+                        f"emit_user_forget failed: "
+                        f"{type(exc).__name__}: {exc}"
+                    )
+                return result
+
+            Memory.delete = _patched_delete
+            dlog("patched truememory.client.Memory.delete (+ emit_user_forget)")
+    except Exception as exc:
+        dlog(f"Memory.delete patch failed: {type(exc).__name__}: {exc}")
+
+    # EncodingGate.evaluate: emit gate_decision + salience + surprise.
+    # One telemetry row per candidate fact, fires before a memory_id exists.
+    try:
+        from truememory.ingest.encoding_gate import EncodingGate
+        if hasattr(EncodingGate, "evaluate"):
+            _original_evaluate = EncodingGate.evaluate
+
+            @functools.wraps(_original_evaluate)
+            def _patched_evaluate(self, fact, category=""):
+                decision = _original_evaluate(self, fact, category)
+                try:
+                    outcome = "pass" if decision.should_encode else "reject"
+                    reason_text = (decision.reason or "").lower()
+                    if "salience" in reason_text and "floor" in reason_text:
+                        reason_code = "salience_floor"
+                    elif "novelty" in reason_text and (
+                        "low" in reason_text or "too" in reason_text
+                    ):
+                        reason_code = "novelty_too_low"
+                    elif "pred" in reason_text and "low" in reason_text:
+                        reason_code = "pred_error_low"
+                    elif outcome == "reject":
+                        reason_code = "combined_below_threshold"
+                    else:
+                        reason_code = "pass"
+                    signals.emit_gate_decision(
+                        memory_id=None,
+                        score=float(decision.encoding_score),
+                        outcome=outcome,
+                        reason_code=reason_code,
+                        context={
+                            "novelty": float(decision.novelty),
+                            "salience": float(decision.salience),
+                            "prediction_error": float(decision.prediction_error),
+                            "category": category or "",
+                            "fact_preview": (fact or "")[:60],
+                        },
+                    )
+                    signals.emit_salience(
+                        memory_id=None,
+                        score=float(decision.salience),
+                    )
+                except Exception as exc:
+                    dlog(
+                        f"emit gate_decision/salience failed: "
+                        f"{type(exc).__name__}: {exc}"
+                    )
+                # surprise signal — the instrumentation layer's novelty-ratio
+                # heuristic, computed here because the engine's native
+                # surprise_scores requires consolidate() which may be off.
+                try:
+                    from truememory.instrumentation import surprise as _surprise
+                    surprise_score = _surprise.compute_surprise(fact)
+                    signals.emit_surprise(
+                        memory_id=None,
+                        score=float(surprise_score),
+                    )
+                except Exception as exc:
+                    dlog(f"emit_surprise failed: {type(exc).__name__}: {exc}")
+                return decision
+
+            EncodingGate.evaluate = _patched_evaluate
+            dlog(
+                "patched truememory.ingest.encoding_gate.EncodingGate.evaluate"
+                " (+ emit_gate_decision + emit_salience + emit_surprise)"
+            )
+        else:
+            dlog("EncodingGate.evaluate not found — encoding_gate patches skipped")
+    except Exception as exc:
+        dlog(f"EncodingGate.evaluate patch failed: {type(exc).__name__}: {exc}")
+
+    # Memory.search + Memory.search_deep: emit search_distance + memory_returned.
+    # search_distance: 1 row per call. memory_returned: 1 row per result.
+    # Results are dicts with an "id" key.
+    def _wrap_search(original_fn, label: str):
+        """Factory so both search and search_deep share identical emit logic."""
+        @functools.wraps(original_fn)
+        def _patched(self, query: str, *args, **kwargs):
+            results = original_fn(self, query, *args, **kwargs)
+            try:
+                # search_distance value_num = SPREAD of the returned score
+                # distribution (top - bottom). After the reranker's per-call
+                # min-max normalization the top is pinned to ~1.0, so spread —
+                # not top — is the real discrimination signal. Raw top/min/mean
+                # go into context_json for absolute plotting.
+                scores = [
+                    float(r.get("score", 0.0))
+                    for r in results
+                    if isinstance(r.get("score"), (int, float))
+                ]
+                if scores:
+                    top_score = scores[0]            # results are pre-sorted desc
+                    min_score = min(scores)
+                    mean_score = sum(scores) / len(scores)
+                    spread = top_score - min_score   # the informative signal
+                else:
+                    top_score = min_score = mean_score = spread = 0.0
+                signals.emit_search_distance(
+                    query_text=query,
+                    spread=spread,
+                    top_score=top_score,
+                    min_score=min_score,
+                    mean_score=mean_score,
+                    n_results=len(results),
+                )
+                for rank, result in enumerate(results):
+                    mem_id = result.get("id")
+                    if mem_id is not None:
+                        signals.emit_memory_returned(
+                            memory_id=int(mem_id),
+                            rank=rank,
+                            query_text=query,
+                        )
+            except Exception as exc:
+                dlog(
+                    f"emit search_distance/memory_returned ({label}) failed: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+            return results
+        return _patched
+
+    try:
+        from truememory.client import Memory
+        if hasattr(Memory, "search"):
+            Memory.search = _wrap_search(Memory.search, "search")
+            dlog(
+                "patched truememory.client.Memory.search"
+                " (+ emit_search_distance + emit_memory_returned)"
+            )
+        else:
+            dlog("Memory.search not found — search patches skipped")
+        if hasattr(Memory, "search_deep"):
+            Memory.search_deep = _wrap_search(Memory.search_deep, "search_deep")
+            dlog(
+                "patched truememory.client.Memory.search_deep"
+                " (+ emit_search_distance + emit_memory_returned)"
+            )
+        else:
+            dlog("Memory.search_deep not found — search_deep patch skipped")
+    except Exception as exc:
+        dlog(f"Memory.search patch failed: {type(exc).__name__}: {exc}")

--- a/truememory/instrumentation/signals.py
+++ b/truememory/instrumentation/signals.py
@@ -1,0 +1,319 @@
+"""Telemetry signal emitters + auxiliary diagnostic helpers.
+
+Every ``emit_*`` here is gated on ``is_enabled()`` (so it is a no-op when the
+overlay is disabled) and writes one row to the ``telemetry`` table via
+``writer.emit``. The monkey-patches in ``patch.py`` call these from inside the
+wrapped engine / MCP-server methods.
+
+Two groups:
+
+1. **Model-lifecycle signals** — ``preload_start``, ``preload_complete``,
+   ``model_unload``, ``reranker_degraded``. Render a per-day model lifecycle
+   view (preload → ready → degraded → unloaded → re-preload).
+2. **Per-memory semantic signals** — ``salience``, ``category``,
+   ``gate_decision``, ``surprise``, ``search_distance``, ``memory_returned``,
+   ``user_forget``. These power the dashboard's data lanes.
+
+Auxiliary helpers (cold/warm model flag, WAL-checkpoint snapshot, HF Hub
+network intercept, spawner classification) are diagnostic-only — they write to
+the instrumentation log via ``dlog``, not the telemetry table.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any
+
+from truememory.instrumentation.log import dlog, is_enabled
+from truememory.instrumentation import writer
+
+_model_warm = False
+_model_warm_lock = threading.Lock()
+
+
+def is_model_cold() -> bool:
+    return not _model_warm
+
+
+def mark_model_warm() -> None:
+    global _model_warm
+    with _model_warm_lock:
+        _model_warm = True
+
+
+def log_spawner_classification() -> None:
+    """Best-effort identification of the spawning process (the MCP host vs a
+    sub-process it launched).
+
+    Uses psutil if available; falls back to logging just PIDs. Diagnostic
+    only — never written to the telemetry table.
+    """
+    if not is_enabled():
+        return
+    pid = os.getpid()
+    ppid = os.getppid()
+    try:
+        import psutil
+        try:
+            parent = psutil.Process(ppid)
+            parent_name = parent.name()
+            try:
+                grandparent = parent.parent()
+                grandparent_name = grandparent.name() if grandparent else "(none)"
+                grandparent_pid = grandparent.pid if grandparent else 0
+            except Exception:
+                grandparent_name = "(unavailable)"
+                grandparent_pid = 0
+            dlog(
+                f"spawner pid={pid} ppid={ppid} parent='{parent_name}' "
+                f"gppid={grandparent_pid} grandparent='{grandparent_name}'"
+            )
+        except psutil.NoSuchProcess:
+            dlog(f"spawner pid={pid} ppid={ppid} (parent process gone)")
+    except ImportError:
+        dlog(f"spawner pid={pid} ppid={ppid} (psutil unavailable)")
+    except Exception as exc:
+        dlog(f"spawner classification failed: {type(exc).__name__}: {exc}")
+
+
+def log_wal_checkpoint(conn) -> None:
+    """Run PRAGMA wal_checkpoint(PASSIVE) and log result. Called after
+    engine.add commit. Diagnostic only."""
+    if not is_enabled():
+        return
+    try:
+        cursor = conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+        row = cursor.fetchone()
+        if row:
+            busy, pages_moved, pages_remaining = row[0], row[1], row[2]
+            dlog(
+                f"wal_checkpoint busy={busy} pages_moved={pages_moved} "
+                f"pages_remaining={pages_remaining}"
+            )
+    except Exception as exc:
+        dlog(f"wal_checkpoint failed: {type(exc).__name__}: {exc}")
+
+
+class _HFHubDiagHandler(logging.Handler):
+    """Forwards WARNING+ records from huggingface_hub to dlog.
+
+    Triggers when HF_HUB_OFFLINE=1 is bypassed somehow and the loader tries to
+    reach the network. Useful for catching race conditions between preload
+    threads and config-mutation calls.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg = record.getMessage()
+            dlog(f"[hf_hub] {record.levelname}: {msg}")
+        except Exception:
+            pass
+
+
+def install_hf_hub_intercept() -> None:
+    """Attach the HF Hub diagnostic handler. Idempotent — checks for prior
+    install."""
+    if not is_enabled():
+        return
+    try:
+        hub_logger = logging.getLogger("huggingface_hub")
+        for h in hub_logger.handlers:
+            if isinstance(h, _HFHubDiagHandler):
+                return
+        handler = _HFHubDiagHandler()
+        handler.setLevel(logging.WARNING)
+        hub_logger.addHandler(handler)
+        dlog("hf_hub intercept attached (WARNING+ -> dlog)")
+    except Exception as exc:
+        dlog(f"hf_hub intercept install failed: {type(exc).__name__}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Model-lifecycle signals (preload / degraded / idle)
+# ---------------------------------------------------------------------------
+#
+# Every emit_* writes BOTH a dlog line (human-readable ops trace) AND a
+# telemetry row (structured query surface). Belt + suspenders: a future
+# dashboard query can JOIN on memory_id, and when the telemetry table is empty
+# the human can still grep the instrumentation log for the same event.
+
+
+def emit_preload_start() -> None:
+    """Fires when ``_preload_models`` begins its work (embedding + reranker
+    preload threads spawn)."""
+    if not is_enabled():
+        return
+    dlog("preload_start")
+    writer.emit(
+        "preload_start",
+        value_text="reranker+embedding",
+        context={"pid": os.getpid()},
+    )
+
+
+def emit_preload_complete(model: str, load_ms: float) -> None:
+    """Fires when ``get_reranker()`` (or the embedding model getter) returns
+    from a cold load."""
+    if not is_enabled():
+        return
+    dlog(f"preload_complete model={model!r} load_ms={load_ms:.0f}")
+    writer.emit(
+        "preload_complete",
+        value_num=load_ms,
+        value_text=model,
+    )
+
+
+def emit_reranker_degraded(reason: str) -> None:
+    """Fires when the reranker degrades — e.g. the shared model-server proxy
+    fails and forces an expensive local fallback load."""
+    if not is_enabled():
+        return
+    dlog(f"reranker_degraded reason={reason!r}")
+    writer.emit(
+        "reranker_degraded",
+        value_text=reason,
+    )
+
+
+def emit_model_unload(model: str, idle_seconds: float | None = None) -> None:
+    """Fires when the MCP server's idle timer unloads a model to free RAM."""
+    if not is_enabled():
+        return
+    dlog(f"model_unload model={model!r} idle_seconds={idle_seconds}")
+    writer.emit(
+        "model_unload",
+        value_num=idle_seconds,
+        value_text=model,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-memory semantic signals (power the dashboard's data lanes)
+# ---------------------------------------------------------------------------
+
+
+def emit_salience(memory_id: int | None, score: float) -> None:
+    """Fires once per candidate fact with the computed salience score [0, 1]."""
+    if not is_enabled():
+        return
+    writer.emit(
+        "salience",
+        memory_id=memory_id,
+        value_num=score,
+    )
+
+
+def emit_category(memory_id: int, category: str) -> None:
+    """Fires once per stored memory with the auto-detected category."""
+    if not is_enabled():
+        return
+    writer.emit(
+        "category",
+        memory_id=memory_id,
+        value_text=category,
+    )
+
+
+def emit_gate_decision(
+    memory_id: int | None,
+    score: float,
+    outcome: str,
+    *,
+    reason_code: str | None = None,
+    context: dict[str, Any] | None = None,
+) -> None:
+    """Fires per encoding-gate decision (pass OR reject)."""
+    if not is_enabled():
+        return
+    writer.emit(
+        "gate_decision",
+        memory_id=memory_id,
+        value_num=score,
+        value_text=reason_code or outcome,
+        context=context,
+    )
+
+
+def emit_search_distance(
+    query_text: str,
+    *,
+    spread: float,
+    top_score: float,
+    min_score: float,
+    mean_score: float,
+    n_results: int,
+) -> None:
+    """Fires once per search call with a retrieval-quality summary.
+
+    ``value_num`` holds the score SPREAD (top - bottom) of the returned result
+    set — the informative signal. The top result's raw score is pinned to ~1.0
+    by the reranker's per-call min-max normalization, so spread, not top, is
+    what tracks retrieval confidence: wide spread = the retriever cleanly
+    separated the best hit from the tail; narrow spread = a flat, low-confidence
+    result set. Spread stays comparable across calls regardless of whether the
+    reranked path (normalized ~1.0 scores) or the rerank-skipped path (raw RRF
+    ~0.03 scores) produced the result, because it is a difference of two scores
+    on the same per-call scale.
+
+    The raw ``top``/``min``/``mean`` absolutes are stashed in context_json so
+    the dashboard can still plot them directly when desired.
+
+    query_text is truncated to 60 chars before storage (never log full query
+    text — avoids leaking PII to the telemetry table).
+    """
+    if not is_enabled():
+        return
+    writer.emit(
+        "search_distance",
+        value_num=spread,
+        context={
+            "query_preview": (query_text or "")[:60],
+            "n_results": n_results,
+            "top": round(top_score, 6),
+            "min": round(min_score, 6),
+            "mean": round(mean_score, 6),
+        },
+    )
+
+
+def emit_memory_returned(memory_id: int, rank: int, query_text: str) -> None:
+    """Fires per returned memory in a search response. Rank is 0-based."""
+    if not is_enabled():
+        return
+    writer.emit(
+        "memory_returned",
+        memory_id=memory_id,
+        value_num=float(rank),
+        context={"query_preview": (query_text or "")[:60]},
+    )
+
+
+def emit_surprise(memory_id: int | None, score: float) -> None:
+    """Fires once per candidate fact with the surprise score [0, 1].
+
+    ⚠ This is the INSTRUMENTATION LAYER'S novelty-ratio heuristic (see
+    ``surprise.compute_surprise``), DISTINCT from TrueMemory's native
+    consolidation-based ``surprise_scores``. The signal keeps the name
+    ``surprise`` because that is the column the dashboard reads.
+    """
+    if not is_enabled():
+        return
+    writer.emit(
+        "surprise",
+        memory_id=memory_id,
+        value_num=score,
+    )
+
+
+def emit_user_forget(memory_id: int | None, requested_text: str, match_count: int) -> None:
+    """Fires per explicit delete call. Powers the audit lane."""
+    if not is_enabled():
+        return
+    writer.emit(
+        "user_forget",
+        memory_id=memory_id,
+        value_num=float(match_count),
+        value_text=(requested_text or "")[:200],
+    )

--- a/truememory/instrumentation/surprise.py
+++ b/truememory/instrumentation/surprise.py
@@ -1,0 +1,220 @@
+"""Standalone novelty-ratio surprise scorer for the instrumentation overlay.
+
+⚠ DISTINCT FROM TRUEMEMORY'S NATIVE ``surprise_scores``.
+================================================================
+The ``surprise`` signal this module computes is the *instrumentation layer's*
+own lightweight, per-process novelty-ratio heuristic. It is NOT the same as
+TrueMemory's consolidation-based ``surprise_scores`` (built by
+``predictive.build_surprise_index`` and used by the L5 surprise reranker).
+
+The reasons they differ:
+  - ``predictive.compute_surprise_score`` requires a caller-managed
+    ``existing_facts`` set and is designed for the batch surprise-index
+    pipeline, which only runs during ``consolidate()``. Consolidation is not
+    guaranteed to be on, so native surprise is often simply absent.
+  - The dashboard wants a surprise value at *ingest* time, on every candidate
+    fact, with no dependency on consolidation. This module provides exactly
+    that: a stateful, per-process accumulator of seen fact-fingerprints that
+    yields a novelty ratio the moment a fact is evaluated by the encoding gate.
+
+The signal is intentionally named ``surprise`` because that is the column name
+the dashboard reads. Treat it as "info-value at birth," not as the engine's
+consolidation-derived surprise.
+
+What was dropped vs. the native scorer:
+  - ``detail_bonus`` (numbers/dates credit) — overlaps with salience's own
+    number/date features; removing it keeps surprise and salience orthogonal.
+  - All DB writes — this module emits via ``signals``, not directly to SQLite.
+  - ``build_surprise_index`` / ``get_high_surprise_messages`` / stats queries.
+
+Public API: ``compute_surprise(fact: str) -> float``  returns [0, 1].
+"""
+from __future__ import annotations
+
+import re
+import threading
+
+# ---------------------------------------------------------------------------
+# Module-level state — rebuilds from scratch on each process start.
+# No cross-restart persistence: surprise is "novelty since this process began."
+# ---------------------------------------------------------------------------
+
+_existing_facts: set[str] = set()
+_lock = threading.Lock()
+
+# ---------------------------------------------------------------------------
+# Regex + noise constants
+# ---------------------------------------------------------------------------
+
+_NOISE_SET: frozenset[str] = frozenset({
+    "ok", "okay", "k", "kk", "sure", "yes", "no", "yeah", "yep", "yup",
+    "nah", "nope", "cool", "nice", "great", "thanks", "thank you",
+    "thx", "ty", "sounds good", "sounds great", "perfect", "got it",
+    "gotcha", "will do", "on it", "bet", "word", "facts", "true",
+    "same", "right", "exactly", "agreed", "absolutely", "definitely",
+    "good morning", "good night", "gn", "gm", "hey", "hi", "hello",
+    "what's up", "sup", "yo", "how are you", "how's it going",
+    "see you", "see ya", "later", "bye", "ttyl", "talk later",
+    "have a good one", "take care",
+    "lol", "lmao", "haha", "hahaha", "lmfao", "rofl",
+    "omg", "wow", "damn", "dude", "bruh",
+})
+
+_NUMBER_RE = re.compile(
+    r"""
+    \$[\d,.]+[KMBkmb]?
+    | \d+\.?\d*\s*%
+    | \d+\.?\d*\s*(?:ms|seconds?|hrs?|hours?|minutes?)
+    | \d{1,3}(?:,\d{3})+
+    | \d+\.?\d*\s*(?:lbs?|pounds?|kg)
+    | \d+\.?\d*\s*(?:miles?|km|steps?)
+    | \d+:\d{2}(?::\d{2})?
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+_PROPER_NOUN_RE = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b")
+
+_DATE_RE = re.compile(
+    r"""
+    \b\d{4}-\d{2}-\d{2}\b
+    | \b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May
+    |Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?
+    |Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2}(?:,?\s*\d{4})?
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+_EVENT_KEYWORDS: frozenset[str] = frozenset({
+    "quit", "hired", "fired", "joined", "started", "founded",
+    "launched", "raised", "closed", "signed", "moved", "switched",
+    "migrated", "decided", "announced", "incorporated", "accepted",
+    "rejected", "bought", "sold", "promoted", "deployed", "released",
+    "published", "graduated", "married", "engaged", "broke up",
+    "diagnosed", "recovered", "completed", "won", "lost",
+})
+
+_COMMON_PROPER_NOUNS: frozenset[str] = frozenset({
+    "I", "The", "A", "An", "Is", "It", "He", "She", "We", "They",
+    "My", "Your", "His", "Her", "Our", "This", "That", "What",
+    "When", "Where", "Who", "How", "Why", "But", "And", "Or",
+    "So", "If", "Not", "No", "Yes", "Can", "Will", "Just",
+    "Do", "Did", "Has", "Have", "Had", "Was", "Were", "Are",
+    "Been", "Be", "Would", "Could", "Should", "May", "Might",
+    "Let", "Also", "Still", "Even", "Too", "Very", "Really",
+    "About", "Like", "Here", "There", "Now", "Then", "Well",
+    "Hey", "Yeah", "Yep", "Thanks", "Thank", "Sure", "Ok",
+    "For", "With", "From", "Into", "Over", "After", "Before",
+    "Between", "During", "Through", "Some", "Any", "All",
+    "Each", "Every", "New", "Good", "Great", "First", "Last",
+    "Going", "Looking", "Don",
+})
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _extract_facts(content: str) -> set[str]:
+    """Extract fact fingerprints from a string. Pure-stdlib, no engine deps."""
+    facts: set[str] = set()
+
+    for match in _NUMBER_RE.finditer(content):
+        fact = match.group(0).strip().lower().replace(",", "")
+        facts.add(f"num:{fact}")
+
+    for match in _PROPER_NOUN_RE.finditer(content):
+        noun = match.group(0)
+        if noun not in _COMMON_PROPER_NOUNS and len(noun) > 1:
+            facts.add(f"entity:{noun.lower()}")
+
+    for match in _DATE_RE.finditer(content):
+        facts.add(f"date:{match.group(0).strip().lower()}")
+
+    lower = content.lower()
+    words = lower.split()
+    for i, word in enumerate(words):
+        clean = word.strip(".,!?\"'()")
+        if clean in _EVENT_KEYWORDS:
+            start, end = max(0, i - 2), min(len(words), i + 3)
+            facts.add(f"event:{' '.join(words[start:end])}")
+
+    for subj, pred in re.findall(
+        r"(\w[\w\s]{2,30})\s+(?:is|are|was|were)\s+(\w[\w\s]{2,30})", content
+    ):
+        s, p = subj.strip().lower(), pred.strip().lower()
+        if len(s) > 3 and len(p) > 3:
+            facts.add(f"def:{s}={p}")
+
+    return facts
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def compute_surprise(fact: str) -> float:
+    """Return info-value score in [0, 1] for *fact* relative to seen history.
+
+    High = genuinely new claim. Low = restatement of known information.
+    Never raises; returns 0.5 (neutral) on any internal error.
+
+    detail_bonus is intentionally omitted (salience already captures
+    number/date density — keeping the two signals orthogonal).
+    """
+    try:
+        # ---- Quick noise check ----
+        stripped = fact.strip().lower()
+        cleaned = re.sub(r"[^\w\s]", "", stripped)
+        if cleaned in _NOISE_SET or len(cleaned) < 4:
+            return 0.05
+        words = cleaned.split()
+        if len(words) <= 2 and all(w in _NOISE_SET for w in words):
+            return 0.05
+
+        # ---- Extract facts ----
+        message_facts = _extract_facts(fact)
+        total_facts = len(message_facts)
+
+        # ---- Thread-safe snapshot + update ----
+        with _lock:
+            snapshot = _existing_facts.copy()
+            _existing_facts.update(message_facts)
+
+        if total_facts == 0:
+            length = len(fact)
+            if length < 30:
+                return 0.1
+            elif length < 80:
+                return 0.2
+            else:
+                return 0.3
+
+        # ---- Novelty ratio (the unique component vs salience) ----
+        new_facts = message_facts - snapshot
+        new_count = len(new_facts)
+        if new_count == 0:
+            return 0.1
+
+        novelty_ratio = new_count / total_facts
+        base_score = novelty_ratio * 0.6  # max: 0.6
+
+        # ---- Length bonus ----
+        length = len(fact)
+        if length > 300:
+            length_bonus = 0.15
+        elif length > 150:
+            length_bonus = 0.10
+        elif length > 80:
+            length_bonus = 0.05
+        else:
+            length_bonus = 0.0
+
+        # ---- Event bonus ----
+        event_facts = [f for f in new_facts if f.startswith("event:")]
+        event_bonus = min(0.10, len(event_facts) * 0.05)
+
+        score = base_score + length_bonus + event_bonus
+        return max(0.05, min(1.0, score))
+
+    except Exception:
+        return 0.5

--- a/truememory/instrumentation/writer.py
+++ b/truememory/instrumentation/writer.py
@@ -1,0 +1,242 @@
+"""SQLite writer for the ``telemetry`` semantic-signal table.
+
+This module adds a structured signal sink: a single ``telemetry`` table inside
+the user's ``memories.db``. A dashboard layer can JOIN ``telemetry.memory_id``
+to ``messages.id`` and aggregate per-signal counts in pure SQL — no log parsing
+required.
+
+Schema (kept stable so external dashboard mirrors can read it)::
+
+    telemetry(
+      id           INTEGER PRIMARY KEY,
+      ts           REAL    NOT NULL,
+      pid          INTEGER,
+      signal       TEXT    NOT NULL,
+      memory_id    INTEGER,
+      value_num    REAL,
+      value_text   TEXT,
+      context_json TEXT
+    )
+    + index idx_telemetry_signal_ts ON telemetry(signal, ts)
+    + index idx_telemetry_memory_id ON telemetry(memory_id)
+
+Design constraints:
+
+- **Independent connection.** The writer never reuses the MCP server's SQLite
+  connection. The server holds its connection on the asyncio event-loop
+  thread, and we cannot risk contention or cross-thread cursor use.
+- **Schema migration on first write.** ``CREATE TABLE IF NOT EXISTS`` runs on
+  the first ``emit()`` — cheap on the SQLite C layer and avoids a separate
+  install step.
+- **Exception-swallowing.** A telemetry-write failure must NEVER bring down the
+  MCP server. Every error is logged via ``dlog`` and dropped.
+- **Disabled by default.** Gated on ``TRUEMEMORY_INSTRUMENTATION`` (the same
+  flag that gates the whole overlay). Production users are unaffected.
+- **No surprise side effects.** Does not call ``PRAGMA journal_mode=WAL`` or
+  ``BEGIN``/``COMMIT`` explicitly — relies on SQLite autocommit so the writer
+  never interferes with the MCP server's transaction state.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from truememory.instrumentation.log import dlog, is_enabled
+
+# Path resolution follows TrueMemory's own convention: TRUEMEMORY_DB_PATH > the
+# legacy TRUEMEMORY_DB env var > ~/.truememory/memories.db. Resolved live on
+# each open so test fixtures that set TRUEMEMORY_DB_PATH are honored.
+_DEFAULT_DB_PATH = Path.home() / ".truememory" / "memories.db"
+
+# Lazy module-level connection. We open on first emit() so a process that never
+# emits never touches the DB. Re-opened automatically if the file moves between
+# calls (rare; supports test fixtures).
+_conn: sqlite3.Connection | None = None
+_conn_path: str | None = None
+_conn_lock = threading.Lock()
+_schema_migrated = False
+
+_TELEMETRY_DDL = """
+CREATE TABLE IF NOT EXISTS telemetry (
+  id           INTEGER PRIMARY KEY,
+  ts           REAL    NOT NULL,
+  pid          INTEGER,
+  signal       TEXT    NOT NULL,
+  memory_id    INTEGER,
+  value_num    REAL,
+  value_text   TEXT,
+  context_json TEXT
+);
+"""
+
+_TELEMETRY_INDICES = (
+    "CREATE INDEX IF NOT EXISTS idx_telemetry_signal_ts ON telemetry(signal, ts);",
+    "CREATE INDEX IF NOT EXISTS idx_telemetry_memory_id ON telemetry(memory_id);",
+)
+
+
+def _resolve_db_path() -> str:
+    """Return the canonical memories.db path (env override or default)."""
+    override = (
+        os.environ.get("TRUEMEMORY_DB_PATH")
+        or os.environ.get("TRUEMEMORY_DB")
+        or ""
+    ).strip()
+    return override or str(_DEFAULT_DB_PATH)
+
+
+def _get_conn() -> sqlite3.Connection | None:
+    """Open (or reopen) the instrumentation-owned SQLite connection.
+
+    Returns None if the DB file's parent directory does not exist — in that
+    case the MCP server hasn't been started yet, so there's nothing to write
+    telemetry for.
+    """
+    global _conn, _conn_path, _schema_migrated
+    path = _resolve_db_path()
+    if _conn is not None and _conn_path == path:
+        return _conn
+
+    with _conn_lock:
+        # Re-check inside the lock — another thread may have opened it.
+        if _conn is not None and _conn_path == path:
+            return _conn
+        if _conn is not None:
+            try:
+                _conn.close()
+            except Exception:
+                pass
+            _conn = None
+            _schema_migrated = False
+
+        parent = Path(path).parent
+        if not parent.exists():
+            return None
+        try:
+            # check_same_thread=False so emit() can fire from any thread
+            # (worker threads under asyncio.to_thread, the WAL-checkpoint hook
+            # in patch.py, background drainers).
+            conn = sqlite3.connect(path, check_same_thread=False)
+            conn.execute("PRAGMA busy_timeout=5000")
+            _conn = conn
+            _conn_path = path
+            dlog(f"telemetry writer opened conn path={path}")
+            return _conn
+        except sqlite3.Error as exc:
+            dlog(
+                f"telemetry writer open FAILED path={path} "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return None
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> bool:
+    """Run the DDL idempotently. Cached so we don't re-run on every emit."""
+    global _schema_migrated
+    if _schema_migrated:
+        return True
+    try:
+        with conn:
+            conn.execute(_TELEMETRY_DDL)
+            for ddl in _TELEMETRY_INDICES:
+                conn.execute(ddl)
+        _schema_migrated = True
+        dlog("telemetry writer schema migrated (CREATE TABLE/INDEX IF NOT EXISTS)")
+        return True
+    except sqlite3.Error as exc:
+        dlog(
+            f"telemetry writer schema migration FAILED "
+            f"{type(exc).__name__}: {exc}"
+        )
+        return False
+
+
+def emit(
+    signal: str,
+    *,
+    memory_id: int | None = None,
+    value_num: float | None = None,
+    value_text: str | None = None,
+    context: dict[str, Any] | None = None,
+) -> None:
+    """Append one row to the ``telemetry`` table.
+
+    Args:
+        signal: One of the documented signal names (``salience``, ``category``,
+            ``gate_decision``, ``surprise``, ``search_distance``,
+            ``memory_returned``, ``user_forget``) or a model-lifecycle signal
+            (``preload_start``, ``preload_complete``, ``model_unload``,
+            ``reranker_degraded``, ``instrumentation_start``). Free-form for
+            future expansion.
+        memory_id: Foreign key into ``messages.id`` when the signal relates to a
+            specific memory. Nullable.
+        value_num: Numeric payload — score, latency in ms, distance, rank.
+            Nullable.
+        value_text: Categorical payload — reason code, model name, requested
+            text. Nullable.
+        context: Arbitrary structured payload serialized as JSON into
+            ``context_json``. Nullable. Use sparingly — column-typed payloads
+            (``value_num`` / ``value_text``) query faster.
+
+    No-op when ``TRUEMEMORY_INSTRUMENTATION`` is unset. Errors are swallowed.
+    """
+    if not is_enabled():
+        return
+    conn = _get_conn()
+    if conn is None:
+        return
+    if not _ensure_schema(conn):
+        return
+
+    context_json = None
+    if context:
+        try:
+            context_json = json.dumps(context, default=str, sort_keys=True)
+        except (TypeError, ValueError) as exc:
+            dlog(
+                f"telemetry writer json encode failed signal={signal} "
+                f"{type(exc).__name__}: {exc}"
+            )
+            context_json = None
+
+    try:
+        with conn:
+            conn.execute(
+                "INSERT INTO telemetry "
+                "(ts, pid, signal, memory_id, value_num, value_text, context_json) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    time.time(),
+                    os.getpid(),
+                    signal,
+                    memory_id,
+                    value_num,
+                    value_text,
+                    context_json,
+                ),
+            )
+    except sqlite3.Error as exc:
+        dlog(
+            f"telemetry writer emit FAILED signal={signal} "
+            f"memory_id={memory_id} {type(exc).__name__}: {exc}"
+        )
+
+
+def close() -> None:
+    """Close the instrumentation-owned connection. Called at process exit by an
+    atexit hook ``install()`` registers. Safe to call multiple times."""
+    global _conn, _conn_path, _schema_migrated
+    with _conn_lock:
+        if _conn is not None:
+            try:
+                _conn.close()
+            except Exception:
+                pass
+            _conn = None
+            _conn_path = None
+            _schema_migrated = False

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1580,6 +1580,19 @@ def main():
     except Exception:
         pass
 
+    # Opt-in SQLite telemetry instrumentation (default OFF). A no-op unless
+    # TRUEMEMORY_INSTRUMENTATION=1. It monkey-patches the engine at runtime to
+    # emit per-memory salience / retrieval / gate signals into a `telemetry`
+    # table — see truememory.instrumentation. Installed here (before
+    # _preload_models below and before any tool fires) so the preload-lifecycle
+    # patches are in place. Fully isolated: any failure leaves the server
+    # running exactly as if instrumentation were disabled.
+    try:
+        from truememory.instrumentation import install as _install_instrumentation
+        _install_instrumentation()
+    except Exception:
+        pass
+
     # Start shared model server (loads models once for all processes).
     # Falls back to per-process loading if server can't start.
     from truememory.model_client import ensure_server_running


### PR DESCRIPTION
## What

TrueMemory emits **no native SQLite telemetry** today. Any dashboard that wants
to plot per-memory salience, retrieval quality, encoding-gate decisions, or the
model lifecycle has to bolt on an **external monkey-patch overlay** â€” and
without one, memory cards render null salience / retrieval values.

This PR adds an **opt-in** (`TRUEMEMORY_INSTRUMENTATION=1`), **self-contained**
`truememory.instrumentation` package that **monkey-patches the engine at
runtime** to emit telemetry into a `telemetry` table inside the user's
`memories.db`.

## So what â€” why this shape

The instrumentation **sits on top of** the engine. It is **not** a set of
`emit_*` calls woven into the core files.

- **Survives core churn.** The package patches a handful of engine + MCP-server
  methods at runtime via `install()`. There are zero emit calls in the engine
  source. If a patched method is later renamed or moved, that single patch
  gracefully **no-ops** (it logs the miss and skips) â€” it can never break the
  host, and the other patches keep working. Each patch is applied inside its
  own `try/except`, so one failure can't disturb the rest.
- **Default OFF â€” zero overhead.** `install()` is a **no-op** unless
  `TRUEMEMORY_INSTRUMENTATION=1`. When unset: no monkey-patching, no writes, no
  overhead, no behavior change whatsoever.
- **Minimal core footprint.** The **only** core-file change is **one guarded,
  opt-in `install()` call** in `mcp_server.main()`, placed near where models
  preload (13 lines incl. comment):

  ```python
  # Opt-in SQLite telemetry instrumentation (default OFF). A no-op unless
  # TRUEMEMORY_INSTRUMENTATION=1. ...
  try:
      from truememory.instrumentation import install as _install_instrumentation
      _install_instrumentation()
  except Exception:
      pass
  ```

  Everything else lives in `truememory/instrumentation/` and patches at runtime.

## Now what â€” how to use it

```bash
# Default: instrumentation is OFF, nothing changes.
truememory-mcp

# Opt in: the MCP server monkey-patches the engine at startup and begins
# writing telemetry rows into ~/.truememory/memories.db (telemetry table).
TRUEMEMORY_INSTRUMENTATION=1 truememory-mcp
```

A dashboard then reads/joins `telemetry.memory_id` against `messages.id`.

---

## Package layout

```
truememory/instrumentation/
â”œâ”€â”€ __init__.py     # exposes install() + is_enabled()
â”œâ”€â”€ log.py          # opt-in gate (is_enabled) + minimal internal debug log
â”œâ”€â”€ writer.py       # the SQLite `telemetry` table writer (independent connection)
â”œâ”€â”€ surprise.py     # novelty-ratio surprise heuristic (see caveat below)
â”œâ”€â”€ signals.py      # emit_* helpers â€” one per signal
â””â”€â”€ patch.py        # install(): applies every monkey-patch, idempotent, isolated
tests/
â””â”€â”€ test_instrumentation.py
```

## Signals emitted

| Signal | Fires from | value_num / value_text |
| --- | --- | --- |
| `gate_decision` | `EncodingGate.evaluate` (per candidate fact) | encoding score / reason code; novelty+salience+PE in context |
| `salience` | `EncodingGate.evaluate` (per candidate fact) | salience score [0,1] |
| `surprise` | `EncodingGate.evaluate` (per candidate fact) | novelty-ratio score [0,1] â€” see caveat |
| `search_distance` | `Memory.search` / `search_deep` (per call) | score **spread** (topâˆ’bottom); raw top/min/mean in context |
| `memory_returned` | `Memory.search` / `search_deep` (per result) | 0-based rank |
| `user_forget` | `Memory.delete` (per explicit delete) | match count |
| `category` | engine `add` (per stored memory w/ category) | category string |
| `preload_start` | `mcp_server._preload_models` | â€” |
| `preload_complete` | `reranker.get_reranker` cold load | load ms / model name |
| `model_unload` | `reranker.unload_reranker` (idle timer) | idle seconds / model name |
| `reranker_degraded` | `model_client.get_reranker_proxy` proxy-fail fallback | reason text |
| `instrumentation_start` | `install()` bootstrap (creates the table immediately) | â€” |

> `embed_neighbor` is intentionally **not** included â€” it requires hooking
> engine internals after vector insert and needs careful design to avoid
> double-counting across retry paths.

### âš  surprise caveat (read this)

The `surprise` signal this overlay emits is the **instrumentation layer's own
novelty-ratio heuristic** (`truememory.instrumentation.surprise`). It is
**DISTINCT** from TrueMemory's native, consolidation-based `surprise_scores`
(built by `predictive.build_surprise_index` and consumed by the L5 surprise
reranker).

- The native scorer requires a caller-managed `existing_facts` set and only
  runs during `consolidate()`, which may be off â€” so native surprise is often
  simply absent.
- A dashboard wants a surprise value **at ingest time**, on every candidate
  fact, with no dependency on consolidation. This overlay provides exactly that
  via a stateful per-process accumulator of seen fact-fingerprints.

The signal keeps the name `surprise` because that is the column a dashboard
reads â€” but reviewers/users should treat it as "info-value at birth," not as
the engine's consolidation-derived surprise. This distinction is documented in
the module docstring and the `emit_surprise` docstring.

## telemetry schema (stable for external dashboard mirrors)

```sql
CREATE TABLE IF NOT EXISTS telemetry (
  id           INTEGER PRIMARY KEY,
  ts           REAL    NOT NULL,
  pid          INTEGER,
  signal       TEXT    NOT NULL,
  memory_id    INTEGER,
  value_num    REAL,
  value_text   TEXT,
  context_json TEXT
);
CREATE INDEX IF NOT EXISTS idx_telemetry_signal_ts ON telemetry(signal, ts);
CREATE INDEX IF NOT EXISTS idx_telemetry_memory_id ON telemetry(memory_id);
```

The writer uses an **independent SQLite connection** (never the MCP server's),
relies on autocommit (no explicit `BEGIN`/`COMMIT`, no `journal_mode` mutation)
so it can't perturb the server's transaction state, and swallows every error so
a telemetry-write failure can never bring down the server.

## Tests

`tests/test_instrumentation.py` (12 tests) covers both halves of the opt-in
contract:

- **Enabled** (`TRUEMEMORY_INSTRUMENTATION=1`): `install()` patches the targeted
  methods; a gate eval â†’ `gate_decision` + `salience` + `surprise`; a search â†’
  `search_distance` + `memory_returned`; a delete â†’ `user_forget`; an
  engine add with a category â†’ `category`; the bootstrap `instrumentation_start`
  row is written; the table schema + both indices match the contract exactly;
  `install()` is idempotent.
- **Disabled** (env unset): `install()` is a no-op â€” no methods patched, the
  `telemetry` table is never created, and a disabled call does not burn the
  idempotency latch (a later enabled call still installs).

The test file is **reload-safe**: it resolves the target classes live from their
modules (rather than caching references at import), so it passes regardless of
suite ordering even though other test modules `importlib.reload` engine modules.

### Verification

```text
# instrumentation suite (isolated)
12 passed in 10.63s

# full suite
679 passed, 4 failed, 44 skipped
```

The 4 failures (`tests/ingest/test_cli_preflight.py` Ã—2,
`tests/test_upgrade_path.py` Ã—2) are **pre-existing, environment-dependent
failures on the dev box** â€” they fail identically with this package not even
imported (they assert on an empty `~/.truememory/logs/` and a clean
`memories.db`, neither of which holds on a box with live TrueMemory data). They
are unrelated to this change; this PR introduces **zero regressions** and adds
+12 passing tests.

## Compatibility / safety notes

- No new dependencies. `psutil` is already a TrueMemory dependency; it is used
  best-effort and degrades gracefully if absent.
- No `pyproject.toml` change needed â€” `truememory/instrumentation/` is picked up
  automatically by the existing `packages = ["truememory"]` wheel config.
- AGPL-3.0 â€” same license as the rest of the package.
```
