### PR TITLE
fix(hooks): only mark session extracted when an ingest process actually spawned (#400)

### DIFF
--- a/tests/ingest/test_stop_hook_mark_guard.py
+++ b/tests/ingest/test_stop_hook_mark_guard.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 import io
 import json
 
-import pytest
-
 
 def _make_transcript(tmp_path, n=6):
     p = tmp_path / "transcript.jsonl"

--- a/tests/ingest/test_stop_hook_mark_guard.py
+++ b/tests/ingest/test_stop_hook_mark_guard.py
@@ -1,0 +1,77 @@
+"""Regression lock for #400 — stop hook must not mark a session extracted
+when no ingest process was actually spawned.
+
+Pre-fix: stop.main() called mark_session_extracted unconditionally after
+_run_background_ingestion. That function returns 0 when the spawn cap denies
+it (after queueing to the backlog) or when Popen fails. Marking the session
+extracted at its current size then made should_extract_session() skip it until
+the transcript grew >1KB, silently dropping the session if the backlog drain
+never completed.
+
+Fix: only mark when spawned_pid > 0 (a real ingest process started). The same
+guard is applied in compact.py and user_prompt_submit.py.
+"""
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+
+def _make_transcript(tmp_path, n=6):
+    p = tmp_path / "transcript.jsonl"
+    p.write_text(
+        "\n".join(
+            json.dumps({"type": "user", "message": {"content": f"message number {i}"}})
+            for i in range(n)
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+def _drive_stop(monkeypatch, tmp_path, transcript, return_pid):
+    """Run stop.main() with _run_background_ingestion stubbed to return_pid.
+    Returns the path where the extracted marker would be written."""
+    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import _shared
+
+    monkeypatch.delenv("TRUEMEMORY_EXTRACTION", raising=False)
+    extracted_dir = tmp_path / "extracted"
+    monkeypatch.setattr(_shared, "EXTRACTED_DIR", extracted_dir)
+    monkeypatch.setattr(stop_mod, "TRACE_DIR", tmp_path / "traces")
+    monkeypatch.setattr(stop_mod, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
+    monkeypatch.setattr(
+        stop_mod, "_run_background_ingestion", lambda *a, **k: return_pid
+    )
+
+    stdin_payload = json.dumps(
+        {"transcript_path": str(transcript), "session_id": "sess-400"}
+    )
+    monkeypatch.setattr("sys.stdin", io.StringIO(stdin_payload))
+    stop_mod.main()
+    return _shared._safe_session_id("sess-400"), extracted_dir
+
+
+def test_not_marked_when_spawn_denied(monkeypatch, tmp_path):
+    """pid == 0 (queued to backlog / Popen failure): no extracted marker."""
+    transcript = _make_transcript(tmp_path)
+    safe_id, extracted_dir = _drive_stop(monkeypatch, tmp_path, transcript, return_pid=0)
+    marker = extracted_dir / safe_id
+    assert not marker.exists(), (
+        "#400 regression: session marked extracted despite spawn denial (pid=0)"
+    )
+
+
+def test_marked_when_real_spawn(monkeypatch, tmp_path):
+    """pid > 0 (real ingest process): marker written so concurrent dedup works."""
+    transcript = _make_transcript(tmp_path)
+    safe_id, extracted_dir = _drive_stop(
+        monkeypatch, tmp_path, transcript, return_pid=999_999
+    )
+    marker = extracted_dir / safe_id
+    assert marker.exists(), "session not marked extracted after a real spawn (pid>0)"
+    data = json.loads(marker.read_text(encoding="utf-8"))
+    assert data["pid"] == 999_999

--- a/truememory/ingest/hooks/compact.py
+++ b/truememory/ingest/hooks/compact.py
@@ -84,7 +84,11 @@ def main():
                     transcript_path, session_id,
                     user_id=args.user, db_path=args.db,
                 )
-                mark_session_extracted(session_id, transcript_path, spawned_pid=spawned_pid)
+                # Only mark extracted on a real spawn; pid==0 means the session
+                # was queued to the backlog (spawn cap / Popen failure) and must
+                # stay eligible so it is not silently dropped (see #400).
+                if spawned_pid > 0:
+                    mark_session_extracted(session_id, transcript_path, spawned_pid=spawned_pid)
     except Exception as e:
         log.error("Compact background extraction failed: %s", e)
 

--- a/truememory/ingest/hooks/stop.py
+++ b/truememory/ingest/hooks/stop.py
@@ -156,10 +156,17 @@ def main():
 
     spawned_pid = _run_background_ingestion(transcript_path, session_id, args.user, args.db)
 
-    try:
-        mark_session_extracted(session_id, transcript_path, spawned_pid=spawned_pid)
-    except Exception:
-        pass
+    # Only mark the session extracted when a real ingest process was spawned.
+    # _run_background_ingestion returns 0 when the spawn cap denied it or Popen
+    # failed — in those cases it has already queued the session to the backlog.
+    # Marking it here would make should_extract_session() treat it as processed
+    # (until the transcript grows >1KB), silently dropping the session if the
+    # backlog drain never completes. The CLI marks it on successful completion.
+    if spawned_pid > 0:
+        try:
+            mark_session_extracted(session_id, transcript_path, spawned_pid=spawned_pid)
+        except Exception:
+            pass
 
 
 def _writable_dirs_ok() -> bool:

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -242,7 +242,11 @@ def main():
                     spawned_pid = _run_background_ingestion(
                         transcript_path, session_id, args.user, args.db,
                     )
-                    mark_session_extracted(session_id, transcript_path, spawned_pid=spawned_pid)
+                    # Only mark extracted on a real spawn; pid==0 means the
+                    # session was queued to the backlog and must stay eligible
+                    # so it is not silently dropped (see #400).
+                    if spawned_pid > 0:
+                        mark_session_extracted(session_id, transcript_path, spawned_pid=spawned_pid)
         except Exception:
             pass
 


### PR DESCRIPTION
## What & why

Fixes #400. `stop.py`, `compact.py`, and `user_prompt_submit.py` called `mark_session_extracted` **unconditionally** after `_run_background_ingestion`. That function returns `0` when the spawn cap denied it (after queueing the session to the backlog) or when `Popen` failed (also queued). Marking the session extracted at its current size — with an immediately-dead pid — made `should_extract_session()` treat it as processed until the transcript grew >1KB. If the backlog drain never completed, the session's memories were silently lost.

## Fix

Guard all three spawn-trigger sites with `if spawned_pid > 0:`. Only a real spawn (live pid) marks the session, which preserves the concurrent-dedup purpose of the optimistic mark. When pid==0 the session stays eligible and is retried; `_queue_to_backlog` is idempotent per session (`{session_id}.json`), so no duplicate entries. The extraction-noise path and the ingest CLI still call `mark_session_extracted` with the default pid (`os.getpid()`), so those marks are unchanged.

Note: exponential backoff / retry-cap for the queued-on-every-prompt case (`user_prompt_submit`) is intentionally **out of scope** here and tracked in #401.

## Tests

`tests/ingest/test_stop_hook_mark_guard.py` drives `stop.main()`:
- `test_not_marked_when_spawn_denied` — pid==0 ⇒ no extracted marker
- `test_marked_when_real_spawn` — pid>0 ⇒ marker written with that pid

All 10 existing `test_stop_hook_safety.py` tests still pass.

## Validation

Design and final diff each reviewed by a 7-model panel (gpt-5.3-codex, claude-opus-4.8/4.7/4.6, claude-sonnet-4.6, qwen3.7-max, deepseek-v3.2). Final consensus: **7/7 satisfied**.
