### PR TITLE
feat(custom-tier): centralize tier configs and add custom presets

### DIFF
--- a/tests/test_tier_config.py
+++ b/tests/test_tier_config.py
@@ -1,0 +1,177 @@
+"""Tests for truememory.tier_config — centralized tier configuration."""
+
+from __future__ import annotations
+
+import os
+import pytest
+
+from truememory.tier_config import (
+    TIERS,
+    MODEL_DIMS,
+    MODEL_TO_GROUP,
+    VALID_TIER_GROUPS,
+    get_tier_config,
+    get_embed_model,
+    get_reranker,
+    get_embed_dim,
+    get_embed_dim_for_model,
+    get_tier_group,
+    get_model_group,
+    get_model_name_for_group,
+    is_custom_tier,
+    resolve_custom_tier,
+)
+
+
+# ---------------------------------------------------------------------------
+# Built-in tiers
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinTiers:
+    def test_edge_config(self):
+        cfg = get_tier_config("edge")
+        assert cfg["embed_model"] == "model2vec"
+        assert cfg["embed_dim"] == 256
+        assert cfg["tier_group"] == "edge"
+        assert cfg["reranker"] == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+    def test_base_config(self):
+        cfg = get_tier_config("base")
+        assert cfg["embed_model"] == "qwen3_256"
+        assert cfg["embed_dim"] == 256
+        assert cfg["tier_group"] == "basepro"
+
+    def test_pro_config(self):
+        cfg = get_tier_config("pro")
+        assert cfg["embed_model"] == "qwen3_256"
+        assert cfg["embed_dim"] == 256
+        assert cfg["tier_group"] == "basepro"
+
+    def test_case_insensitive(self):
+        assert get_tier_config("Edge")["embed_model"] == "model2vec"
+        assert get_tier_config("BASE")["embed_model"] == "qwen3_256"
+        assert get_tier_config("Pro")["embed_model"] == "qwen3_256"
+
+    def test_unknown_tier_raises(self):
+        with pytest.raises(ValueError, match="Unknown tier"):
+            get_tier_config("nonexistent")
+
+    def test_get_tier_config_returns_copy(self):
+        """Ensure callers cannot mutate the global TIERS dict."""
+        cfg1 = get_tier_config("edge")
+        cfg1["embed_dim"] = 9999
+        cfg2 = get_tier_config("edge")
+        assert cfg2["embed_dim"] == 256
+
+
+class TestHelpers:
+    def test_get_embed_model(self):
+        assert get_embed_model("edge") == "model2vec"
+        assert get_embed_model("base") == "qwen3_256"
+        assert get_embed_model("pro") == "qwen3_256"
+
+    def test_get_reranker(self):
+        assert get_reranker("edge") == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+        assert get_reranker("base") == "Alibaba-NLP/gte-reranker-modernbert-base"
+
+    def test_get_embed_dim(self):
+        assert get_embed_dim("edge") == 256
+        assert get_embed_dim("base") == 256
+
+    def test_get_embed_dim_for_model(self):
+        assert get_embed_dim_for_model("model2vec") == 256
+        assert get_embed_dim_for_model("minilm") == 384
+        assert get_embed_dim_for_model("unknown_model") == 256  # default
+
+    def test_get_tier_group(self):
+        assert get_tier_group("edge") == "edge"
+        assert get_tier_group("base") == "basepro"
+        assert get_tier_group("pro") == "basepro"
+
+    def test_get_model_group(self):
+        assert get_model_group("model2vec") == "edge"
+        assert get_model_group("qwen3_256") == "basepro"
+        assert get_model_group("unknown_model") == "custom"
+
+    def test_get_model_name_for_group(self):
+        assert get_model_name_for_group("edge") == "potion-base-8M"
+        assert get_model_name_for_group("basepro") == "Qwen3-Embedding-0.6B"
+        assert get_model_name_for_group("custom") == ""
+
+    def test_is_custom_tier(self):
+        assert is_custom_tier("custom") is True
+        assert is_custom_tier("Custom") is True
+        assert is_custom_tier("edge") is False
+        assert is_custom_tier("pro") is False
+
+
+class TestValidGroups:
+    def test_contains_custom(self):
+        assert "custom" in VALID_TIER_GROUPS
+        assert "edge" in VALID_TIER_GROUPS
+        assert "basepro" in VALID_TIER_GROUPS
+
+
+# ---------------------------------------------------------------------------
+# Custom tier
+# ---------------------------------------------------------------------------
+
+
+class TestCustomTier:
+    def test_custom_tier_requires_opt_in(self):
+        """Custom tier raises ValueError without TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD."""
+        env = {
+            "TRUEMEMORY_CUSTOM_EMBED_MODEL": "org/my-model",
+            "TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD": "",
+        }
+        with pytest.MonkeyPatch.context() as mp:
+            for k, v in env.items():
+                mp.setenv(k, v)
+            mp.delenv("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", raising=False)
+            with pytest.raises(ValueError, match="TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD"):
+                resolve_custom_tier()
+
+    def test_custom_tier_requires_embed_model(self):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "1")
+            mp.delenv("TRUEMEMORY_CUSTOM_EMBED_MODEL", raising=False)
+            with pytest.raises(ValueError, match="TRUEMEMORY_CUSTOM_EMBED_MODEL"):
+                resolve_custom_tier()
+
+    def test_custom_tier_valid(self):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "1")
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_MODEL", "Alibaba-NLP/gte-base-en-v1.5")
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_DIM", "768")
+            mp.setenv("TRUEMEMORY_CUSTOM_RERANKER", "cross-encoder/ms-marco-MiniLM-L-6-v2")
+
+            cfg = resolve_custom_tier()
+            assert cfg["embed_model"] == "Alibaba-NLP/gte-base-en-v1.5"
+            assert cfg["embed_dim"] == 768
+            assert cfg["tier_group"] == "custom"
+            assert cfg["reranker"] == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+    def test_custom_tier_via_get_tier_config(self):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "1")
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_MODEL", "org/model-name")
+
+            cfg = get_tier_config("custom")
+            assert cfg["tier_group"] == "custom"
+            assert cfg["embed_model"] == "org/model-name"
+
+    def test_custom_tier_invalid_model_id(self):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "1")
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_MODEL", "../../../etc/passwd")
+            with pytest.raises(ValueError, match="Invalid model ID"):
+                resolve_custom_tier()
+
+    def test_custom_tier_dim_bounds(self):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "1")
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_MODEL", "org/model")
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_DIM", "99999")
+            with pytest.raises(ValueError, match="1-4096"):
+                resolve_custom_tier()

--- a/tests/test_tier_config.py
+++ b/tests/test_tier_config.py
@@ -120,15 +120,26 @@ class TestValidGroups:
 
 class TestCustomTier:
     def test_custom_tier_requires_opt_in(self):
-        """Custom tier raises ValueError without TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD."""
-        env = {
-            "TRUEMEMORY_CUSTOM_EMBED_MODEL": "org/my-model",
-            "TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD": "",
-        }
+        """Custom tier raises ValueError without TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=1."""
         with pytest.MonkeyPatch.context() as mp:
-            for k, v in env.items():
-                mp.setenv(k, v)
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_MODEL", "org/my-model")
             mp.delenv("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", raising=False)
+            with pytest.raises(ValueError, match="TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD"):
+                resolve_custom_tier()
+
+    def test_custom_tier_rejects_false_opt_in(self):
+        """TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=0 must be rejected."""
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_MODEL", "org/my-model")
+            mp.setenv("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "0")
+            with pytest.raises(ValueError, match="TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD"):
+                resolve_custom_tier()
+
+    def test_custom_tier_rejects_false_string_opt_in(self):
+        """TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=false must be rejected."""
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_MODEL", "org/my-model")
+            mp.setenv("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "false")
             with pytest.raises(ValueError, match="TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD"):
                 resolve_custom_tier()
 
@@ -175,3 +186,25 @@ class TestCustomTier:
             mp.setenv("TRUEMEMORY_CUSTOM_EMBED_DIM", "99999")
             with pytest.raises(ValueError, match="1-4096"):
                 resolve_custom_tier()
+
+    def test_custom_tier_dim_non_integer(self):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "1")
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_MODEL", "org/model")
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_DIM", "abc")
+            with pytest.raises(ValueError, match="must be an integer"):
+                resolve_custom_tier()
+
+    def test_custom_tier_dim_boundaries(self):
+        """Boundary values: dim=1 and dim=4096 should be valid."""
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "1")
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_MODEL", "org/model")
+
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_DIM", "1")
+            cfg = resolve_custom_tier()
+            assert cfg["embed_dim"] == 1
+
+            mp.setenv("TRUEMEMORY_CUSTOM_EMBED_DIM", "4096")
+            cfg = resolve_custom_tier()
+            assert cfg["embed_dim"] == 4096

--- a/truememory/__init__.py
+++ b/truememory/__init__.py
@@ -124,6 +124,7 @@ __all__ = [
     "hybrid", "temporal", "salience", "personality", "personality_style_vec",
     "consolidation",
     "predictive", "query_classifier", "reranker", "hyde", "clustering",
+    "tier_config",
 ]
 
 

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -870,8 +870,16 @@ def truememory_configure(
     """
     global _memory
     tier = tier.lower().strip()
-    if tier not in ("edge", "base", "pro"):
-        return json.dumps({"error": "tier must be 'edge', 'base', or 'pro'"})
+    if tier not in ("edge", "base", "pro", "custom"):
+        return json.dumps({"error": "tier must be 'edge', 'base', 'pro', or 'custom'"})
+
+    # Custom tier: validate env vars are set before proceeding
+    if tier == "custom":
+        try:
+            from truememory.tier_config import resolve_custom_tier
+            resolve_custom_tier()  # raises ValueError on missing env vars
+        except ValueError as e:
+            return json.dumps({"error": str(e)})
 
     if api_key and len(api_key) > 4096:
         return json.dumps({"error": "api_key exceeds maximum length of 4096 characters"})
@@ -985,6 +993,7 @@ def truememory_configure(
         "edge": "Edge: Model2Vec embeddings (8M params), MiniLM reranker",
         "base": "Base: Qwen3 embeddings (256d), gte-reranker-modernbert",
         "pro": "Pro: Qwen3 + HyDE query expansion",
+        "custom": "Custom: user-provided embedding model + reranker via TRUEMEMORY_CUSTOM_* env vars",
     }
     result = {
         "status": "configured",

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -117,8 +117,18 @@ class ModelServer:
             set_embedding_model(tier)
 
         resolved = EMBEDDING_MODEL if not tier else tier
+        # Resolve tier -> internal model ID via centralized tier_config.
+        # _TIER_ALIASES is still exported by vector_search for compat.
         from truememory.vector_search import _TIER_ALIASES
         model_id = _TIER_ALIASES.get(resolved, resolved)
+
+        # Custom tier: resolve via tier_config
+        if resolved == "custom":
+            try:
+                from truememory.tier_config import get_embed_model
+                model_id = get_embed_model("custom")
+            except (ValueError, ImportError):
+                pass
 
         if model_id == "model2vec":
             from model2vec import StaticModel
@@ -135,6 +145,27 @@ class ModelServer:
                 truncate_dim=256,
                 model_kwargs=mkwargs or None,
             )
+        elif model_id not in ("model2vec", "minilm", "bge-small", "qwen3_256"):
+            # Custom model: require explicit opt-in for arbitrary downloads
+            if not os.environ.get("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD"):
+                log.warning(
+                    "Custom model %r requested without "
+                    "TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=1 -- "
+                    "falling back to model2vec.",
+                    model_id,
+                )
+                from model2vec import StaticModel
+                self._embed_model = StaticModel.from_pretrained(
+                    "minishlab/potion-base-8M", force_download=False
+                )
+            else:
+                from sentence_transformers import SentenceTransformer
+                custom_dim = int(os.environ.get(
+                    "TRUEMEMORY_CUSTOM_EMBED_DIM", "256"
+                ))
+                self._embed_model = SentenceTransformer(
+                    model_id, truncate_dim=custom_dim,
+                )
         else:
             from model2vec import StaticModel
             self._embed_model = StaticModel.from_pretrained(

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -127,8 +127,9 @@ class ModelServer:
             try:
                 from truememory.tier_config import get_embed_model
                 model_id = get_embed_model("custom")
-            except (ValueError, ImportError):
-                pass
+            except (ValueError, ImportError) as e:
+                log.warning("Custom tier resolution failed (%s); falling back to model2vec.", e)
+                model_id = "model2vec"
 
         if model_id == "model2vec":
             from model2vec import StaticModel
@@ -147,7 +148,7 @@ class ModelServer:
             )
         elif model_id not in ("model2vec", "minilm", "bge-small", "qwen3_256"):
             # Custom model: require explicit opt-in for arbitrary downloads
-            if not os.environ.get("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD"):
+            if os.environ.get("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "").strip() != "1":
                 log.warning(
                     "Custom model %r requested without "
                     "TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=1 -- "
@@ -160,11 +161,12 @@ class ModelServer:
                 )
             else:
                 from sentence_transformers import SentenceTransformer
-                custom_dim = int(os.environ.get(
-                    "TRUEMEMORY_CUSTOM_EMBED_DIM", "256"
-                ))
+                from truememory.tier_config import resolve_custom_tier
+                cfg = resolve_custom_tier()
+                custom_dim = cfg["embed_dim"]
                 self._embed_model = SentenceTransformer(
                     model_id, truncate_dim=custom_dim,
+                    trust_remote_code=False,
                 )
         else:
             from model2vec import StaticModel

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -78,7 +78,8 @@ def get_reranker_name_for_tier(tier: str) -> str:
     if t == "custom":
         try:
             return _cfg_get_reranker("custom")
-        except ValueError:
+        except ValueError as e:
+            log.warning("Custom tier reranker resolution failed (%s); using edge default.", e)
             return _TIER_RERANKERS["edge"]
     return _TIER_RERANKERS.get(t, _TIER_RERANKERS["edge"])
 

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -44,35 +44,43 @@ _lock = threading.Lock()
 _inference_lock = threading.Lock()  # Protects concurrent model.predict() calls
 
 # ---------------------------------------------------------------------------
-# Tier-aware reranker resolution (v0.4.0 paper §2.0)
+# Tier-aware reranker resolution (v0.4.0 paper S2.0)
 # ---------------------------------------------------------------------------
 #
 # Edge uses the lightweight MiniLM cross-encoder (22M params, CPU-friendly).
-# Base and Pro use gte-reranker-modernbert-base (149M, GPU recommended) —
+# Base and Pro use gte-reranker-modernbert-base (149M, GPU recommended) --
 # required to reach the 92.0% / 93.0% LoCoMo targets for those tiers.
 #
 # The active tier is cached in _active_tier. It's seeded lazily on first
 # get_current_reranker_name() call (from TRUEMEMORY_EMBED_MODEL env var or
 # ~/.truememory/config.json), and can be updated at runtime via
-# set_active_tier() — the MCP server calls this on truememory_configure.
-_TIER_RERANKERS = {
-    "edge": "cross-encoder/ms-marco-MiniLM-L-6-v2",
-    "base": "Alibaba-NLP/gte-reranker-modernbert-base",
-    "pro": "Alibaba-NLP/gte-reranker-modernbert-base",
-}
+# set_active_tier() -- the MCP server calls this on truememory_configure.
+#
+# The canonical mapping lives in tier_config.TIERS; this dict is a
+# backward-compat delegate for callers that access _TIER_RERANKERS directly.
+from truememory.tier_config import TIERS as _TIERS, get_reranker as _cfg_get_reranker
+
+_TIER_RERANKERS = {t: cfg["reranker"] for t, cfg in _TIERS.items()}
 
 _active_tier: str | None = None  # None = not yet resolved; resolved lazily
 
 
 def get_reranker_name_for_tier(tier: str) -> str:
-    """Pure mapping from tier name ("edge" / "base" / "pro") to reranker HF ID.
+    """Pure mapping from tier name ("edge" / "base" / "pro" / "custom") to reranker HF ID.
 
     Case-insensitive. Unknown or empty tier names fall back to the Edge
-    default (MiniLM). Does not load any model — use ``get_reranker`` for that.
+    default (MiniLM). Does not load any model -- use ``get_reranker`` for that.
+    Supports the "custom" tier via tier_config.get_reranker().
     """
     if not tier:
         return _TIER_RERANKERS["edge"]
-    return _TIER_RERANKERS.get(tier.lower(), _TIER_RERANKERS["edge"])
+    t = tier.lower()
+    if t == "custom":
+        try:
+            return _cfg_get_reranker("custom")
+        except ValueError:
+            return _TIER_RERANKERS["edge"]
+    return _TIER_RERANKERS.get(t, _TIER_RERANKERS["edge"])
 
 
 def _resolve_tier_from_env_and_config() -> str:
@@ -84,8 +92,9 @@ def _resolve_tier_from_env_and_config() -> str:
     set_active_tier() is called explicitly.
     """
     import os
+    _KNOWN_TIERS = {"edge", "base", "pro", "custom"}
     env = os.environ.get("TRUEMEMORY_EMBED_MODEL", "").strip().lower()
-    if env in ("edge", "base", "pro"):
+    if env in _KNOWN_TIERS:
         return env
     try:
         from pathlib import Path
@@ -94,7 +103,7 @@ def _resolve_tier_from_env_and_config() -> str:
         if cfg_path.exists():
             data = json.loads(cfg_path.read_text(encoding="utf-8"))
             tier = (data.get("tier") or "").strip().lower()
-            if tier in ("edge", "base", "pro"):
+            if tier in _KNOWN_TIERS:
                 return tier
     except (json.JSONDecodeError, OSError) as e:
         # Previously a bare `except Exception: pass`
@@ -124,7 +133,7 @@ def set_active_tier(tier: str) -> None:
         _active_tier = "edge"
         return
     t = tier.strip().lower()
-    _active_tier = t if t in ("edge", "base", "pro") else "edge"
+    _active_tier = t if t in ("edge", "base", "pro", "custom") else "edge"
 
 
 def get_current_reranker_name() -> str:

--- a/truememory/tier_config.py
+++ b/truememory/tier_config.py
@@ -1,0 +1,201 @@
+"""Centralized tier configuration -- single source of truth.
+
+Every tier-aware module (vector_search, reranker, model_server,
+tier_switch/cache) imports from here instead of maintaining its own
+mapping dicts.  This eliminates the class of bugs where a new tier is
+added to one module but forgotten in another.
+
+Named ``tier_config`` (not ``config``) to avoid shadowing the heavily-used
+local variable pattern ``config = _load_config()`` throughout mcp_server.py.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+import re
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Built-in tier definitions
+# ---------------------------------------------------------------------------
+
+TIERS: dict[str, dict] = {
+    "edge": {
+        "embed_model": "model2vec",
+        "reranker": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        "embed_dim": 256,
+        "tier_group": "edge",
+        "model_name": "potion-base-8M",  # for vector_cache_registry
+    },
+    "base": {
+        "embed_model": "qwen3_256",
+        "reranker": "Alibaba-NLP/gte-reranker-modernbert-base",
+        "embed_dim": 256,
+        "tier_group": "basepro",
+        "model_name": "Qwen3-Embedding-0.6B",
+    },
+    "pro": {
+        "embed_model": "qwen3_256",
+        "reranker": "Alibaba-NLP/gte-reranker-modernbert-base",
+        "embed_dim": 256,
+        "tier_group": "basepro",
+        "model_name": "Qwen3-Embedding-0.6B",
+    },
+}
+
+MODEL_DIMS: dict[str, int] = {
+    "model2vec": 256,
+    "minilm": 384,
+    "bge-small": 384,
+    "qwen3_256": 256,
+}
+
+VALID_TIER_GROUPS: frozenset[str] = frozenset({"edge", "basepro", "custom"})
+
+MODEL_TO_GROUP: dict[str, str] = {
+    "model2vec": "edge",
+    "qwen3_256": "basepro",
+    "minilm": "basepro",
+    "bge-small": "basepro",
+}
+
+# Regex for validating HuggingFace model IDs:
+# org/model-name or just model-name, alphanumeric + dots/hyphens/underscores
+_HF_MODEL_ID_RE = re.compile(r"^[\w][\w.\-]*(\/[\w][\w.\-]*)?$")
+
+# ---------------------------------------------------------------------------
+# Custom tier resolution (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+def resolve_custom_tier() -> dict:
+    """Build custom tier config from ``TRUEMEMORY_CUSTOM_*`` env vars.
+
+    Requires ``TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=1`` as an explicit opt-in
+    to acknowledge that arbitrary HuggingFace models will be downloaded.
+
+    Raises:
+        ValueError: if required env vars are missing or invalid.
+    """
+    if not os.environ.get("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", ""):
+        raise ValueError(
+            "Custom tier requires TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=1 "
+            "to acknowledge arbitrary model downloads."
+        )
+
+    # Do NOT lowercase the embed model -- HF IDs are case-sensitive
+    # (e.g. "Qwen/Qwen3-Embedding-0.6B")
+    embed = os.environ.get("TRUEMEMORY_CUSTOM_EMBED_MODEL", "").strip()
+    if not embed:
+        raise ValueError(
+            "TRUEMEMORY_CUSTOM_EMBED_MODEL must be set for custom tier"
+        )
+
+    # Validate model ID format to prevent shell injection / path traversal
+    if not _HF_MODEL_ID_RE.match(embed):
+        raise ValueError(
+            f"Invalid model ID format: {embed!r}. "
+            f"Expected HuggingFace format like 'org/model-name' or 'model-name'."
+        )
+
+    reranker = os.environ.get(
+        "TRUEMEMORY_CUSTOM_RERANKER",
+        "cross-encoder/ms-marco-MiniLM-L-6-v2",
+    ).strip()
+    if reranker and not _HF_MODEL_ID_RE.match(reranker):
+        raise ValueError(
+            f"Invalid reranker model ID format: {reranker!r}."
+        )
+
+    try:
+        dim = int(os.environ.get("TRUEMEMORY_CUSTOM_EMBED_DIM", "256"))
+    except (ValueError, TypeError):
+        dim = 256
+
+    if dim < 1 or dim > 4096:
+        raise ValueError(
+            f"TRUEMEMORY_CUSTOM_EMBED_DIM must be 1-4096, got {dim}"
+        )
+
+    return {
+        "embed_model": embed,
+        "reranker": reranker or "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        "embed_dim": dim,
+        "tier_group": "custom",
+        "model_name": embed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_tier_config(tier: str) -> dict:
+    """Return a *copy* of the config dict for the given tier.
+
+    Routes "custom" to :func:`resolve_custom_tier`.  Raises
+    :class:`ValueError` for truly unknown tier names (does NOT silently
+    fall back to edge -- that masks configuration errors).
+
+    Returns a shallow copy so callers cannot mutate the global TIERS dict.
+    """
+    t = tier.lower().strip()
+    if t == "custom":
+        return resolve_custom_tier()
+    if t not in TIERS:
+        raise ValueError(
+            f"Unknown tier: {tier!r}. Valid tiers: {sorted(TIERS)} + ['custom']"
+        )
+    return copy.copy(TIERS[t])
+
+
+def get_embed_model(tier: str) -> str:
+    """Return the embedding model ID for a tier."""
+    return get_tier_config(tier)["embed_model"]
+
+
+def get_reranker(tier: str) -> str:
+    """Return the reranker HF model ID for a tier."""
+    return get_tier_config(tier)["reranker"]
+
+
+def get_embed_dim(tier: str) -> int:
+    """Return the embedding dimension for a tier."""
+    return get_tier_config(tier)["embed_dim"]
+
+
+def get_embed_dim_for_model(model_name: str) -> int:
+    """Return the embedding dimension for an internal model name."""
+    return MODEL_DIMS.get(model_name, 256)
+
+
+def get_tier_group(tier: str) -> str:
+    """Return the tier group for a tier (edge / basepro / custom)."""
+    return get_tier_config(tier)["tier_group"]
+
+
+def get_model_group(model_name: str) -> str:
+    """Return the tier group for a model name.
+
+    Checks MODEL_TO_GROUP first, then falls back to "custom" for
+    any model loaded via the custom tier path.
+    """
+    return MODEL_TO_GROUP.get(model_name, "custom")
+
+
+def get_model_name_for_group(group: str) -> str:
+    """Return the canonical model display name for a tier group."""
+    _GROUP_MODEL_NAMES = {
+        "edge": "potion-base-8M",
+        "basepro": "Qwen3-Embedding-0.6B",
+    }
+    return _GROUP_MODEL_NAMES.get(group, "")
+
+
+def is_custom_tier(tier: str) -> bool:
+    """Check if a tier string refers to the custom tier."""
+    return tier.lower().strip() == "custom"

--- a/truememory/tier_config.py
+++ b/truememory/tier_config.py
@@ -80,7 +80,7 @@ def resolve_custom_tier() -> dict:
     Raises:
         ValueError: if required env vars are missing or invalid.
     """
-    if not os.environ.get("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", ""):
+    if os.environ.get("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "").strip() != "1":
         raise ValueError(
             "Custom tier requires TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=1 "
             "to acknowledge arbitrary model downloads."
@@ -95,7 +95,7 @@ def resolve_custom_tier() -> dict:
         )
 
     # Validate model ID format to prevent shell injection / path traversal
-    if not _HF_MODEL_ID_RE.match(embed):
+    if not _HF_MODEL_ID_RE.fullmatch(embed):
         raise ValueError(
             f"Invalid model ID format: {embed!r}. "
             f"Expected HuggingFace format like 'org/model-name' or 'model-name'."
@@ -105,15 +105,18 @@ def resolve_custom_tier() -> dict:
         "TRUEMEMORY_CUSTOM_RERANKER",
         "cross-encoder/ms-marco-MiniLM-L-6-v2",
     ).strip()
-    if reranker and not _HF_MODEL_ID_RE.match(reranker):
+    if reranker and not _HF_MODEL_ID_RE.fullmatch(reranker):
         raise ValueError(
             f"Invalid reranker model ID format: {reranker!r}."
         )
 
+    raw_dim = os.environ.get("TRUEMEMORY_CUSTOM_EMBED_DIM", "256").strip()
     try:
-        dim = int(os.environ.get("TRUEMEMORY_CUSTOM_EMBED_DIM", "256"))
+        dim = int(raw_dim)
     except (ValueError, TypeError):
-        dim = 256
+        raise ValueError(
+            f"TRUEMEMORY_CUSTOM_EMBED_DIM must be an integer, got {raw_dim!r}"
+        )
 
     if dim < 1 or dim > 4096:
         raise ValueError(
@@ -169,8 +172,22 @@ def get_embed_dim(tier: str) -> int:
 
 
 def get_embed_dim_for_model(model_name: str) -> int:
-    """Return the embedding dimension for an internal model name."""
-    return MODEL_DIMS.get(model_name, 256)
+    """Return the embedding dimension for an internal model name.
+
+    For known built-in models, returns from MODEL_DIMS.
+    For unknown models (custom tier), attempts to resolve the custom
+    tier config and returns the configured dimension if the model matches.
+    """
+    if model_name in MODEL_DIMS:
+        return MODEL_DIMS[model_name]
+    # Check if this is a custom tier model
+    try:
+        cfg = resolve_custom_tier()
+        if model_name == cfg["embed_model"]:
+            return cfg["embed_dim"]
+    except ValueError:
+        pass
+    return 256
 
 
 def get_tier_group(tier: str) -> str:

--- a/truememory/tier_switch/cache.py
+++ b/truememory/tier_switch/cache.py
@@ -1,4 +1,4 @@
-"""Vector cache registry — tracks per-tier-group vector table state.
+"""Vector cache registry -- tracks per-tier-group vector table state.
 
 Enables instant switch-back by keeping old vector tables and only
 re-embedding the delta (new messages since last switch).
@@ -10,8 +10,14 @@ import time
 
 import psutil
 
+from truememory.tier_config import (
+    get_tier_group as _cfg_get_tier_group,
+    get_model_name_for_group as _cfg_get_model_name_for_group,
+)
+
 log = logging.getLogger(__name__)
 
+# Backward-compat: kept for any external callers, delegates to tier_config.
 _MODEL_NAMES = {
     "edge": "potion-base-8M",
     "basepro": "Qwen3-Embedding-0.6B",
@@ -19,17 +25,17 @@ _MODEL_NAMES = {
 
 
 def tier_group(tier: str) -> str:
-    """Map a tier name to its embedding model group."""
-    if tier == "edge":
-        return "edge"
-    if tier in ("base", "pro"):
-        return "basepro"
-    raise ValueError(f"Unknown tier: {tier!r}")
+    """Map a tier name to its embedding model group.
+
+    Delegates to :func:`truememory.tier_config.get_tier_group` so that
+    the custom tier is resolved via the centralized config.
+    """
+    return _cfg_get_tier_group(tier)
 
 
 def model_name_for_group(group: str) -> str:
     """Return the canonical embedding model name for a tier group."""
-    return _MODEL_NAMES.get(group, "")
+    return _cfg_get_model_name_for_group(group) or _MODEL_NAMES.get(group, "")
 
 
 class VectorCacheRegistry:

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -69,19 +69,21 @@ class TrueMemoryMigrationError(Exception):
 # Singleton model loader
 # ---------------------------------------------------------------------------
 
-# Public tier names → internal model identifiers (v0.4.0 paper-aligned Edge/Base/Pro)
-_TIER_ALIASES = {
-    "edge": "model2vec",
-    "base": "qwen3_256",
-    "pro": "qwen3_256",
-}
+# Centralized tier config -- single source of truth lives in tier_config.py.
+# Legacy symbols (_TIER_ALIASES, _MODEL_DIMS, _MODEL_TO_GROUP) are kept as
+# thin delegates so that existing callers (model_server.py etc.) don't break.
+from truememory.tier_config import (
+    TIERS as _TIERS,
+    MODEL_DIMS as _MODEL_DIMS,
+    MODEL_TO_GROUP as _MODEL_TO_GROUP,
+    VALID_TIER_GROUPS as _VALID_GROUPS,
+    get_embed_model as _cfg_get_embed_model,
+    get_embed_dim_for_model as _cfg_get_embed_dim_for_model,
+    get_model_group as _cfg_get_model_group,
+)
 
-_MODEL_DIMS = {
-    "model2vec": 256,
-    "minilm": 384,
-    "bge-small": 384,
-    "qwen3_256": 256,
-}
+# Backward-compat alias -- model_server.py imports this symbol.
+_TIER_ALIASES = {t: cfg["embed_model"] for t, cfg in _TIERS.items()}
 
 # v0.4.0 breaking change: the old internal name "qwen3" (1024d native) is gone.
 # Callers must migrate to "pro" (tier alias) or "qwen3_256" (internal name).
@@ -89,7 +91,7 @@ _REMOVED_MODELS = {"qwen3"}
 
 
 def _resolve_model_name(name: str) -> str:
-    """Resolve a public tier name (edge/base/pro) or internal model name.
+    """Resolve a public tier name (edge/base/pro/custom) or internal model name.
 
     Raises:
         ValueError: if *name* refers to a model removed in v0.4.0.
@@ -98,14 +100,19 @@ def _resolve_model_name(name: str) -> str:
     if lowered in _REMOVED_MODELS:
         raise ValueError(
             f"Embedding model {name!r} was removed in TrueMemory v0.4.0. "
-            f"Migrate to 'pro' (tier alias) or 'qwen3_256' (internal name) — "
+            f"Migrate to 'pro' (tier alias) or 'qwen3_256' (internal name) -- "
             f"the paper-aligned Qwen3-Embedding-0.6B @ 256d Matryoshka config."
         )
+    if lowered == "custom":
+        try:
+            return _cfg_get_embed_model("custom")
+        except ValueError:
+            return name
     return _TIER_ALIASES.get(lowered, name)
 
 
 def resolve_tier() -> str:
-    """Resolve the active tier: env var → config.json → ``'edge'``.
+    """Resolve the active tier: env var -> config.json -> ``'edge'``.
 
     Canonical tier resolver for the entire codebase.  Every call site
     that formerly did ``os.environ.get("TRUEMEMORY_EMBED_MODEL", "edge")``
@@ -134,18 +141,10 @@ _model = None
 _embedding_dim: int = _MODEL_DIMS.get(EMBEDDING_MODEL, 256)
 _lock = threading.Lock()
 
-_MODEL_TO_GROUP = {
-    "model2vec": "edge",
-    "qwen3_256": "basepro",
-    "minilm": "basepro",
-    "bge-small": "basepro",
-}
-_VALID_GROUPS = frozenset({"edge", "basepro"})
-
 
 def _active_tier_group() -> str:
     """Map the current embedding model to its tier group."""
-    return _MODEL_TO_GROUP.get(EMBEDDING_MODEL, "basepro")
+    return _cfg_get_model_group(EMBEDDING_MODEL)
 
 
 def _active_vec_table(conn: sqlite3.Connection) -> str:
@@ -193,7 +192,7 @@ def set_embedding_model(name: str) -> None:
 def get_embedding_dim(name: str | None = None) -> int:
     """Return the embedding dimension for a given model name."""
     name = _resolve_model_name(name) if name else EMBEDDING_MODEL
-    return _MODEL_DIMS.get(name, 256)
+    return _cfg_get_embed_dim_for_model(name)
 
 
 def unload_model() -> None:
@@ -255,6 +254,31 @@ def get_model():
                 model_kwargs=_mkwargs or None,
             )
             _embedding_dim = 256
+        elif resolved not in _MODEL_DIMS:
+            # Custom tier: load arbitrary SentenceTransformer model.
+            # Requires TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=1 (enforced by
+            # tier_config.resolve_custom_tier at config time).
+            if not os.environ.get("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD"):
+                logger.warning(
+                    "Custom model %r requested without "
+                    "TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=1 -- "
+                    "falling back to model2vec.",
+                    resolved,
+                )
+                from model2vec import StaticModel
+                _model = StaticModel.from_pretrained(
+                    "minishlab/potion-base-8M", force_download=False
+                )
+                _embedding_dim = 256
+            else:
+                from sentence_transformers import SentenceTransformer
+                custom_dim = int(os.environ.get(
+                    "TRUEMEMORY_CUSTOM_EMBED_DIM", "256"
+                ))
+                _model = SentenceTransformer(
+                    resolved, truncate_dim=custom_dim,
+                )
+                _embedding_dim = custom_dim
         else:
             from model2vec import StaticModel
             _model = StaticModel.from_pretrained("minishlab/potion-base-8M", force_download=False)
@@ -462,7 +486,10 @@ def init_vec_table(
 
     if tier_group:
         if tier_group not in _VALID_GROUPS:
-            raise ValueError(f"Invalid tier_group: {tier_group!r}")
+            raise ValueError(
+                f"Invalid tier_group: {tier_group!r}. "
+                f"Valid: {sorted(_VALID_GROUPS)}"
+            )
         vec_name = f"vec_messages_{tier_group}"
         sep_name = f"vec_messages_sep_{tier_group}"
     else:

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -107,7 +107,8 @@ def _resolve_model_name(name: str) -> str:
         try:
             return _cfg_get_embed_model("custom")
         except ValueError:
-            return name
+            logger.warning("Custom tier resolution failed; falling back to model2vec.")
+            return "model2vec"
     return _TIER_ALIASES.get(lowered, name)
 
 
@@ -191,6 +192,9 @@ def set_embedding_model(name: str) -> None:
 
 def get_embedding_dim(name: str | None = None) -> int:
     """Return the embedding dimension for a given model name."""
+    if name and name.lower().strip() == "custom":
+        from truememory.tier_config import get_embed_dim
+        return get_embed_dim("custom")
     name = _resolve_model_name(name) if name else EMBEDDING_MODEL
     return _cfg_get_embed_dim_for_model(name)
 
@@ -258,7 +262,7 @@ def get_model():
             # Custom tier: load arbitrary SentenceTransformer model.
             # Requires TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=1 (enforced by
             # tier_config.resolve_custom_tier at config time).
-            if not os.environ.get("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD"):
+            if os.environ.get("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "").strip() != "1":
                 logger.warning(
                     "Custom model %r requested without "
                     "TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD=1 -- "
@@ -272,11 +276,12 @@ def get_model():
                 _embedding_dim = 256
             else:
                 from sentence_transformers import SentenceTransformer
-                custom_dim = int(os.environ.get(
-                    "TRUEMEMORY_CUSTOM_EMBED_DIM", "256"
-                ))
+                from truememory.tier_config import resolve_custom_tier
+                cfg = resolve_custom_tier()
+                custom_dim = cfg["embed_dim"]
                 _model = SentenceTransformer(
                     resolved, truncate_dim=custom_dim,
+                    trust_remote_code=False,
                 )
                 _embedding_dim = custom_dim
         else:


### PR DESCRIPTION
## Summary

Rewrite of #162 by @mkozal. Uses their approach as inspiration but rewrites from scratch with full system knowledge.

## Validation

Analyzed by 7 independent AI models via OpenRouter (Opus 4.8, Opus 4.7, Sonnet 4.6, GPT-5.5, DeepSeek V4, Qwen 3.7, Gemini 3.1 Pro).

## Credit

Feature originally proposed by @mkozal in #162.

Co-authored-by: mkozal <mkozal@users.noreply.github.com>