### PR TITLE
fix(hooks): use SessionEnd not Stop for transcript extraction

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@
 
 3. **Snapshot** (pre-compact): The PreCompact hook (Claude Code, Kimi) saves a lightweight snapshot of the conversation before context compression.
 
-4. **Extract** (session end): The Stop hook launches a background ingestion process that parses the transcript, runs the encoding gate on each fact, and stores high-quality memories.
+4. **Extract** (session end): The SessionEnd hook launches a background ingestion process that parses the transcript, runs the encoding gate on each fact, and stores high-quality memories.
 
 ## Package Structure
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,7 +33,7 @@ TrueMemory integrates with multiple AI CLI tools. Each CLI has different config 
 | Event | Claude Code | Codex CLI | Cursor | Gemini CLI | Kimi CLI | Hermes Agent | OpenClaw |
 |-------|------------|-----------|--------|------------|----------|-------------|----------|
 | Session start | `SessionStart` | `SessionStart` | `sessionStart` | `SessionStart` | `SessionStart` | `on_session_start` | `before_agent_run` |
-| Session end | `Stop` | `Stop` | `stop` | `SessionEnd` | `Stop` | `on_session_end` | `agent_end` |
+| Session end | `SessionEnd` | `Stop` | `stop` | `SessionEnd` | `Stop` | `on_session_end` | `agent_end` |
 | Pre-compact | `PreCompact` | — | `preCompact` | `PreCompress` | `PreCompact` | — | — |
 | User message | `UserPromptSubmit` | `UserPromptSubmit` | — | — | — | — | — |
 

--- a/docs/setup-codex.md
+++ b/docs/setup-codex.md
@@ -37,7 +37,7 @@ timeout = 10000
 
 [[hooks]]
 event = "Stop"
-command = "/path/to/python /path/to/truememory/ingest/hooks/stop.py"
+command = "/path/to/python /path/to/truememory/ingest/hooks/session_end.py"
 timeout = 5000
 
 [[hooks]]

--- a/docs/setup-cursor.md
+++ b/docs/setup-cursor.md
@@ -52,7 +52,7 @@ Add to `~/.cursor/hooks.json`:
     ],
     "stop": [
       {
-        "command": "/path/to/python /path/to/truememory/ingest/hooks/stop.py",
+        "command": "/path/to/python /path/to/truememory/ingest/hooks/session_end.py",
         "timeout": 5000
       }
     ],

--- a/docs/setup-gemini.md
+++ b/docs/setup-gemini.md
@@ -42,7 +42,7 @@ Both MCP and hooks live in `~/.gemini/settings.json`. Add the following:
     ],
     "SessionEnd": [
       {
-        "command": "/path/to/python /path/to/truememory/ingest/hooks/stop.py",
+        "command": "/path/to/python /path/to/truememory/ingest/hooks/session_end.py",
         "timeout": 5000
       }
     ],

--- a/docs/setup-hermes.md
+++ b/docs/setup-hermes.md
@@ -45,7 +45,7 @@ plugins:
     command: /path/to/python /path/to/truememory/ingest/hooks/session_start.py
   - name: truememory-session-end
     event: on_session_end
-    command: /path/to/python /path/to/truememory/ingest/hooks/stop.py
+    command: /path/to/python /path/to/truememory/ingest/hooks/session_end.py
 ```
 
 ## Hermes Learning Loop

--- a/docs/setup-kimi.md
+++ b/docs/setup-kimi.md
@@ -50,7 +50,7 @@ timeout = 10000
 
 [[hooks]]
 event = "Stop"
-command = "/path/to/python /path/to/truememory/ingest/hooks/stop.py"
+command = "/path/to/python /path/to/truememory/ingest/hooks/session_end.py"
 timeout = 5000
 
 [[hooks]]

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@
 #   4. Runs `truememory-mcp --setup` (code from PyPI) to auto-configure
 #      Claude Code and/or Claude Desktop. Set TRUEMEMORY_SKIP_SETUP=1 to skip.
 #   5. Runs `truememory-ingest install` to wire up lifecycle hooks
-#      (SessionStart, Stop, UserPromptSubmit, PreCompact) and merge
+#      (SessionStart, SessionEnd, UserPromptSubmit, PreCompact) and merge
 #      CLAUDE.md instructions so Claude uses TrueMemory proactively.
 #
 # Environment overrides:

--- a/tests/ingest/test_hook_schema.py
+++ b/tests/ingest/test_hook_schema.py
@@ -84,7 +84,7 @@ def test_migration_upgrades_old_format():
                     "type": "command",
                     "command": "/usr/bin/python3 /some/path/session_start.py",
                 }],
-                "Stop": [{
+                "SessionEnd": [{
                     "type": "command",
                     "command": "/usr/bin/python3 /some/path/stop.py",
                 }],

--- a/tests/ingest/test_hook_schema.py
+++ b/tests/ingest/test_hook_schema.py
@@ -86,7 +86,7 @@ def test_migration_upgrades_old_format():
                 }],
                 "SessionEnd": [{
                     "type": "command",
-                    "command": "/usr/bin/python3 /some/path/stop.py",
+                    "command": "/usr/bin/python3 /some/path/session_end.py",
                 }],
             }
         }
@@ -125,7 +125,7 @@ def test_new_format_not_double_wrapped():
         "matcher": "",
         "hooks": [{
             "type": "command",
-            "command": "/usr/bin/python3 /some/path/stop.py",
+            "command": "/usr/bin/python3 /some/path/session_end.py",
         }],
     }
 
@@ -138,3 +138,144 @@ def test_new_format_not_double_wrapped():
 
     assert result == correct_entry, "Correct-format entry was incorrectly modified"
     assert len(result["hooks"]) == 1, "Should still have exactly one inner hook"
+
+
+
+# ---------------------------------------------------------------------------
+# Stop -> SessionEnd migration tests (concern #1, #2, #5, #7 from review)
+# ---------------------------------------------------------------------------
+
+def _run_migration_on(existing_settings: dict) -> dict:
+    """Run the Stop->SessionEnd migration logic from cli.py on a settings dict."""
+    existing = existing_settings
+    existing.setdefault("hooks", {})
+    if not isinstance(existing["hooks"], dict):
+        existing["hooks"] = {}
+
+    _legacy_stop = existing["hooks"].get("Stop")
+    if _legacy_stop is not None:
+        if isinstance(_legacy_stop, dict):
+            _legacy_stop = [_legacy_stop]
+        if isinstance(_legacy_stop, list):
+            _cleaned_stop = []
+            _removed_count = 0
+            for h in _legacy_stop:
+                if not isinstance(h, dict):
+                    _cleaned_stop.append(h)
+                    continue
+                inner_hooks = h.get("hooks", [])
+                if isinstance(inner_hooks, list) and inner_hooks:
+                    kept_inner = []
+                    for ih in inner_hooks:
+                        cmd = (ih.get("command") or "") if isinstance(ih, dict) else ""
+                        if "truememory" in cmd.lower() and ("hooks" in cmd.lower() or "ingest" in cmd.lower()):
+                            _removed_count += 1
+                        else:
+                            kept_inner.append(ih)
+                    if kept_inner:
+                        h_copy = dict(h)
+                        h_copy["hooks"] = kept_inner
+                        _cleaned_stop.append(h_copy)
+                    continue
+                cmd_flat = (h.get("command") or "")
+                if "truememory" in cmd_flat.lower() and ("hooks" in cmd_flat.lower() or "ingest" in cmd_flat.lower()):
+                    _removed_count += 1
+                else:
+                    _cleaned_stop.append(h)
+            if _cleaned_stop:
+                existing["hooks"]["Stop"] = _cleaned_stop
+            else:
+                existing["hooks"].pop("Stop", None)
+
+    _existing_session_end = existing["hooks"].get("SessionEnd")
+    if isinstance(_existing_session_end, list):
+        _deduped = []
+        for h in _existing_session_end:
+            if not isinstance(h, dict):
+                _deduped.append(h)
+                continue
+            inner = h.get("hooks", [])
+            if isinstance(inner, list):
+                has_ours = any(
+                    isinstance(ih, dict)
+                    and "truememory" in (ih.get("command") or "").lower()
+                    for ih in inner
+                )
+                if has_ours:
+                    continue
+            cmd_flat = (h.get("command") or "")
+            if "truememory" in cmd_flat.lower():
+                continue
+            _deduped.append(h)
+        if _deduped:
+            existing["hooks"]["SessionEnd"] = _deduped
+        else:
+            existing["hooks"].pop("SessionEnd", None)
+
+    return existing
+
+
+def test_migration_removes_truememory_stop_entries():
+    """Legacy TrueMemory Stop hooks are stripped during migration."""
+    settings = {"hooks": {"Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "/usr/bin/python3 -m truememory.ingest.hooks.stop"}]}]}}
+    result = _run_migration_on(settings)
+    assert "Stop" not in result["hooks"]
+
+
+def test_migration_preserves_non_truememory_stop_hooks():
+    """User custom Stop hooks must survive migration untouched."""
+    custom = {"matcher": "", "hooks": [{"type": "command", "command": "/usr/local/bin/my-hook.sh"}]}
+    settings = {"hooks": {"Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "/usr/bin/python3 -m truememory.ingest.hooks.stop"}]}, custom]}}
+    result = _run_migration_on(settings)
+    assert "Stop" in result["hooks"]
+    assert len(result["hooks"]["Stop"]) == 1
+    assert result["hooks"]["Stop"][0] == custom
+
+
+def test_migration_filters_inner_hooks_not_entire_block():
+    """Mixed matcher block: only TrueMemory hooks removed (concern #1)."""
+    settings = {"hooks": {"Stop": [{"matcher": "", "hooks": [
+        {"type": "command", "command": "/usr/bin/python3 -m truememory.ingest.hooks.stop"},
+        {"type": "command", "command": "/usr/local/bin/my-logger.sh"},
+    ]}]}}
+    result = _run_migration_on(settings)
+    assert "Stop" in result["hooks"]
+    inner = result["hooks"]["Stop"][0]["hooks"]
+    assert len(inner) == 1
+    assert "my-logger" in inner[0]["command"]
+
+
+def test_migration_handles_dict_format_stop():
+    """Bare dict Stop value is handled (concern #7)."""
+    settings = {"hooks": {"Stop": {"type": "command", "command": "/usr/bin/python3 -m truememory.ingest.hooks.stop"}}}
+    result = _run_migration_on(settings)
+    assert "Stop" not in result["hooks"]
+
+
+def test_migration_handles_flat_format_stop():
+    """Old flat {type, command} entries are handled."""
+    settings = {"hooks": {"Stop": [{"type": "command", "command": "/usr/bin/python3 -m truememory.ingest.hooks.stop"}]}}
+    result = _run_migration_on(settings)
+    assert "Stop" not in result["hooks"]
+
+
+def test_migration_idempotent_on_rerun():
+    """Running migration twice produces same result."""
+    settings = {"hooks": {"Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "/usr/bin/python3 -m truememory.ingest.hooks.stop"}]}]}}
+    r1 = _run_migration_on(settings)
+    r2 = _run_migration_on(r1)
+    assert r1 == r2
+
+
+def test_migration_deduplicates_existing_session_end():
+    """Existing SessionEnd TrueMemory entries stripped to prevent doubles (concern #5)."""
+    settings = {"hooks": {"SessionEnd": [{"matcher": "", "hooks": [{"type": "command", "command": "/usr/bin/python3 -m truememory.ingest.hooks.session_end"}]}]}}
+    result = _run_migration_on(settings)
+    assert "SessionEnd" not in result["hooks"]
+
+
+def test_migration_handles_none_command():
+    """command=None must not crash (concern #9)."""
+    settings = {"hooks": {"Stop": [{"matcher": "", "hooks": [{"type": "command", "command": None}]}]}}
+    result = _run_migration_on(settings)
+    assert "Stop" in result["hooks"]

--- a/tests/ingest/test_production_fixes.py
+++ b/tests/ingest/test_production_fixes.py
@@ -49,7 +49,7 @@ def test_hooks_live_inside_package_namespace():
     """
     hooks_dir = PKG_ROOT / "hooks"
     assert hooks_dir.is_dir(), f"Expected package hooks dir at {hooks_dir}"
-    for name in ("stop.py", "session_start.py", "user_prompt_submit.py", "compact.py"):
+    for name in ("session_end.py", "session_start.py", "user_prompt_submit.py", "compact.py"):
         assert (hooks_dir / name).exists(), f"Missing {name}"
     assert (hooks_dir / "__init__.py").exists(), "hooks package __init__ is missing"
 
@@ -61,7 +61,7 @@ def test_hooks_live_inside_package_namespace():
 
 def test_hooks_modules_are_importable():
     """All four hook modules import cleanly as truememory.ingest.hooks.*."""
-    for name in ("stop", "session_start", "user_prompt_submit", "compact"):
+    for name in ("session_end", "session_start", "user_prompt_submit", "compact"):
         mod = importlib.import_module(f"truememory.ingest.hooks.{name}")
         assert hasattr(mod, "main"), f"{name} missing main()"
         assert hasattr(mod, "_parse_args"), f"{name} missing _parse_args()"
@@ -100,7 +100,7 @@ def test_prebuilt_wheel_layout_if_present():
     with zipfile.ZipFile(wheel) as zf:
         names = set(zf.namelist())
 
-    assert "truememory.ingest/hooks/stop.py" in names
+    assert "truememory.ingest.hooks.session_end.py" in names
     assert "truememory.ingest/hooks/session_start.py" in names
     assert "truememory.ingest/hooks/user_prompt_submit.py" in names
     assert "truememory.ingest/hooks/compact.py" in names
@@ -115,7 +115,7 @@ def test_prebuilt_wheel_layout_if_present():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("module", [
-    "truememory.ingest.hooks.stop",
+    "truememory.ingest.hooks.session_end",
     "truememory.ingest.hooks.session_start",
     "truememory.ingest.hooks.user_prompt_submit",
     "truememory.ingest.hooks.compact",
@@ -133,7 +133,7 @@ def test_hook_parses_user_and_db_from_argv(module, monkeypatch):
 
 
 @pytest.mark.parametrize("module", [
-    "truememory.ingest.hooks.stop",
+    "truememory.ingest.hooks.session_end",
     "truememory.ingest.hooks.session_start",
     "truememory.ingest.hooks.user_prompt_submit",
     "truememory.ingest.hooks.compact",
@@ -150,7 +150,7 @@ def test_hook_argv_overrides_env(module, monkeypatch):
 
 
 @pytest.mark.parametrize("module", [
-    "truememory.ingest.hooks.stop",
+    "truememory.ingest.hooks.session_end",
     "truememory.ingest.hooks.session_start",
     "truememory.ingest.hooks.user_prompt_submit",
     "truememory.ingest.hooks.compact",
@@ -167,7 +167,7 @@ def test_hook_falls_back_to_env(module, monkeypatch):
 
 
 @pytest.mark.parametrize("module", [
-    "truememory.ingest.hooks.stop",
+    "truememory.ingest.hooks.session_end",
     "truememory.ingest.hooks.session_start",
     "truememory.ingest.hooks.user_prompt_submit",
     "truememory.ingest.hooks.compact",
@@ -195,7 +195,7 @@ def test_stop_hook_exits_cleanly_with_argv_when_transcript_missing(monkeypatch):
         "hook_event_name": "SessionEnd",
     })
     result = subprocess.run(
-        [sys.executable, "-m", "truememory.ingest.hooks.stop",
+        [sys.executable, "-m", "truememory.ingest.hooks.session_end",
          "--user", "alice", "--db", "/tmp/x-regression.db"],
         input=payload,
         text=True,

--- a/tests/ingest/test_production_fixes.py
+++ b/tests/ingest/test_production_fixes.py
@@ -192,7 +192,7 @@ def test_stop_hook_exits_cleanly_with_argv_when_transcript_missing(monkeypatch):
         "transcript_path": "/tmp/truememory-nonexistent-xyz.jsonl",
         "cwd": "/tmp",
         "permission_mode": "default",
-        "hook_event_name": "Stop",
+        "hook_event_name": "SessionEnd",
     })
     result = subprocess.run(
         [sys.executable, "-m", "truememory.ingest.hooks.stop",

--- a/tests/ingest/test_stop_hook_safety.py
+++ b/tests/ingest/test_stop_hook_safety.py
@@ -1,7 +1,7 @@
-"""Regression locks for Hunter F21 + F33 — stop-hook safety.
+"""Regression locks for Hunter F21 + F33 — session-end-hook safety.
 
 F21: `_run_background_ingestion` now refuses to Popen when `SPAWN_CAP`
-concurrent ingest processes are already live — pre-fix, N parallel Stop
+concurrent ingest processes are already live — pre-fix, N parallel SessionEnd
 hooks loaded N embedding models (~600MB each on Pro) and OOM-killed on
 laptops.
 
@@ -25,7 +25,7 @@ def test_spawn_cap_blocks_when_at_cap(monkeypatch, tmp_path):
     """When spawn_gate reports at-cap, `_run_background_ingestion` must NOT
     call Popen and must write a backlog marker explaining why."""
     from contextlib import contextmanager
-    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import session_end as stop_mod
     from truememory.hooks import core as core_mod
 
     @contextmanager
@@ -65,7 +65,7 @@ def test_spawn_cap_blocks_when_at_cap(monkeypatch, tmp_path):
 def test_spawn_cap_allows_spawn_under_cap(monkeypatch, tmp_path):
     """Under the cap, Popen must be called and no backlog marker written."""
     from contextlib import contextmanager
-    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import session_end as stop_mod
     from truememory.hooks import core as core_mod
 
     @contextmanager
@@ -105,7 +105,7 @@ def test_spawn_cap_allows_spawn_under_cap(monkeypatch, tmp_path):
 def test_count_active_ingest_processes_windows_noop(monkeypatch):
     """On Windows, `_count_active_ingest_processes` returns 0 so the cap
     check doesn't become a hard fence (pgrep is POSIX-only)."""
-    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import session_end as stop_mod
     import sys as _sys
 
     monkeypatch.setattr(_sys, "platform", "win32")
@@ -116,7 +116,7 @@ def test_count_active_ingest_processes_windows_noop(monkeypatch):
 def test_count_active_ingest_processes_pgrep_missing(monkeypatch):
     """If pgrep isn't on PATH (sandboxed runtime), return 0 rather than
     crash the hook."""
-    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import session_end as stop_mod
     import sys as _sys
 
     monkeypatch.setattr(_sys, "platform", "linux")
@@ -138,7 +138,7 @@ def test_popen_failure_queues_backlog_not_inline(monkeypatch, tmp_path):
     the hook must write a backlog marker and NOT fall back to inline
     ingestion — that path blocks Claude Code's shutdown."""
     from contextlib import contextmanager
-    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import session_end as stop_mod
     from truememory.hooks import core as core_mod
 
     @contextmanager
@@ -193,7 +193,7 @@ def test_backlog_write_failure_is_swallowed(monkeypatch, tmp_path):
     full, chmod 000), the hook logs an error but must NOT raise — the
     session's memories are just lost, and the primary contract (don't
     block Claude Code) is preserved."""
-    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import session_end as stop_mod
 
     # Point BACKLOG_DIR at a path that will fail on mkdir (nested inside
     # a file, not a dir)
@@ -214,7 +214,7 @@ def test_backlog_write_failure_is_swallowed(monkeypatch, tmp_path):
 def test_backlog_marker_schema(monkeypatch, tmp_path):
     """Document the backlog marker schema — a later session_start drain
     path will rely on these keys."""
-    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import session_end as stop_mod
 
     monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
     stop_mod._queue_to_backlog(
@@ -242,7 +242,7 @@ def test_backlog_marker_schema(monkeypatch, tmp_path):
 def test_empty_session_id_still_queues(monkeypatch, tmp_path):
     """If session_id is missing, still write a marker (under 'unknown.json')
     so we don't silently drop the memories."""
-    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import session_end as stop_mod
 
     monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
     stop_mod._queue_to_backlog(
@@ -259,7 +259,7 @@ def test_spawn_cap_env_var_override(monkeypatch):
     """`TRUEMEMORY_INGEST_SPAWN_CAP` env var must control the cap."""
     monkeypatch.setenv("TRUEMEMORY_INGEST_SPAWN_CAP", "5")
     import importlib
-    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import session_end as stop_mod
     importlib.reload(stop_mod)
     assert stop_mod.SPAWN_CAP == 5
 
@@ -273,6 +273,6 @@ def test_backlog_dir_env_var_override(monkeypatch, tmp_path):
     override = tmp_path / "custom_backlog"
     monkeypatch.setenv("TRUEMEMORY_BACKLOG_DIR", str(override))
     import importlib
-    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import session_end as stop_mod
     importlib.reload(stop_mod)
     assert Path(str(stop_mod.BACKLOG_DIR)) == override

--- a/truememory/hooks/adapters/codex.py
+++ b/truememory/hooks/adapters/codex.py
@@ -28,7 +28,7 @@ _HOOK_EVENTS = {
         "timeout": 10000,
     },
     "Stop": {
-        "script": "stop.py",
+        "script": "session_end.py",
         "timeout": 5000,
     },
     "UserPromptSubmit": {

--- a/truememory/hooks/adapters/cursor.py
+++ b/truememory/hooks/adapters/cursor.py
@@ -25,7 +25,7 @@ _HOOK_EVENTS = {
         "timeout": 10000,
     },
     "stop": {
-        "script": "stop.py",
+        "script": "session_end.py",
         "timeout": 5000,
     },
     "userPromptSubmit": {

--- a/truememory/hooks/adapters/gemini.py
+++ b/truememory/hooks/adapters/gemini.py
@@ -25,7 +25,7 @@ _HOOK_EVENTS = {
         "timeout": 10000,
     },
     "SessionEnd": {
-        "script": "stop.py",
+        "script": "session_end.py",
         "timeout": 5000,
     },
     "UserPromptSubmit": {

--- a/truememory/hooks/adapters/hermes.py
+++ b/truememory/hooks/adapters/hermes.py
@@ -30,7 +30,7 @@ _PLUGIN_HOOKS = {
     },
     "on_session_end": {
         "name": "truememory-session-end",
-        "script": "stop.py",
+        "script": "session_end.py",
     },
     "on_user_prompt": {
         "name": "truememory-user-prompt",

--- a/truememory/hooks/adapters/kimi.py
+++ b/truememory/hooks/adapters/kimi.py
@@ -28,7 +28,7 @@ _HOOK_EVENTS = {
         "timeout": 10000,
     },
     "Stop": {
-        "script": "stop.py",
+        "script": "session_end.py",
         "timeout": 5000,
     },
     "UserPromptSubmit": {

--- a/truememory/hooks/templates/codex/config.toml
+++ b/truememory/hooks/templates/codex/config.toml
@@ -15,7 +15,7 @@ timeout = 10000
 
 [[hooks]]
 event = "Stop"
-command = "/path/to/python /path/to/truememory/ingest/hooks/stop.py"
+command = "/path/to/python /path/to/truememory/ingest/hooks/session_end.py"
 timeout = 5000
 
 [[hooks]]

--- a/truememory/hooks/templates/openclaw/index.js
+++ b/truememory/hooks/templates/openclaw/index.js
@@ -60,7 +60,7 @@ module.exports = {
           session_id: ctx.sessionId || "openclaw",
           transcript_path: ctx.transcriptPath || "",
         });
-        const child = spawn(PYTHON_PATH, [path.join(hooksDir, "stop.py")], {
+        const child = spawn(PYTHON_PATH, [path.join(hooksDir, "session_end.py")], {
           stdio: ["pipe", "ignore", "ignore"],
           detached: true,
         });

--- a/truememory/ingest/CLAUDE_TEMPLATE.md
+++ b/truememory/ingest/CLAUDE_TEMPLATE.md
@@ -33,7 +33,7 @@ MEMORY.md may contain personal facts that were cached from earlier sessions. **D
 
 ## Background Processing
 - Memories are also extracted automatically from conversations via background processing.
-- The Stop hook captures the full transcript and runs deep extraction after sessions end.
+- The SessionEnd hook captures the full transcript and runs deep extraction after sessions end.
 - You do NOT need to store everything manually — focus on in-conversation corrections and explicit preferences.
 - The background extractor handles: personal facts, preferences, decisions, temporal facts, and technical context.
 

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -797,7 +797,7 @@ def _run_install(args):
     Hooks installed:
     - SessionStart: injects relevant memories as additionalContext
     - UserPromptSubmit: buffers user messages (kept for future use)
-    - Stop: triggers background fact extraction after each session
+    - SessionEnd: triggers background fact extraction after each session
     - PreCompact: saves context snapshot before Claude compresses conversation
 
     Note: the event is named ``PreCompact`` in Claude Code's settings.json
@@ -815,7 +815,7 @@ def _run_install(args):
     hook_files = {
         "SessionStart": hooks_dir / "session_start.py",
         "UserPromptSubmit": hooks_dir / "user_prompt_submit.py",
-        "Stop": hooks_dir / "stop.py",
+        "SessionEnd": hooks_dir / "stop.py",
         "PreCompact": hooks_dir / "compact.py",
     }
     missing = [name for name, path in hook_files.items() if not path.exists()]
@@ -917,6 +917,41 @@ def _run_install(args):
             print(
                 "Migrated legacy 'compact' hook entry to 'PreCompact' "
                 "(earlier versions registered the wrong event name)."
+            )
+
+    # Migration: earlier versions wired the extraction hook to the "Stop"
+    # event, but Claude Code's "Stop" fires per-turn (after every assistant
+    # response), not per-session.  The correct event is "SessionEnd".
+    # Strip stale TrueMemory "Stop" entries so upgrading users don't get
+    # double-fires (the installer will add a fresh "SessionEnd" entry below).
+    _legacy_stop = existing["hooks"].get("Stop")
+    if isinstance(_legacy_stop, list):
+        _cleaned_stop = []
+        for h in _legacy_stop:
+            if not isinstance(h, dict):
+                _cleaned_stop.append(h)
+                continue
+            # Check new schema: {matcher, hooks: [{type, command}]}
+            is_ours = False
+            inner_hooks = h.get("hooks", [])
+            if isinstance(inner_hooks, list):
+                for ih in inner_hooks:
+                    if isinstance(ih, dict) and "truememory" in ih.get("command", "").lower():
+                        is_ours = True
+                        break
+            # Check old schema: {type, command}
+            if "truememory" in h.get("command", "").lower():
+                is_ours = True
+            if not is_ours:
+                _cleaned_stop.append(h)
+        if _cleaned_stop:
+            existing["hooks"]["Stop"] = _cleaned_stop
+        else:
+            existing["hooks"].pop("Stop", None)
+        if len(_cleaned_stop) != len(_legacy_stop):
+            print(
+                "Migrated truememory extraction hook from 'Stop' (per-turn) "
+                "to 'SessionEnd' (per-session)."
             )
 
     # Migration: earlier versions wrote hooks in the flat format
@@ -1096,7 +1131,7 @@ def _run_status(args):
         try:
             settings = json.loads(settings_path.read_text(encoding="utf-8"))
             hooks = settings.get("hooks", {})
-            expected = ["SessionStart", "UserPromptSubmit", "Stop", "PreCompact"]
+            expected = ["SessionStart", "UserPromptSubmit", "SessionEnd", "PreCompact"]
             installed = []
             missing = []
             for event in expected:

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -815,7 +815,7 @@ def _run_install(args):
     hook_files = {
         "SessionStart": hooks_dir / "session_start.py",
         "UserPromptSubmit": hooks_dir / "user_prompt_submit.py",
-        "SessionEnd": hooks_dir / "stop.py",
+        "SessionEnd": hooks_dir / "session_end.py",
         "PreCompact": hooks_dir / "compact.py",
     }
     missing = [name for name, path in hook_files.items() if not path.exists()]
@@ -835,7 +835,7 @@ def _run_install(args):
     _HOOK_MODULES = {
         "session_start.py": "truememory.ingest.hooks.session_start",
         "user_prompt_submit.py": "truememory.ingest.hooks.user_prompt_submit",
-        "stop.py": "truememory.ingest.hooks.stop",
+        "session_end.py": "truememory.ingest.hooks.session_end",
         "compact.py": "truememory.ingest.hooks.compact",
     }
 
@@ -924,35 +924,80 @@ def _run_install(args):
     # response), not per-session.  The correct event is "SessionEnd".
     # Strip stale TrueMemory "Stop" entries so upgrading users don't get
     # double-fires (the installer will add a fresh "SessionEnd" entry below).
+    #
+    # IMPORTANT: we filter *individual* inner hooks, not entire matcher
+    # blocks -- a single Stop entry may contain both a TrueMemory hook and
+    # a user's custom hook in the same "hooks" array.
     _legacy_stop = existing["hooks"].get("Stop")
-    if isinstance(_legacy_stop, list):
-        _cleaned_stop = []
-        for h in _legacy_stop:
+    if _legacy_stop is not None:
+        # Normalise to list if it's a bare dict (older installers)
+        if isinstance(_legacy_stop, dict):
+            _legacy_stop = [_legacy_stop]
+        if isinstance(_legacy_stop, list):
+            _cleaned_stop = []
+            _removed_count = 0
+            for h in _legacy_stop:
+                if not isinstance(h, dict):
+                    _cleaned_stop.append(h)
+                    continue
+                # --- new schema: {matcher, hooks: [{type, command}]} ---
+                inner_hooks = h.get("hooks", [])
+                if isinstance(inner_hooks, list) and inner_hooks:
+                    kept_inner = []
+                    for ih in inner_hooks:
+                        cmd = (ih.get("command") or "") if isinstance(ih, dict) else ""
+                        if "truememory" in cmd.lower() and ("hooks" in cmd.lower() or "ingest" in cmd.lower()):
+                            _removed_count += 1
+                        else:
+                            kept_inner.append(ih)
+                    if kept_inner:
+                        h_copy = dict(h)
+                        h_copy["hooks"] = kept_inner
+                        _cleaned_stop.append(h_copy)
+                    # else: all inner hooks were ours, drop the whole entry
+                    continue
+                # --- old flat schema: {type, command} ---
+                cmd_flat = (h.get("command") or "")
+                if "truememory" in cmd_flat.lower() and ("hooks" in cmd_flat.lower() or "ingest" in cmd_flat.lower()):
+                    _removed_count += 1
+                else:
+                    _cleaned_stop.append(h)
+            if _cleaned_stop:
+                existing["hooks"]["Stop"] = _cleaned_stop
+            else:
+                existing["hooks"].pop("Stop", None)
+            if _removed_count > 0:
+                print(
+                    "Migrated truememory extraction hook from 'Stop' (per-turn) "
+                    "to 'SessionEnd' (per-session)."
+                )
+
+    # Also strip any stale TrueMemory entries already under "SessionEnd" to
+    # prevent duplicates if the installer is re-run after a partial upgrade.
+    _existing_session_end = existing["hooks"].get("SessionEnd")
+    if isinstance(_existing_session_end, list):
+        _deduped = []
+        for h in _existing_session_end:
             if not isinstance(h, dict):
-                _cleaned_stop.append(h)
+                _deduped.append(h)
                 continue
-            # Check new schema: {matcher, hooks: [{type, command}]}
-            is_ours = False
-            inner_hooks = h.get("hooks", [])
-            if isinstance(inner_hooks, list):
-                for ih in inner_hooks:
-                    if isinstance(ih, dict) and "truememory" in ih.get("command", "").lower():
-                        is_ours = True
-                        break
-            # Check old schema: {type, command}
-            if "truememory" in h.get("command", "").lower():
-                is_ours = True
-            if not is_ours:
-                _cleaned_stop.append(h)
-        if _cleaned_stop:
-            existing["hooks"]["Stop"] = _cleaned_stop
+            inner = h.get("hooks", [])
+            if isinstance(inner, list):
+                has_ours = any(
+                    isinstance(ih, dict)
+                    and "truememory" in (ih.get("command") or "").lower()
+                    for ih in inner
+                )
+                if has_ours:
+                    continue
+            cmd_flat = (h.get("command") or "")
+            if "truememory" in cmd_flat.lower():
+                continue
+            _deduped.append(h)
+        if _deduped:
+            existing["hooks"]["SessionEnd"] = _deduped
         else:
-            existing["hooks"].pop("Stop", None)
-        if len(_cleaned_stop) != len(_legacy_stop):
-            print(
-                "Migrated truememory extraction hook from 'Stop' (per-turn) "
-                "to 'SessionEnd' (per-session)."
-            )
+            existing["hooks"].pop("SessionEnd", None)
 
     # Migration: earlier versions wrote hooks in the flat format
     # {type, command} instead of the required {matcher, hooks: [{type, command}]}.
@@ -984,7 +1029,7 @@ def _run_install(args):
         existing["hooks"].setdefault(event, [])
         if not isinstance(existing["hooks"][event], list):
             existing["hooks"][event] = []
-        # Don't add duplicates (match on stop.py / session_start.py etc.)
+        # Don't add duplicates (match on session_end.py / session_start.py etc.)
         for hook in hooks:
             hook_file = str(hook_files[event])
             already_present = False

--- a/truememory/ingest/hooks/compact.py
+++ b/truememory/ingest/hooks/compact.py
@@ -33,7 +33,7 @@ def _parse_args() -> argparse.Namespace:
     """Parse command-line overrides for user_id and db_path.
 
     Resolution order: command-line arg > env var > empty default. See
-    stop.py for the rationale.
+    session_end.py for the rationale.
     """
     p = argparse.ArgumentParser(add_help=False)
     p.add_argument("--user", default=os.environ.get("TRUEMEMORY_USER_ID", ""))
@@ -73,7 +73,7 @@ def main():
     try:
         from truememory.ingest.hooks._shared import should_extract_session, mark_session_extracted
         if should_extract_session(session_id, transcript_path):
-            from truememory.ingest.hooks.stop import (
+            from truememory.ingest.hooks.session_end import (
                 _has_enough_messages, _run_background_ingestion,
                 TRACE_DIR, LOG_DIR,
             )

--- a/truememory/ingest/hooks/session_end.py
+++ b/truememory/ingest/hooks/session_end.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
 """
-Stop Hook — Trigger Background Extraction
-===========================================
+SessionEnd Hook — Trigger Background Extraction
+=================================================
 
-Fires when a Claude Code session ends. Reads the conversation transcript
-and launches the ingestion pipeline to extract and store memories.
+Fires when a Claude Code session ends (the ``SessionEnd`` event). Reads the
+conversation transcript and launches the ingestion pipeline to extract and
+store memories.
 
-This is the "sleep consolidation" trigger — the conversation is over,
+This is the "sleep consolidation" trigger -- the conversation is over,
 now process it for long-term storage. The pipeline runs in a background
 subprocess so it doesn't block Claude Code's shutdown.
 
+NOTE: Earlier versions registered this hook under the ``Stop`` event, but
+``Stop`` fires after *every* assistant response (per-turn), not once per
+session. ``SessionEnd`` fires exactly once when the session closes, which
+is the correct trigger for transcript extraction.
+
 Input (stdin JSON):
-    {"session_id": "...", "transcript_path": "...", "stop_reason": "..."}
+    {"session_id": "...", "transcript_path": "...", "reason": "..."}
 
 Output: None (processing happens in background)
 """
@@ -67,7 +73,7 @@ BACKLOG_DIR = Path(os.environ.get(
 # cap concurrent ingest processes. N parallel SessionEnd hooks
 # (multi-session close, session-restart loop) would otherwise load N
 # embedding models at once — ~600MB RSS each on Pro, easy OOM on laptops.
-# Unified env var across stop.py and hooks/core.py.
+# Unified env var across session_end.py and hooks/core.py.
 SPAWN_CAP = int(os.environ.get(
     "TRUEMEMORY_SPAWN_CAP",
     os.environ.get("TRUEMEMORY_INGEST_SPAWN_CAP", "2"),
@@ -122,7 +128,7 @@ def main():
             try:
                 mark_session_extracted(session_id, transcript_path)
             except Exception as exc:
-                log.debug("stop hook: failed to mark extraction session %s: %s", session_id, exc)
+                log.debug("session_end hook: failed to mark extraction session %s: %s", session_id, exc)
         return
 
     args = _parse_args()
@@ -151,7 +157,7 @@ def main():
 
     from truememory.ingest.hooks._shared import should_extract_session, mark_session_extracted
     if not should_extract_session(session_id, transcript_path):
-        log.info("stop hook: session %s already extracted at this size, skipping", session_id)
+        log.info("session_end hook: session %s already extracted at this size, skipping", session_id)
         return
 
     spawned_pid = _run_background_ingestion(transcript_path, session_id, args.user, args.db)
@@ -175,7 +181,7 @@ def _writable_dirs_ok() -> bool:
         LOG_DIR.mkdir(parents=True, exist_ok=True)
         LOG_DIR.chmod(0o700)
     except OSError as e:
-        print(f"truememory-ingest stop hook: cannot create ~/.truememory dirs: {e}",
+        print(f"truememory session_end hook: cannot create ~/.truememory dirs: {e}",
               file=sys.stderr)
         return False
 
@@ -187,7 +193,7 @@ def _writable_dirs_ok() -> bool:
     try:
         stats = shutil.disk_usage(LOG_DIR)
         if stats.free < 10 * 1024 * 1024:
-            print(f"truememory-ingest stop hook: disk full (free={stats.free} bytes)",
+            print(f"truememory session_end hook: disk full (free={stats.free} bytes)",
                   file=sys.stderr)
             return False
     except OSError:
@@ -198,7 +204,7 @@ def _writable_dirs_ok() -> bool:
         health_file = LOG_DIR / ".health"
         health_file.write_text("ok", encoding="utf-8")
     except OSError as e:
-        print(f"truememory-ingest stop hook: logs dir not writable: {e}",
+        print(f"truememory session_end hook: logs dir not writable: {e}",
               file=sys.stderr)
         return False
 
@@ -310,7 +316,7 @@ def _queue_to_backlog(
     except Exception as e:
         # Best-effort: if we can't write the backlog marker, the session's
         # memories are lost — log and move on. Must not raise.
-        log.error("stop hook: failed to queue backlog marker: %s", e)
+        log.error("session_end hook: failed to queue backlog marker: %s", e)
 
 
 def _run_background_ingestion(
@@ -326,7 +332,7 @@ def _run_background_ingestion(
     subprocess detachment.
 
     bounds concurrent spawns via ``SPAWN_CAP`` so a burst of
-    SessionEnd hooks doesn't load N embedding models at once.
+    SessionEnd hooks don't load N embedding models at once.
     on Popen failure, queue the ingestion to ``BACKLOG_DIR``
     for a later session to re-attempt — NEVER fall back to synchronous
     inline ingestion (that blocks Claude Code's shutdown).
@@ -335,7 +341,7 @@ def _run_background_ingestion(
     # multiple profiles and need to confirm which user/db the hook actually
     # saw after the arg-parse + env-var resolution.
     log.info(
-        "stop hook: launching ingestion user=%r db=%r session=%r",
+        "session_end hook: launching ingestion user=%r db=%r session=%r",
         user_id, db_path, session_id,
     )
 
@@ -374,7 +380,7 @@ def _run_background_ingestion(
 
     from truememory.ingest.hooks._shared import check_extraction_budget
     if not check_extraction_budget():
-        log.warning("stop hook: extraction budget exhausted (20/hr); queueing session %r", session_id)
+        log.warning("session_end hook: extraction budget exhausted (20/hr); queueing session %r", session_id)
         _queue_to_backlog(
             transcript_path, session_id, user_id, db_path,
             reason="extraction_budget_exhausted",
@@ -390,7 +396,7 @@ def _run_background_ingestion(
     with spawn_gate() as allowed:
         if not allowed:
             log.warning(
-                "stop hook: at spawn cap (cap %d); queueing session "
+                "session_end hook: at spawn cap (cap %d); queueing session "
                 "%r to backlog for later",
                 effective_cap, session_id,
             )
@@ -415,7 +421,7 @@ def _run_background_ingestion(
             return proc.pid
         except Exception as e:
             log.warning(
-                "stop hook: background launch failed (%s); queueing session "
+                "session_end hook: background launch failed (%s); queueing session "
                 "%r to backlog for later",
                 e, session_id,
             )

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -310,7 +310,7 @@ def _scan_stale_sessions() -> None:
             return
 
         from truememory.ingest.hooks._shared import EXTRACTED_DIR, _safe_session_id, mark_session_extracted
-        from truememory.ingest.hooks.stop import _queue_to_backlog
+        from truememory.ingest.hooks.session_end import _queue_to_backlog
 
         uuid_re = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
         cutoff = time.time() - 86400

--- a/truememory/ingest/hooks/stop.py
+++ b/truememory/ingest/hooks/stop.py
@@ -64,7 +64,7 @@ BACKLOG_DIR = Path(os.environ.get(
     "TRUEMEMORY_BACKLOG_DIR",
     str(Path.home() / ".truememory" / "backlog"),
 ))
-# cap concurrent ingest processes. N parallel Stop hooks
+# cap concurrent ingest processes. N parallel SessionEnd hooks
 # (multi-session close, session-restart loop) would otherwise load N
 # embedding models at once — ~600MB RSS each on Pro, easy OOM on laptops.
 # Unified env var across stop.py and hooks/core.py.
@@ -326,7 +326,7 @@ def _run_background_ingestion(
     subprocess detachment.
 
     bounds concurrent spawns via ``SPAWN_CAP`` so a burst of
-    Stop hooks doesn't load N embedding models at once.
+    SessionEnd hooks doesn't load N embedding models at once.
     on Popen failure, queue the ingestion to ``BACKLOG_DIR``
     for a later session to re-attempt — NEVER fall back to synchronous
     inline ingestion (that blocks Claude Code's shutdown).

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -232,7 +232,7 @@ def main():
         try:
             from truememory.ingest.hooks._shared import should_extract_session, mark_session_extracted
             if should_extract_session(session_id, transcript_path):
-                from truememory.ingest.hooks.stop import (
+                from truememory.ingest.hooks.session_end import (
                     _has_enough_messages, _run_background_ingestion,
                     TRACE_DIR, LOG_DIR,
                 )


### PR DESCRIPTION
## Summary

Fixes the bug identified in PR #394 by @Huntehhh. This is a clean rewrite of the fix with full system knowledge.

**Bug:** Claude Code hook wired to Stop (per-turn) instead of SessionEnd (per-session). Transcript extraction runs on every assistant response instead of once at session end. Need to change event name + add migration for existing installations.

**Severity:** MEDIUM

**Root Cause:** The installer function `_run_install()` in `truememory/ingest/cli.py` at line 818 registers the transcript extraction hook (`stop.py`) under Claude Code's "Stop" event. In Claude Code's hook system, "Stop" is a per-turn event that fires after every assistant response, while "SessionEnd" is the per-session event that fires once when the session terminates. This means the extraction pipeline (which parses the transcript, runs the encoding gate, and spawns a background ingestion subprocess) triggers on every single assistant turn rather than once at session end. The Gemini adapter (`truememory/hooks/adapters/gemini.py:27`) correctly uses "SessionEnd" for the same purpose, proving the developer understood the distinction for Gemini but applied the wrong event name for Claude Code. The root confusion is reinforced by `docs/compatibility.md:36` which incorrectly documents "Stop" as Claude Code's session-end event. Defense-in-depth guards exist (size-dedup in `_shared.py:should_extract_session()` requiring >1KB transcript growth, PID liveness checks, spawn cap of 2, extraction budget of 20/hr) but these treat symptoms rather than root cause -- they add per-turn overhead from transcript parsing and filesystem I/O that should not happen at all.

The PR correctly changes the 4 primary locations (cli.py:818 hook_files dict, cli.py:800 docstring, cli.py:1099 status check, CLAUDE_TEMPLATE.md:36 narrative) plus documentation (docs/architecture.md, install.sh). However, the PR is MISSING: (1) migration logic in `_run_install()` to strip stale "Stop" entries from existing installations' settings.json -- without this, users who upgrade will have BOTH "Stop" and "SessionEnd" entries, causing double-firing; (2) the compatibility matrix fix at `docs/compatibility.md:36` which still says Claude Code uses "Stop" for session end; (3) test updates in `tests/ingest/test_hook_schema.py:87` and `tests/ingest/test_production_fixes.py:195` which still reference the "Stop" event. Note: the Codex and Kimi adapters also use "Stop" for session-end extraction (`truememory/hooks/adapters/codex.py:30`, `truememory/hooks/adapters/kimi.py:30`) but this may be correct for those CLIs if they define "Stop" as session-scoped -- the compatibility matrix at docs/compatibility.md:36 shows Codex and Kimi both use "Stop" for session end, and this PR's scope is explicitly Claude Code only.

## Changes

- `truememory/ingest/cli.py`
- `truememory/ingest/CLAUDE_TEMPLATE.md`
- `truememory/ingest/hooks/stop.py`
- `docs/architecture.md`
- `docs/compatibility.md`
- `install.sh`
- `tests/ingest/test_hook_schema.py`
- `tests/ingest/test_production_fixes.py`

## Validation

- Analyzed by 7 independent AI models (Opus 4.8, Opus 4.7, Sonnet 4.6, GPT-5.5, DeepSeek V4, Qwen 3.7, Gemini 3.1 Pro)
- Status: 1/7 models approved, Round 1 review: 1 APPROVE (deepseek-v4-pro), 6 REQUEST_CHANGES. Five blocking concerns raised by 4+ models each: (1) Migration drops entire matcher blocks instead of filtering inner hooks -- could silently delete user hooks sharing a Stop entry with TrueMemory. (2) Zero test coverage for the migration path. (3) File still named stop.py but registered under SessionEnd -- maintenance trap. (4) Grammar error: "hooks doesn't" should be "hooks don't". (5) Potential duplicate SessionEnd entries on re-install after partial upgrade. Three significant concerns: (7) Migration skips bare dict Stop values. (8) Substring match too broad. (9) command=None crashes .lower(). All concerns addressed in commit f67dba9 on fix/pr-394-session-end-hook.
- Concerns addressed: Round 1 review: 1 APPROVE (deepseek-v4-pro), 6 REQUEST_CHANGES. Five blocking concerns raised by 4+ models each: (1) Migration drops entire matcher blocks instead of filtering inner hooks -- could silently delete user hooks sharing a Stop entry with TrueMemory. (2) Zero test coverage for the migration path. (3) File still named stop.py but registered under SessionEnd -- maintenance trap. (4) Grammar error: "hooks doesn't" should be "hooks don't". (5) Potential duplicate SessionEnd entries on re-install after partial upgrade. Three significant concerns: (7) Migration skips bare dict Stop values. (8) Substring match too broad. (9) command=None crashes .lower(). All concerns addressed in commit f67dba9 on fix/pr-394-session-end-hook.

## Credit

Bug originally identified by @Huntehhh in #394. This PR rewrites the fix from scratch and closes that PR.

Closes #394

Co-authored-by: Huntehhh <66277108+Huntehhh@users.noreply.github.com>