### PR TITLE
fix(hooks): use SessionEnd not Stop for Claude Code transcript extraction

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@
 
 3. **Snapshot** (pre-compact): The PreCompact hook (Claude Code, Kimi) saves a lightweight snapshot of the conversation before context compression.
 
-4. **Extract** (session end): The Stop hook launches a background ingestion process that parses the transcript, runs the encoding gate on each fact, and stores high-quality memories.
+4. **Extract** (session end): The SessionEnd hook launches a background ingestion process that parses the transcript, runs the encoding gate on each fact, and stores high-quality memories.
 
 ## Package Structure
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,7 +33,7 @@ TrueMemory integrates with multiple AI CLI tools. Each CLI has different config 
 | Event | Claude Code | Codex CLI | Cursor | Gemini CLI | Kimi CLI | Hermes Agent | OpenClaw |
 |-------|------------|-----------|--------|------------|----------|-------------|----------|
 | Session start | `SessionStart` | `SessionStart` | `sessionStart` | `SessionStart` | `SessionStart` | `on_session_start` | `before_agent_run` |
-| Session end | `Stop` | `Stop` | `stop` | `SessionEnd` | `Stop` | `on_session_end` | `agent_end` |
+| Session end | `SessionEnd` | `Stop` | `stop` | `SessionEnd` | `Stop` | `on_session_end` | `agent_end` |
 | Pre-compact | `PreCompact` | — | `preCompact` | `PreCompress` | `PreCompact` | — | — |
 | User message | `UserPromptSubmit` | `UserPromptSubmit` | — | — | — | — | — |
 

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@
 #   4. Runs `truememory-mcp --setup` (code from PyPI) to auto-configure
 #      Claude Code and/or Claude Desktop. Set TRUEMEMORY_SKIP_SETUP=1 to skip.
 #   5. Runs `truememory-ingest install` to wire up lifecycle hooks
-#      (SessionStart, Stop, UserPromptSubmit, PreCompact) and merge
+#      (SessionStart, SessionEnd, UserPromptSubmit, PreCompact) and merge
 #      CLAUDE.md instructions so Claude uses TrueMemory proactively.
 #
 # Environment overrides:

--- a/truememory/ingest/CLAUDE_TEMPLATE.md
+++ b/truememory/ingest/CLAUDE_TEMPLATE.md
@@ -33,7 +33,7 @@ MEMORY.md may contain personal facts that were cached from earlier sessions. **D
 
 ## Background Processing
 - Memories are also extracted automatically from conversations via background processing.
-- The Stop hook captures the full transcript and runs deep extraction after sessions end.
+- The SessionEnd hook captures the full transcript and runs deep extraction after sessions end.
 - You do NOT need to store everything manually — focus on in-conversation corrections and explicit preferences.
 - The background extractor handles: personal facts, preferences, decisions, temporal facts, and technical context.
 

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -797,7 +797,7 @@ def _run_install(args):
     Hooks installed:
     - SessionStart: injects relevant memories as additionalContext
     - UserPromptSubmit: buffers user messages (kept for future use)
-    - Stop: triggers background fact extraction after each session
+    - SessionEnd: triggers background fact extraction after each session
     - PreCompact: saves context snapshot before Claude compresses conversation
 
     Note: the event is named ``PreCompact`` in Claude Code's settings.json
@@ -815,7 +815,7 @@ def _run_install(args):
     hook_files = {
         "SessionStart": hooks_dir / "session_start.py",
         "UserPromptSubmit": hooks_dir / "user_prompt_submit.py",
-        "Stop": hooks_dir / "stop.py",
+        "SessionEnd": hooks_dir / "stop.py",
         "PreCompact": hooks_dir / "compact.py",
     }
     missing = [name for name, path in hook_files.items() if not path.exists()]
@@ -917,6 +917,30 @@ def _run_install(args):
             print(
                 "Migrated legacy 'compact' hook entry to 'PreCompact' "
                 "(earlier versions registered the wrong event name)."
+            )
+
+    # Migration: earlier versions wired the transcript extraction hook to
+    # Claude Code's "Stop" event, but "Stop" fires after every assistant
+    # response (per-turn), not once at session end. The correct event is
+    # "SessionEnd". Strip stale "Stop" entries that point at our hook file
+    # so upgrading users don't get double-fires.
+    _legacy_stop = existing["hooks"].get("Stop")
+    if isinstance(_legacy_stop, list):
+        _cleaned = [
+            h for h in _legacy_stop
+            if not (
+                isinstance(h, dict)
+                and "truememory" in str(h.get("command", "")).lower()
+            )
+        ]
+        if _cleaned:
+            existing["hooks"]["Stop"] = _cleaned
+        else:
+            del existing["hooks"]["Stop"]
+        if len(_cleaned) != len(_legacy_stop):
+            print(
+                "Migrated truememory extraction hook from 'Stop' (per-turn) "
+                "to 'SessionEnd' (per-session)."
             )
 
     # Migration: earlier versions wrote hooks in the flat format
@@ -1096,7 +1120,7 @@ def _run_status(args):
         try:
             settings = json.loads(settings_path.read_text(encoding="utf-8"))
             hooks = settings.get("hooks", {})
-            expected = ["SessionStart", "UserPromptSubmit", "Stop", "PreCompact"]
+            expected = ["SessionStart", "UserPromptSubmit", "SessionEnd", "PreCompact"]
             installed = []
             missing = []
             for event in expected:
@@ -1312,7 +1336,7 @@ def _run_logs(args):
     """Tail recent hook log output from ~/.truememory/logs/."""
     if not _LOG_DIR.exists():
         print(f"No logs directory at {_LOG_DIR}")
-        print("(Logs are created when the Stop hook fires in Claude Code.)")
+        print("(Logs are created when the SessionEnd hook fires in Claude Code.)")
         return
 
     if args.list:


### PR DESCRIPTION
## Summary

Fixes the bug identified in #394 by @Huntehhh. Clean rewrite with correct scope — changes only the event name, not the filename.

**Bug:** The installer registered `stop.py` under Claude Code's `Stop` event, which fires after every assistant response (per-turn). The correct event is `SessionEnd` (per-session). This caused transcript extraction to run on every assistant turn instead of once at session end.

**Root Cause:** The developer assumed "Stop" meant "session stop" rather than "agent turn stop." The Gemini adapter got it right (`SessionEnd`), but the Claude Code adapter used `Stop`.

## Changes

- `truememory/ingest/cli.py` — Change event key from `"Stop"` to `"SessionEnd"` in hook_files dict, status checker, and log messages. Add migration logic to strip stale `"Stop"` entries for upgrading users (follows existing `compact`→`PreCompact` pattern).
- `docs/compatibility.md` — Fix Claude Code column: `Stop` → `SessionEnd`
- `docs/architecture.md` — Narrative fix
- `install.sh` — Comment fix
- `truememory/ingest/CLAUDE_TEMPLATE.md` — Narrative fix

## What this does NOT do (unlike the closed #404)

Does NOT rename `stop.py` to `session_end.py`. The file keeps its name — only the event it's registered under changes. This avoids cascading changes across 24 files.

## Validation

- Analyzed by 7 independent AI models via OpenRouter (Opus 4.8, Opus 4.7, Sonnet 4.6, GPT-5.5, DeepSeek V4, Qwen 3.7, Gemini 3.1 Pro)
- Migration logic follows the existing `compact`→`PreCompact` pattern exactly

## Credit

Bug originally identified by @Huntehhh in #394.

Co-authored-by: Huntehhh <66277108+Huntehhh@users.noreply.github.com>