### PR TITLE
fix(hooks): use SessionEnd not Stop for Claude Code transcript extraction (re-submit of #355)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@
 
 3. **Snapshot** (pre-compact): The PreCompact hook (Claude Code, Kimi) saves a lightweight snapshot of the conversation before context compression.
 
-4. **Extract** (session end): The Stop hook launches a background ingestion process that parses the transcript, runs the encoding gate on each fact, and stores high-quality memories.
+4. **Extract** (session end): The SessionEnd hook launches a background ingestion process that parses the transcript, runs the encoding gate on each fact, and stores high-quality memories. (On Claude Code, the `SessionEnd` event fires only when the session actually terminates — `Stop` fires per-turn and is therefore the wrong trigger for transcript-end extraction.)
 
 ## Package Structure
 

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@
 #   4. Runs `truememory-mcp --setup` (code from PyPI) to auto-configure
 #      Claude Code and/or Claude Desktop. Set TRUEMEMORY_SKIP_SETUP=1 to skip.
 #   5. Runs `truememory-ingest install` to wire up lifecycle hooks
-#      (SessionStart, Stop, UserPromptSubmit, PreCompact) and merge
+#      (SessionStart, SessionEnd, UserPromptSubmit, PreCompact) and merge
 #      CLAUDE.md instructions so Claude uses TrueMemory proactively.
 #
 # Environment overrides:

--- a/truememory/ingest/CLAUDE_TEMPLATE.md
+++ b/truememory/ingest/CLAUDE_TEMPLATE.md
@@ -33,7 +33,7 @@ MEMORY.md may contain personal facts that were cached from earlier sessions. **D
 
 ## Background Processing
 - Memories are also extracted automatically from conversations via background processing.
-- The Stop hook captures the full transcript and runs deep extraction after sessions end.
+- The SessionEnd hook captures the full transcript and runs deep extraction when the session terminates.
 - You do NOT need to store everything manually — focus on in-conversation corrections and explicit preferences.
 - The background extractor handles: personal facts, preferences, decisions, temporal facts, and technical context.
 

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -797,7 +797,7 @@ def _run_install(args):
     Hooks installed:
     - SessionStart: injects relevant memories as additionalContext
     - UserPromptSubmit: buffers user messages (kept for future use)
-    - Stop: triggers background fact extraction after each session
+    - SessionEnd: triggers background fact extraction when the session terminates
     - PreCompact: saves context snapshot before Claude compresses conversation
 
     Note: the event is named ``PreCompact`` in Claude Code's settings.json
@@ -815,7 +815,7 @@ def _run_install(args):
     hook_files = {
         "SessionStart": hooks_dir / "session_start.py",
         "UserPromptSubmit": hooks_dir / "user_prompt_submit.py",
-        "Stop": hooks_dir / "stop.py",
+        "SessionEnd": hooks_dir / "stop.py",
         "PreCompact": hooks_dir / "compact.py",
     }
     missing = [name for name, path in hook_files.items() if not path.exists()]
@@ -1096,7 +1096,7 @@ def _run_status(args):
         try:
             settings = json.loads(settings_path.read_text(encoding="utf-8"))
             hooks = settings.get("hooks", {})
-            expected = ["SessionStart", "UserPromptSubmit", "Stop", "PreCompact"]
+            expected = ["SessionStart", "UserPromptSubmit", "SessionEnd", "PreCompact"]
             installed = []
             missing = []
             for event in expected:


### PR DESCRIPTION
## Summary

Re-submission of PR #355 (closed 2026-05-22 without merge during the same hour as a 9-PR mass merge — likely an inadvertent close, no superseding PR has landed). The original change is small and well-scoped; resubmitting unchanged.

The Claude Code adapter wires `stop.py` to the per-turn `Stop` event instead of the per-session `SessionEnd` event. Per [Claude Code's hook docs](https://code.claude.com/docs/en/hooks): `Stop` fires once per assistant response; `SessionEnd` fires once per session terminate. Result on the current installer: every turn triggers an ingest spawn — the 20/hr budget + 2-process spawn cap prevent runaway, but produces visible ingest spam on chatty sessions, most of which then no-op via the size-dedup gate but still pay the `python.exe` spawn cost.

The Gemini adapter at `truememory/hooks/adapters/gemini.py:27` already uses `SessionEnd` correctly — this brings the Claude adapter in line with that pattern. Codex (`adapters/codex.py:30`) and Kimi (`adapters/kimi.py:30`) intentionally untouched — they correctly use `Stop` per their own CLI specs.

## Changes

| File | Change |
|---|---|
| `truememory/ingest/cli.py:794` | docstring narrative: Stop → SessionEnd |
| `truememory/ingest/cli.py:812` | installer event key: `"Stop"` → `"SessionEnd"` (the bug) |
| `truememory/ingest/cli.py:1086` | expected-events health check list |
| `truememory/ingest/CLAUDE_TEMPLATE.md:36` | user-facing narrative |
| `docs/architecture.md:43` | architecture doc + brief Stop-vs-SessionEnd clarification |
| `install.sh:15` | install-script comment listing events |

## Test plan

- [ ] Fresh install on Claude Code → `truememory-ingest status` shows `Hooks installed: SessionStart, UserPromptSubmit, SessionEnd, PreCompact`
- [ ] Verify `~/.claude/settings.json` contains a `"SessionEnd"` block pointing at `stop.py`
- [ ] Run multi-turn session in Claude Code → confirm NO ingest spawns mid-session
- [ ] Quit the session → confirm exactly 1 ingest spawn fires
- [ ] Codex + Kimi installs unchanged (still on `Stop`)

## Runtime confirmation

Hunter's machine has been running with manually-patched `SessionEnd` for the past several days — zero issues, ingest spam gone, salience signals still flow correctly on chat-end. This fix would make the same behavior the default for everyone else.
