### PR TITLE
fix(reranker): guard idle-unload against concurrent cold load

### DIFF
--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1004,6 +1004,18 @@ _idle_timer: threading.Timer | None = None
 _idle_timer_lock = threading.Lock()
 
 
+def _is_still_idle() -> bool:
+    """Check whether models are still idle (no search since timeout expired).
+
+    Evaluated inside model locks to close the TOCTOU window between the
+    timer callback's staleness check and the actual model teardown.
+    """
+    return (
+        _last_search_time > 0
+        and (time.monotonic() - _last_search_time) >= _MODEL_IDLE_TIMEOUT_SEC
+    )
+
+
 def _get_rss_mb() -> float:
     if _resource_mod is None:
         return 0.0
@@ -1014,31 +1026,48 @@ def _get_rss_mb() -> float:
 
 
 def _unload_models() -> None:
-    try:
-        from truememory.vector_search import unload_model
-        unload_model()
-    except Exception:
-        pass
-    try:
-        from truememory.reranker import unload_reranker
-        unload_reranker()
-    except Exception:
-        pass
-    try:
-        import torch
-        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-            torch.mps.empty_cache()
-            torch.mps.synchronize()
-    except Exception:
-        pass
-    gc.collect()
-    log.info("Models unloaded (idle timeout). RSS=%.0f MB", _get_rss_mb())
+    """Unload ML models after idle timeout.
+
+    Re-checks ``_is_still_idle()`` before each unload and passes the
+    predicate into each unload function so it can be re-evaluated inside
+    the model lock — closing the TOCTOU window where a search arrives
+    while the unload thread blocks on a concurrent cold load.
+    """
+    unloaded_any = False
+
+    if _is_still_idle():
+        try:
+            from truememory.vector_search import unload_model
+            unload_model()
+            unloaded_any = True
+        except Exception:
+            pass
+
+    if _is_still_idle():
+        try:
+            from truememory.reranker import unload_reranker
+            if unload_reranker(should_unload=_is_still_idle):
+                unloaded_any = True
+        except Exception:
+            pass
+
+    if unloaded_any:
+        try:
+            import torch
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                torch.mps.empty_cache()
+                torch.mps.synchronize()
+        except Exception:
+            pass
+        gc.collect()
+        log.info("Models unloaded (idle timeout). RSS=%.0f MB", _get_rss_mb())
+    else:
+        log.debug("Idle unload skipped — search activity detected during unload window")
 
 
 def _check_idle_unload() -> None:
     global _idle_timer
-    elapsed = time.monotonic() - _last_search_time
-    if _last_search_time > 0 and elapsed >= _MODEL_IDLE_TIMEOUT_SEC:
+    if _is_still_idle():
         _unload_models()
     with _idle_timer_lock:
         _idle_timer = None

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    pass
+    from collections.abc import Callable
 
 # ---------------------------------------------------------------------------
 # Singleton model loader
@@ -140,11 +140,28 @@ def get_current_reranker_name() -> str:
     return get_reranker_name_for_tier(_active_tier)
 
 
-def unload_reranker() -> None:
-    """Release the reranker model from memory."""
+def unload_reranker(
+    should_unload: "Callable[[], bool] | None" = None,
+) -> bool:
+    """Release the reranker model from memory.
+
+    Args:
+        should_unload: Optional predicate evaluated inside ``_lock`` before
+            clearing the model. When provided and it returns ``False``, the
+            unload is skipped (a concurrent search arrived while we were
+            waiting on the lock). Pass ``None`` for unconditional unload.
+
+    Returns:
+        ``True`` if the model was actually unloaded, ``False`` if skipped.
+    """
     global _model
     with _lock:
+        if should_unload is not None and not should_unload():
+            return False
+        if _model is None:
+            return False
         _model = None
+        return True
 
 
 def get_reranker(model_name: str | None = None, device: str | None = None):
@@ -183,7 +200,7 @@ def get_reranker(model_name: str | None = None, device: str | None = None):
                 proxy = get_reranker_proxy(model_name=name)
                 _model = proxy
                 _model_name = name
-                return _model
+                return proxy
             except Exception:
                 log.warning(
                     "Model server available but reranker proxy failed — "
@@ -207,7 +224,8 @@ def get_reranker(model_name: str | None = None, device: str | None = None):
 
         _model = CrossEncoder(name, device=device)
         _model_name = name
-        return _model
+        result = _model
+        return result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the race condition identified in #388 by @Huntehhh. Clean rewrite using the _is_still_idle() predicate approach (more robust than the _loading flag pattern which has a residual TOCTOU race).

**Bug:** `unload_reranker()` from the idle timer could race with `get_reranker()` cold load — the timer thread blocks on `_lock`, and once the load completes and the lock is released, immediately nullifies the freshly-loaded model.

**Fix:** Three-layer defense:
1. `_is_still_idle()` predicate re-checked before each unload call in `_unload_models()`
2. `should_unload` callback parameter on `unload_reranker()` evaluated inside `_lock`
3. Local var capture in `get_reranker()` prevents return-after-null

## Changes

- `truememory/reranker.py` — `unload_reranker()` gains `should_unload` callback param, evaluated inside lock. Returns bool. `get_reranker()` captures model ref to local before return.
- `truememory/mcp_server.py` — `_is_still_idle()` predicate, `_unload_models()` rewritten with re-check pattern, `_check_idle_unload()` uses predicate.

## Credit

Race condition originally identified by @Huntehhh in #388.

Co-authored-by: Huntehhh <66277108+Huntehhh@users.noreply.github.com>