### PR TITLE
fix(mcp_server): reap orphaned launchers when parent dies ungracefully

### DIFF
--- a/tests/test_lifecycle_orphan_cleanup.py
+++ b/tests/test_lifecycle_orphan_cleanup.py
@@ -1,0 +1,519 @@
+"""Regression locks for the Windows orphan-launcher reaper.
+
+When Claude Code dies ungracefully, the ``truememory.mcp_server`` child
+can survive as a zombie holding the SQLite read lock. The hardening in
+``truememory._lifecycle`` covers it with two mechanisms:
+
+    1. ``sweep_orphan_siblings()`` — kill other MCP processes whose
+       parent PID is dead, on every server boot.
+    2. ``start_parent_watchdog()`` — daemon thread that exits us when
+       our parent dies.
+
+These tests lock in the unit-level behaviour of (1) and the
+end-to-end behaviour of (2) on Windows (POSIX has different reaping
+semantics so the integration test is gated on ``sys.platform``).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers — psutil mocks
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """Minimal psutil.Process stand-in.
+
+    Mirrors the subset of the psutil.Process API that
+    ``sweep_orphan_siblings`` exercises: ``pid``, ``info``, ``kill``,
+    ``wait``, ``create_time``, ``ppid``, ``cmdline``.
+
+    ``info`` is the dict returned by ``process_iter([...])`` and is the
+    fast-path psutil reads. The instance methods are the slow-path
+    fallback when ``info`` is missing a key.
+    """
+
+    def __init__(
+        self,
+        pid: int,
+        ppid: int,
+        cmdline: list[str],
+        create_time: float,
+        *,
+        no_such_on_kill: bool = False,
+    ) -> None:
+        self.pid = pid
+        self.info = {
+            "pid": pid,
+            "ppid": ppid,
+            "cmdline": cmdline,
+            "create_time": create_time,
+        }
+        self._ppid = ppid
+        self._cmdline = cmdline
+        self._create_time = create_time
+        self._no_such_on_kill = no_such_on_kill
+        self.killed = False
+        self.waited = False
+
+    def ppid(self):
+        return self._ppid
+
+    def cmdline(self):
+        return self._cmdline
+
+    def create_time(self):
+        return self._create_time
+
+    def kill(self):
+        import psutil
+        if self._no_such_on_kill:
+            raise psutil.NoSuchProcess(self.pid)
+        self.killed = True
+
+    def wait(self, timeout=None):
+        self.waited = True
+        return 0
+
+
+class _FakePsutilParent:
+    """Stand-in for ``psutil.Process(<ppid>)`` returning a parent stub.
+
+    Used by ``_parent_seems_alive`` to query ``create_time`` of a
+    candidate parent. We construct these via ``_make_pid_map`` below
+    rather than instantiating directly.
+    """
+
+    def __init__(self, pid: int, create_time: float) -> None:
+        self.pid = pid
+        self._create_time = create_time
+
+    def create_time(self):
+        return self._create_time
+
+
+def _install_fake_psutil(
+    monkeypatch,
+    *,
+    processes: list[_FakeProc],
+    live_pids: dict[int, float],
+):
+    """Monkey-patch ``psutil`` so the helpers see a controlled fake world.
+
+    Args:
+        processes: ``_FakeProc`` instances returned by ``process_iter``.
+        live_pids: mapping ``{pid: create_time}`` of every PID that
+            ``pid_exists`` should report alive. ``psutil.Process(pid)``
+            looks up here for ``create_time``.
+    """
+    import psutil
+
+    def fake_process_iter(attrs=None):
+        return list(processes)
+
+    def fake_pid_exists(pid):
+        return pid in live_pids
+
+    real_Process = psutil.Process
+
+    def fake_Process(pid):
+        if pid in live_pids:
+            return _FakePsutilParent(pid, live_pids[pid])
+        # Mirror real psutil: raise NoSuchProcess for unknown PIDs.
+        raise psutil.NoSuchProcess(pid)
+
+    monkeypatch.setattr(psutil, "process_iter", fake_process_iter)
+    monkeypatch.setattr(psutil, "pid_exists", fake_pid_exists)
+    monkeypatch.setattr(psutil, "Process", fake_Process)
+    return real_Process
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — sweep_orphan_siblings()
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_kills_orphan_with_dead_parent(monkeypatch):
+    """Case (a): a sibling whose PPID is no longer alive must be killed."""
+    from truememory import _lifecycle
+
+    monkeypatch.setattr(_lifecycle.os, "getpid", lambda: 100)
+    orphan = _FakeProc(
+        pid=200,
+        ppid=9999,  # parent is dead
+        cmdline=["python.exe", "-m", "truememory.mcp_server"],
+        create_time=1000.0,
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        processes=[orphan],
+        live_pids={},  # PPID 9999 NOT in live_pids → parent is dead
+    )
+
+    swept = _lifecycle.sweep_orphan_siblings()
+
+    assert swept == [200]
+    assert orphan.killed is True
+
+
+def test_sweep_kills_orphan_when_ppid_recycled(monkeypatch):
+    """Case (b): PPID exists but ``create_time`` newer than child → recycled.
+
+    PID-recycling: child's parent died, but Windows reassigned the same
+    PID to a newer unrelated process. We detect this because the
+    candidate parent's ``create_time`` is later than the child's.
+    """
+    from truememory import _lifecycle
+
+    monkeypatch.setattr(_lifecycle.os, "getpid", lambda: 100)
+    orphan = _FakeProc(
+        pid=200,
+        ppid=300,
+        cmdline=["python.exe", "-m", "truememory.mcp_server"],
+        create_time=1000.0,  # child created at t=1000
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        processes=[orphan],
+        # PID 300 exists, but was created at t=2000 — AFTER the child.
+        # Real parent is gone; PID was recycled.
+        live_pids={300: 2000.0},
+    )
+
+    swept = _lifecycle.sweep_orphan_siblings()
+
+    assert swept == [200]
+    assert orphan.killed is True
+
+
+def test_sweep_spares_live_sibling(monkeypatch):
+    """Case (c): a sibling with a real, older parent must NOT be killed."""
+    from truememory import _lifecycle
+
+    monkeypatch.setattr(_lifecycle.os, "getpid", lambda: 100)
+    live_sibling = _FakeProc(
+        pid=200,
+        ppid=300,
+        cmdline=["python.exe", "-m", "truememory.mcp_server"],
+        create_time=2000.0,  # child created at t=2000
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        processes=[live_sibling],
+        # PID 300 exists and was created BEFORE the child — real parent.
+        live_pids={300: 1000.0},
+    )
+
+    swept = _lifecycle.sweep_orphan_siblings()
+
+    assert swept == []
+    assert live_sibling.killed is False
+
+
+def test_sweep_spares_current_process(monkeypatch):
+    """Case (d): the current process must always be spared, even if its
+    own parent looks dead. ``start_parent_watchdog`` handles that case."""
+    from truememory import _lifecycle
+
+    my_pid = 100
+    monkeypatch.setattr(_lifecycle.os, "getpid", lambda: my_pid)
+    me = _FakeProc(
+        pid=my_pid,
+        ppid=9999,  # my own parent is "dead" — but I'm not a candidate
+        cmdline=["python.exe", "-m", "truememory.mcp_server"],
+        create_time=1000.0,
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        processes=[me],
+        live_pids={},
+    )
+
+    swept = _lifecycle.sweep_orphan_siblings()
+
+    assert swept == []
+    assert me.killed is False
+
+
+def test_sweep_ignores_unrelated_processes(monkeypatch):
+    """Non-truememory cmdlines must be ignored regardless of parent state."""
+    from truememory import _lifecycle
+
+    monkeypatch.setattr(_lifecycle.os, "getpid", lambda: 100)
+    unrelated = _FakeProc(
+        pid=200,
+        ppid=9999,  # dead parent — but doesn't matter
+        cmdline=["python.exe", "-m", "some_other_tool"],
+        create_time=1000.0,
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        processes=[unrelated],
+        live_pids={},
+    )
+
+    swept = _lifecycle.sweep_orphan_siblings()
+
+    assert swept == []
+    assert unrelated.killed is False
+
+
+def test_sweep_matches_entry_point_shim(monkeypatch):
+    """``truememory-mcp.exe`` (the pyproject entry-point shim) must be
+    recognized in addition to the ``-m truememory.mcp_server`` form."""
+    from truememory import _lifecycle
+
+    monkeypatch.setattr(_lifecycle.os, "getpid", lambda: 100)
+    shim_orphan = _FakeProc(
+        pid=200,
+        ppid=9999,
+        cmdline=["C:\\Python\\Scripts\\truememory-mcp.exe"],
+        create_time=1000.0,
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        processes=[shim_orphan],
+        live_pids={},
+    )
+
+    swept = _lifecycle.sweep_orphan_siblings()
+
+    assert swept == [200]
+    assert shim_orphan.killed is True
+
+
+def test_sweep_dry_run_does_not_kill(monkeypatch):
+    """``dry_run=True`` must return the candidate PIDs but never call
+    ``proc.kill()``. Used by the CLI for ``sweep --dry-run`` previews."""
+    from truememory import _lifecycle
+
+    monkeypatch.setattr(_lifecycle.os, "getpid", lambda: 100)
+    orphan = _FakeProc(
+        pid=200,
+        ppid=9999,
+        cmdline=["python.exe", "-m", "truememory.mcp_server"],
+        create_time=1000.0,
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        processes=[orphan],
+        live_pids={},
+    )
+
+    swept = _lifecycle.sweep_orphan_siblings(dry_run=True)
+
+    assert swept == [200]
+    assert orphan.killed is False  # dry-run must NOT kill
+
+
+def test_sweep_returns_empty_when_psutil_missing(monkeypatch):
+    """Server boot must continue if ``psutil`` import fails. Sweep
+    returns an empty list and never raises in that case."""
+    from truememory import _lifecycle
+
+    # Force the in-function ``import psutil`` to fail.
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def bad_import(name, *args, **kwargs):
+        if name == "psutil":
+            raise ImportError("simulated missing psutil")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setitem(sys.modules, "psutil", None)
+    # Prevent the cached ``psutil`` module from being reused inside the
+    # function: setitem(..., None) makes ``import psutil`` raise.
+    swept = _lifecycle.sweep_orphan_siblings()
+    assert swept == []
+
+
+def test_sweep_survives_process_iter_exception(monkeypatch):
+    """If ``psutil.process_iter`` itself raises, sweep returns ``[]`` and
+    does NOT propagate the exception (boot must continue)."""
+    import psutil
+    from truememory import _lifecycle
+
+    monkeypatch.setattr(_lifecycle.os, "getpid", lambda: 100)
+
+    def broken_iter(attrs=None):
+        raise OSError("simulated process_iter failure")
+
+    monkeypatch.setattr(psutil, "process_iter", broken_iter)
+    swept = _lifecycle.sweep_orphan_siblings()
+    assert swept == []
+
+
+# ---------------------------------------------------------------------------
+# Integration test — start_parent_watchdog() on Windows
+# ---------------------------------------------------------------------------
+#
+# POSIX has different parent-death semantics (the child gets re-parented
+# to PID 1, so ``os.getppid()`` returns 1 rather than the original
+# parent's PID — the watchdog's ``pid_exists(ppid)`` would stay True
+# forever). On Windows, ``os.getppid()`` keeps returning the original
+# parent's PID even after it dies, which is exactly what the watchdog
+# needs to detect death.
+#
+# We use ``subprocess.Popen`` rather than ``multiprocessing.Process``
+# for the parent shim because ``multiprocessing`` installs an atexit
+# handler that joins managed child Processes, so the shim cannot die
+# while its grandchild lives. ``subprocess.Popen``-spawned grandchildren
+# have no such backreference — they're plain OS processes, which is
+# exactly how Claude Code spawns the MCP server in production.
+
+
+_GRANDCHILD_SCRIPT = r"""
+import os, sys, time
+sys.path.insert(0, %(repo_root)r)
+from truememory._lifecycle import start_parent_watchdog
+start_parent_watchdog(poll_interval_s=%(poll)f)
+# Sleep far longer than the watchdog interval; the watchdog should
+# os._exit(0) before this wakes up.
+time.sleep(120)
+"""
+
+
+_PARENT_SHIM_SCRIPT = r"""
+import os, subprocess, sys
+sys.path.insert(0, %(repo_root)r)
+grandchild = subprocess.Popen(
+    [sys.executable, "-c", %(grandchild_code)r],
+)
+with open(%(ready_path)r, "w", encoding="utf-8") as f:
+    f.write(str(grandchild.pid))
+    f.flush()
+# Parent shim exits immediately. Grandchild's parent is now dead.
+"""
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows-specific orphan reaper: POSIX re-parents to PID 1 so ppid never dies",
+)
+def test_watchdog_exits_when_parent_dies(tmp_path):
+    """End-to-end: grandchild starts the watchdog, parent shim dies,
+    grandchild must self-terminate within poll_interval_s plus slack.
+
+    Uses a 5s poll interval so the test wraps in ~10s rather than the
+    30s default — keeps CI fast while still exercising the real
+    sleep/check/exit loop. Total bound: ~20s.
+    """
+    import subprocess
+    from pathlib import Path
+
+    repo_root = str(Path(__file__).resolve().parent.parent)
+    ready_path = tmp_path / "grandchild_pid.txt"
+    poll_interval_s = 5.0
+
+    grandchild_code = _GRANDCHILD_SCRIPT % {
+        "repo_root": repo_root,
+        "poll": poll_interval_s,
+    }
+    parent_code = _PARENT_SHIM_SCRIPT % {
+        "repo_root": repo_root,
+        "grandchild_code": grandchild_code,
+        "ready_path": str(ready_path),
+    }
+
+    parent = subprocess.Popen(
+        [sys.executable, "-c", parent_code],
+        # Detach stdio so the grandchild doesn't inherit pytest's
+        # captured pipes (which could keep the parent alive via
+        # pipe-write).
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+    )
+
+    # Wait for the parent shim to spawn the grandchild and write the PID.
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        if ready_path.exists() and ready_path.stat().st_size > 0:
+            break
+        time.sleep(0.1)
+    else:
+        try:
+            parent.kill()
+        except Exception:
+            pass
+        pytest.fail("parent shim did not write grandchild PID within 15s")
+
+    grandchild_pid = int(ready_path.read_text(encoding="utf-8").strip())
+
+    # Wait for the parent shim to exit.
+    try:
+        parent_rc = parent.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        parent.kill()
+        pytest.fail("parent shim failed to exit within 10s")
+    assert parent_rc == 0, f"parent shim exited non-zero: {parent_rc}"
+
+    # Watchdog poll interval = 5s; allow up to ~3x for slack on a
+    # contended box. Total wait bound ~20s.
+    import psutil
+    deadline = time.time() + (poll_interval_s * 3 + 5)
+    while time.time() < deadline:
+        if not psutil.pid_exists(grandchild_pid):
+            break
+        time.sleep(0.5)
+    else:
+        # Cleanup before failing.
+        try:
+            psutil.Process(grandchild_pid).kill()
+        except Exception:
+            pass
+        pytest.fail(
+            f"grandchild PID {grandchild_pid} still alive after parent died — "
+            f"watchdog did not fire within {poll_interval_s * 3 + 5}s"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+
+def test_cli_help_returns_zero(capsys):
+    """The CLI must return 0 on ``help`` / ``--help`` / ``-h``."""
+    from truememory import _lifecycle
+
+    assert _lifecycle._cli([]) == 0
+    assert _lifecycle._cli(["--help"]) == 0
+    assert _lifecycle._cli(["-h"]) == 0
+
+
+def test_cli_unknown_command_returns_two():
+    """The CLI must return exit code 2 on unknown subcommands."""
+    from truememory import _lifecycle
+
+    assert _lifecycle._cli(["bogus"]) == 2
+
+
+def test_cli_dry_run_does_not_kill(monkeypatch, capsys):
+    """``sweep --dry-run`` must report would-kill PIDs without killing."""
+    from truememory import _lifecycle
+
+    monkeypatch.setattr(_lifecycle.os, "getpid", lambda: 100)
+    orphan = _FakeProc(
+        pid=200,
+        ppid=9999,
+        cmdline=["python.exe", "-m", "truememory.mcp_server"],
+        create_time=1000.0,
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        processes=[orphan],
+        live_pids={},
+    )
+
+    rc = _lifecycle._cli(["sweep", "--dry-run"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert orphan.killed is False
+    assert "would kill" in captured.out
+    assert "200" in captured.out

--- a/truememory/_lifecycle.py
+++ b/truememory/_lifecycle.py
@@ -1,0 +1,313 @@
+"""Lifecycle hardening for the TrueMemory MCP server.
+
+Solves the zombie-MCP problem: when Claude Code closes ungracefully
+(crash, force-quit, system reboot), the ``truememory.mcp_server`` child
+process is not always reaped, leaving an orphan that holds a SQLite
+read lock on ``~/.truememory/memories.db``. Stacking enough orphans
+triggers 60s search timeouts and stale-cache pathologies.
+
+Two complementary mechanisms cover the common failure modes:
+
+    1. ``sweep_orphan_siblings()`` — at server startup, find any OTHER
+       MCP server processes whose parent PID is dead and kill them.
+       Catches every zombie the next time Claude Code starts.
+
+    2. ``start_parent_watchdog()`` — daemon thread that polls our own
+       parent PID every N seconds. If the parent dies, we exit hard
+       (``os._exit``, bypassing atexit). Catches the case where the
+       server is running but Claude Code went down.
+
+This module is also runnable directly for ad-hoc cleanup::
+
+    # See what would be swept (no kills):
+    python -m truememory._lifecycle sweep --dry-run
+
+    # Actually sweep:
+    python -m truememory._lifecycle sweep
+
+A third option — Windows Job Objects with
+``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`` — would be the gold-standard
+fix, but it requires the PARENT (Claude Code) to wrap the spawn in a
+job object, and we don't own Claude Code's process-spawn code. So we
+work from the child side with the two mechanisms above.
+
+PID-recycling caveat (Windows): when a process dies its PID can be
+reassigned. ``psutil.pid_exists(ppid)`` can therefore return True even
+after our actual parent is gone, if some other process happened to
+land on the same PID. We mitigate by comparing the candidate parent's
+``create_time`` against the child's (a real parent must be older).
+False positives mean the watchdog briefly fails to fire, which is the
+safe failure mode: the next server restart cleans up via
+``sweep_orphan_siblings()`` anyway.
+
+Module is named ``_lifecycle`` (leading underscore) to mark it as
+internal — public API surface for this hardening is the two helpers
+imported from ``truememory.mcp_server.main()``.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from typing import Iterable
+
+# We deliberately do not raise from any function in this module — the
+# MCP server must boot regardless of whether the cleanup helpers can
+# run. Every entry point swallows exceptions and continues.
+
+# Canonical invocation forms we must detect:
+#   * ``python -m truememory.mcp_server``  (module form, joined cmdline
+#     contains ``truememory.mcp_server``)
+#   * ``truememory-mcp`` / ``truememory-mcp.exe`` (entry-point shim
+#     installed by pyproject.toml [project.scripts])
+#
+# Note: ``setproctitle.setproctitle("TrueMemory MCP")`` is a no-op on
+# Windows for ``psutil.Process.cmdline()`` — the cmdline still reflects
+# the original argv. On POSIX it overwrites argv[0] visible in ``ps``,
+# but ``psutil.cmdline()`` is read from ``/proc/<pid>/cmdline`` and may
+# or may not reflect the new title depending on platform. We match the
+# canonical module/script forms above, which are reliable across both.
+_TOKEN_MODULE = "truememory.mcp_server"
+_TOKEN_SCRIPT = "truememory-mcp"
+_DEFAULT_WATCHDOG_INTERVAL_S = 30.0
+
+
+def _is_truememory_mcp_server(proc) -> bool:
+    """Return True iff ``proc`` is a python process running the MCP server.
+
+    We accept the server running under any python.exe path (venv,
+    pyenv, system python, etc.). Match is on the joined command-line
+    containing either ``truememory.mcp_server`` (module form) or
+    ``truememory-mcp`` (entry-point shim form).
+    """
+    try:
+        cmdline = proc.info.get("cmdline") if hasattr(proc, "info") else proc.cmdline()
+    except Exception:
+        try:
+            cmdline = proc.cmdline()
+        except Exception:
+            return False
+    if not cmdline:
+        return False
+    try:
+        joined = " ".join(str(p) for p in cmdline).lower()
+    except Exception:
+        return False
+    return _TOKEN_MODULE in joined or _TOKEN_SCRIPT in joined
+
+
+def _parent_seems_alive(child_proc, child_create_time: float | None = None) -> bool:
+    """Best-effort check whether ``child_proc``'s parent is its REAL parent.
+
+    Returns False if the parent PID does not exist, or if the parent
+    process exists but was created AFTER the child (which means the
+    PID was recycled and the original parent is gone).
+
+    Failure mode is fail-open: if we cannot read parent metadata for
+    any reason, we report the parent as alive so we never kill a
+    process whose lineage we're uncertain about.
+    """
+    try:
+        import psutil
+    except ImportError:
+        return True  # fail open — never kill if we can't verify
+
+    try:
+        ppid = child_proc.info.get("ppid") if hasattr(child_proc, "info") else child_proc.ppid()
+    except Exception:
+        return True
+
+    if not ppid:
+        return False  # no parent recorded = orphan
+    try:
+        if not psutil.pid_exists(ppid):
+            return False
+    except Exception:
+        return True
+
+    # PID-recycling guard: a real parent's ``create_time`` must be
+    # <= the child's. If the parent's ``create_time`` is greater, the
+    # original parent is gone and the PID was reassigned.
+    try:
+        parent = psutil.Process(ppid)
+        parent_ct = parent.create_time()
+        if child_create_time is None:
+            child_create_time = child_proc.create_time()
+        if parent_ct > child_create_time:
+            return False  # PID was recycled; original parent is gone
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return False
+    except Exception:
+        # If we can't read the parent's create_time, fail open.
+        pass
+
+    return True
+
+
+def sweep_orphan_siblings(dry_run: bool = False) -> list[int]:
+    """Find and kill orphaned sibling MCP server processes.
+
+    A sibling is any OTHER python process whose command line contains
+    ``truememory.mcp_server`` (or the ``truememory-mcp`` entry-point
+    shim). An orphan is a sibling whose parent PID is dead (or was
+    recycled — see PID-recycling caveat in the module docstring).
+
+    The current process is always spared, even if its own parent
+    looks dead (we are after all the one running). That case is
+    handled by ``start_parent_watchdog`` instead.
+
+    Returns the list of PIDs killed (or the list that WOULD be killed
+    when ``dry_run=True``). Never raises — every failure mode is
+    swallowed so the MCP server can boot even if psutil is missing or
+    ``process_iter`` errors.
+    """
+    try:
+        import psutil
+    except ImportError:
+        return []
+
+    try:
+        my_pid = os.getpid()
+    except Exception:
+        return []
+
+    swept: list[int] = []
+    try:
+        proc_iter = psutil.process_iter(["pid", "ppid", "cmdline", "create_time"])
+    except Exception:
+        return swept
+
+    for proc in proc_iter:
+        try:
+            if proc.pid == my_pid:
+                continue
+            if not _is_truememory_mcp_server(proc):
+                continue
+            try:
+                child_ct = proc.info.get("create_time") if hasattr(proc, "info") else None
+                if child_ct is None:
+                    child_ct = proc.create_time()
+            except Exception:
+                child_ct = None
+            if _parent_seems_alive(proc, child_ct):
+                continue
+            swept.append(proc.pid)
+            if not dry_run:
+                try:
+                    proc.kill()
+                    try:
+                        proc.wait(timeout=5)
+                    except psutil.TimeoutExpired:
+                        pass
+                except psutil.NoSuchProcess:
+                    # Already gone between detection and kill — count it.
+                    pass
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+        except Exception:
+            # Defensive: any unexpected psutil hiccup must not break boot.
+            continue
+    return swept
+
+
+def start_parent_watchdog(
+    poll_interval_s: float = _DEFAULT_WATCHDOG_INTERVAL_S,
+) -> threading.Thread | None:
+    """Spawn a daemon thread that exits us hard when our parent dies.
+
+    Uses ``os._exit`` so we skip atexit handlers — they can hang
+    waiting on the dead parent's STDIO pipes, which defeats the whole
+    point. The exit code is 0 because this is an expected lifecycle
+    event (parent gone), not a crash.
+
+    Returns the started ``Thread``, or ``None`` if psutil is
+    unavailable. The thread is ``daemon=True`` so it does not delay
+    normal MCP shutdown when the parent is alive and asks us to exit.
+    """
+    try:
+        import psutil
+    except ImportError:
+        return None
+
+    my_pid = os.getpid()
+    my_ppid = os.getppid()
+
+    try:
+        my_create_time = psutil.Process(my_pid).create_time()
+    except Exception:
+        my_create_time = None
+
+    def _watch() -> None:
+        try:
+            import psutil  # local import inside thread is fine
+        except ImportError:
+            return
+        while True:
+            try:
+                time.sleep(poll_interval_s)
+            except Exception:
+                # Should never happen, but if sleep raises we exit the loop.
+                return
+            try:
+                if not psutil.pid_exists(my_ppid):
+                    _exit_with_message(my_ppid, "PID does not exist")
+                    return
+                # PID-recycling guard.
+                if my_create_time is not None:
+                    try:
+                        parent_ct = psutil.Process(my_ppid).create_time()
+                        if parent_ct > my_create_time:
+                            _exit_with_message(my_ppid, "PID was recycled")
+                            return
+                    except (psutil.NoSuchProcess, psutil.AccessDenied):
+                        _exit_with_message(my_ppid, "parent unreadable")
+                        return
+            except Exception:
+                # Any psutil hiccup: wait for next tick.
+                continue
+
+    t = threading.Thread(target=_watch, daemon=True, name="truememory-ppid-watchdog")
+    t.start()
+    return t
+
+
+def _exit_with_message(ppid: int, reason: str) -> None:
+    try:
+        sys.stderr.write(
+            f"truememory.mcp_server: parent PID {ppid} gone ({reason}), exiting.\n"
+        )
+        sys.stderr.flush()
+    except Exception:
+        pass
+    os._exit(0)
+
+
+# ---- CLI ----------------------------------------------------------------
+
+
+def _cli(argv: Iterable[str]) -> int:
+    args = list(argv)
+    if not args or args[0] in ("-h", "--help", "help"):
+        sys.stdout.write(
+            "usage: python -m truememory._lifecycle sweep [--dry-run]\n"
+            "\n"
+            "Find and kill orphaned truememory.mcp_server processes\n"
+            "whose parent Claude Code is gone.\n"
+        )
+        return 0
+    if args[0] != "sweep":
+        sys.stderr.write(f"unknown command: {args[0]!r}\n")
+        return 2
+    dry_run = "--dry-run" in args[1:]
+    swept = sweep_orphan_siblings(dry_run=dry_run)
+    label = "would kill" if dry_run else "killed"
+    if not swept:
+        sys.stdout.write("no orphaned MCP servers found.\n")
+    else:
+        sys.stdout.write(f"{label} {len(swept)} orphaned MCP server(s): {swept}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_cli(sys.argv[1:]))

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1549,6 +1549,50 @@ def main():
     except ImportError:
         pass
 
+    # Ungraceful-parent-exit hardening (Windows-primary, POSIX-safe).
+    #
+    # When Claude Code dies hard (crash, force-quit, system reboot) the
+    # MCP child can survive as a zombie holding the SQLite read lock on
+    # ~/.truememory/memories.db. Stacking enough zombies triggers 60s
+    # search timeouts. Two complementary mechanisms in truememory._lifecycle:
+    #
+    #   1) sweep_orphan_siblings() — kill any other truememory.mcp_server
+    #      processes whose parent PID is dead before we boot further.
+    #   2) start_parent_watchdog() — daemon thread that exits us hard
+    #      (os._exit) within ~30s of the parent dying.
+    #
+    # Both calls swallow every exception by contract; this try/except is
+    # a belt-and-suspenders guard so server boot continues even if the
+    # module import itself fails for any reason (e.g., stripped wheel).
+    try:
+        from truememory._lifecycle import sweep_orphan_siblings
+        swept = sweep_orphan_siblings()
+        if swept:
+            sys.stderr.write(
+                f"truememory.mcp_server: swept {len(swept)} orphaned "
+                f"sibling(s): {swept}\n"
+            )
+            sys.stderr.flush()
+    except Exception as exc:
+        try:
+            sys.stderr.write(
+                f"truememory.mcp_server: orphan sweep failed "
+                f"({type(exc).__name__}: {exc}); continuing.\n"
+            )
+        except Exception:
+            pass
+    try:
+        from truememory._lifecycle import start_parent_watchdog
+        start_parent_watchdog()
+    except Exception as exc:
+        try:
+            sys.stderr.write(
+                f"truememory.mcp_server: ppid watchdog failed to start "
+                f"({type(exc).__name__}: {exc}); continuing.\n"
+            )
+        except Exception:
+            pass
+
     # HuggingFace offline mode — skip HTTP freshness checks when models are
     # cached. Models are downloaded on first install; subsequent loads
     # should be pure disk reads (~170ms) instead of HTTP round-trips


### PR DESCRIPTION
## Summary

- Claude Code dying ungracefully can leave `truememory.mcp_server` as a zombie holding the SQLite read lock — stacks cause 60s search timeouts. Most visible on Windows (no parent-death signal; Job Objects need spawner opt-in we don't control).
- Adds `truememory/_lifecycle.py`: `sweep_orphan_siblings()` reaps siblings whose PPID is dead (with `create_time` PID-recycling guard), and `start_parent_watchdog()` daemon thread `os._exit(0)`s within ~30s of parent death.
- Wired into `mcp_server.main()` after `setproctitle`, before `telemetry.init()`. Both call sites fail-open so a stripped wheel still boots. Also runnable: `python -m truememory._lifecycle sweep [--dry-run]`.

Reference: `~/.claude/_GLOBAL-best-PRACTICES/ai-engineering/mcps/04-lifecycle-and-restarts.md` § *Ungraceful parent exits — orphan cleanup*.

## Test plan

- [x] 12 unit tests: dead-parent, recycled-PID, live-parent, self-spare, entry-point-shim, dry-run, psutil-missing, broken `process_iter`.
- [x] Windows integration: real subprocess parent dies, grandchild watchdog self-terminates within ~15s.
- [x] `pytest tests/test_lifecycle_orphan_cleanup.py -v` → **13 passed in 5.73s** (Win/Py3.13).
- [x] No regression in `test_mcp_safety` / `test_platform_compat`.
