### PR TITLE
fix(health): vec_messages health-check looks up tier-specific table name

### DIFF
--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -881,10 +881,15 @@ class TrueMemoryEngine:
         # Check for vector tables — rebuild if missing.
         # if metadata names a different embedder, refuse silent
         # rebuild; route the user through truememory_configure() instead.
+        # The active table is tier-specific (vec_messages_edge / _basepro);
+        # probing the flat name produced a spurious "no such table:
+        # vec_messages" surfaced as ``health.vectors = degraded``.
         self._has_vectors = False
         if _HAS_VECTOR:
             try:
-                self.conn.execute("SELECT COUNT(*) FROM vec_messages").fetchone()
+                from truememory.vector_search import _active_vec_table
+                _vec_tbl = _active_vec_table(self.conn)
+                self.conn.execute(f"SELECT COUNT(*) FROM {_vec_tbl}").fetchone()
                 self._has_vectors = True
             except Exception:
                 logger.warning(


### PR DESCRIPTION
## Summary

`truememory_stats.health.vectors` reports `degraded — no such table: vec_messages` even when vector search is fully healthy. The cosmetic culprit is one probe in `engine.open()` that checks the flat `vec_messages` name; the actual tables on disk are tier-specific (`vec_messages_edge` / `vec_messages_basepro`) and tracked in `vector_cache_registry`.

This PR fixes that one read-only health probe. **Search and ingest** already route through the tier-specific helpers and are unaffected. **Delete/update and clustering do _not_** — they still hardcoded the flat name (orphaned vectors on `forget`/`delete_all`/`update`, and a hard crash in `clustering._get_all_embeddings`); those are fixed separately in #395.

## Fix

Resolve the active table name via the existing `_active_vec_table()` helper. It falls back to the legacy flat name when no registry rows exist, so fresh-DB rebuild paths are preserved.

## Verification

- Pro tier (352 rows in `vec_messages_basepro`) → `vectors.status = ok`, `_vectors_load_error = None`
- Fresh empty DB → `has_vectors = False` rebuild path still triggers; no spurious load-error
