### PR TITLE
fix(consolidation,mcp): shrink summary write-lock window + self-only orphan watcher (#401)

### DIFF
--- a/tests/test_consolidation_lock.py
+++ b/tests/test_consolidation_lock.py
@@ -14,7 +14,6 @@ error). The write lock is held only for the fast bulk write.
 from __future__ import annotations
 
 import sqlite3
-import sys
 
 import pytest
 

--- a/tests/test_consolidation_lock.py
+++ b/tests/test_consolidation_lock.py
@@ -1,0 +1,136 @@
+"""Regression locks for #401 — build_summaries must not hold the SQLite write
+lock during its (30-60s) salience/sentence computation.
+
+Pre-fix: build_summaries ran `DELETE FROM summaries` first, then did all the
+per-month/per-entity scoring inside that open write transaction, committing
+only at the end. The exclusive write lock was held for the whole computation,
+so any concurrent writer failed with "database is locked" once the 10s
+busy_timeout elapsed.
+
+Fix: compute all rows first (reads only, no write transaction), then do
+DELETE + executemany(INSERT) + commit in one short transaction (rollback on
+error). The write lock is held only for the fast bulk write.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+
+import pytest
+
+from truememory.storage import create_db
+from truememory import consolidation
+
+
+def _seed(conn, per_month=8):
+    rows = []
+    for month in ("2026-01", "2026-02", "2026-03"):
+        for i in range(per_month):
+            rows.append((
+                f"Project update {month} #{i}: revenue grew 12 percent and we shipped 3 features.",
+                "alice", "bob", f"{month}-{(i % 27) + 1:02d}T10:00:00Z",
+                "session", "conversation",
+            ))
+    conn.executemany(
+        "INSERT INTO messages (content, sender, recipient, timestamp, category, modality) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+
+
+def test_build_summaries_correctness(tmp_path):
+    """Behavior preserved: summaries are built and the table row count matches."""
+    conn = create_db(str(tmp_path / "c.db"))
+    _seed(conn)
+    n = consolidation.build_summaries(conn)
+    assert n > 0
+    total = conn.execute("SELECT COUNT(*) FROM summaries").fetchone()[0]
+    assert total == n
+    monthly = conn.execute(
+        "SELECT COUNT(*) FROM summaries WHERE period='monthly'"
+    ).fetchone()[0]
+    assert monthly >= 1
+    conn.close()
+
+
+def test_build_summaries_releases_write_lock_during_compute(tmp_path, monkeypatch):
+    """A concurrent writer must succeed WHILE build_summaries is computing.
+
+    This is the #401 lock. We hook `_message_salience` (called during the
+    monthly scoring loop, before the final write) so that on its first call a
+    second connection performs a quick write with a short busy_timeout. Pre-fix
+    the DELETE-first transaction held the write lock and this write would block
+    past the timeout; post-fix there is no open write txn during compute.
+    """
+    db = str(tmp_path / "c.db")
+    conn = create_db(db)
+    conn.execute("PRAGMA journal_mode=WAL")
+    _seed(conn)
+
+    state = {"attempted": False, "ok": None, "err": None}
+    real_salience = consolidation._message_salience
+
+    def hooked(msg):
+        if not state["attempted"]:
+            state["attempted"] = True
+            try:
+                other = sqlite3.connect(db, timeout=0.5)
+                other.execute("PRAGMA busy_timeout=500")
+                other.execute(
+                    "INSERT INTO messages (content, sender, recipient, timestamp, category, modality) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    ("concurrent write probe", "carol", "dave",
+                     "2026-04-01T10:00:00Z", "session", "conversation"),
+                )
+                other.commit()
+                other.close()
+                state["ok"] = True
+            except Exception as e:  # pragma: no cover - failure path is the assertion
+                state["ok"] = False
+                state["err"] = repr(e)
+        return real_salience(msg)
+
+    monkeypatch.setattr(consolidation, "_message_salience", hooked)
+    consolidation.build_summaries(conn)
+    conn.close()
+
+    assert state["attempted"], "compute hook never ran — test setup invalid"
+    assert state["ok"] is True, (
+        f"#401 regression: concurrent write blocked while build_summaries was "
+        f"computing (write lock held during compute): {state['err']}"
+    )
+
+
+def test_build_summaries_atomic_rollback_on_write_failure(tmp_path):
+    """If the bulk insert fails, the prior summaries must survive (the DELETE
+    is rolled back, never leaving the table emptied)."""
+    db = str(tmp_path / "c.db")
+    conn = create_db(db)
+    _seed(conn)
+    n_before = consolidation.build_summaries(conn)
+    assert n_before > 0
+
+    class _FailExecMany:
+        """Forwards everything to the real connection but makes executemany raise."""
+        def __init__(self, real):
+            object.__setattr__(self, "_real", real)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+        def __setattr__(self, name, value):
+            setattr(self._real, name, value)
+
+        def executemany(self, *a, **k):
+            raise sqlite3.OperationalError("simulated write failure")
+
+    proxy = _FailExecMany(conn)
+    with pytest.raises(sqlite3.OperationalError):
+        consolidation.build_summaries(proxy)
+
+    after = conn.execute("SELECT COUNT(*) FROM summaries").fetchone()[0]
+    assert after == n_before, (
+        "rollback should preserve the prior summaries when the bulk insert fails"
+    )
+    conn.close()

--- a/tests/test_parent_death_watcher.py
+++ b/tests/test_parent_death_watcher.py
@@ -1,0 +1,74 @@
+"""Tests for the #401 self-only parent-death watcher.
+
+The MCP server normally exits when its stdio client disconnects, but an
+abrupt parent death (no stdin EOF) can leave it lingering and holding a
+memories.db connection. The watcher self-terminates ONLY this process when its
+launching parent dies (reparent to init, ppid==1). It never signals sibling
+processes, so it cannot kill a live concurrent session's MCP server. Orphaning
+is detected as a transition from a non-1 initial parent to ppid==1, so a server
+launched directly by init/launchd/container init is never falsely killed.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+
+import pytest
+
+import truememory.mcp_server as ms
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="orphan/reparent is POSIX-only")
+def test_is_orphaned_true_on_transition_to_init(monkeypatch):
+    """Started under a real parent, now reparented to init -> orphaned."""
+    monkeypatch.setattr(os, "getppid", lambda: 1)
+    assert ms._is_orphaned(initial_ppid=4321) is True
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="orphan/reparent is POSIX-only")
+def test_is_orphaned_false_when_parent_alive(monkeypatch):
+    monkeypatch.setattr(os, "getppid", lambda: 4321)
+    assert ms._is_orphaned(initial_ppid=4321) is False
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="orphan/reparent is POSIX-only")
+def test_is_orphaned_false_when_launched_under_init(monkeypatch):
+    """If we were ALREADY a child of init at startup (initial_ppid==1), a
+    current ppid of 1 is NOT an orphan transition -> must not report orphaned."""
+    monkeypatch.setattr(os, "getppid", lambda: 1)
+    assert ms._is_orphaned(initial_ppid=1) is False
+
+
+def test_watcher_is_noop_during_extraction(monkeypatch):
+    """Extraction subprocesses must not start the watcher."""
+    monkeypatch.setenv("TRUEMEMORY_EXTRACTION", "1")
+    before = threading.active_count()
+    ms._start_parent_death_watcher(poll_interval=0.01)
+    assert threading.active_count() == before, "watcher thread should not start under extraction"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="watcher is a no-op on Windows")
+def test_watcher_not_started_when_launched_under_init(monkeypatch):
+    """Launched directly by init (ppid==1 at startup): reparent detection is
+    impossible, so the watcher must not start (avoids false-positive exit)."""
+    monkeypatch.delenv("TRUEMEMORY_EXTRACTION", raising=False)
+    monkeypatch.setattr(os, "getppid", lambda: 1)
+    before = threading.active_count()
+    ms._start_parent_death_watcher(poll_interval=0.01)
+    assert threading.active_count() == before, "watcher must not start when launched under init"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="watcher is a no-op on Windows")
+def test_watcher_starts_thread_when_parent_alive(monkeypatch):
+    """With a real (non-init) parent the watcher starts a daemon thread that
+    does not exit the process while the parent stays alive."""
+    monkeypatch.delenv("TRUEMEMORY_EXTRACTION", raising=False)
+    monkeypatch.setattr(os, "getppid", lambda: 4321)  # non-init parent, stays alive
+    before = threading.active_count()
+    ms._start_parent_death_watcher(poll_interval=0.01)
+    import time as _t
+    _t.sleep(0.05)
+    assert threading.active_count() >= before + 1
+    watcher = [t for t in threading.enumerate() if t.name == "parent-death-watcher"]
+    assert watcher and watcher[0].daemon

--- a/truememory/consolidation.py
+++ b/truememory/consolidation.py
@@ -585,11 +585,14 @@ def build_summaries(conn: sqlite3.Connection) -> int:
     if not all_msgs:
         return 0
 
-    # Clear existing summaries for a clean rebuild
-    conn.execute("DELETE FROM summaries")
-
     now = datetime.now(timezone.utc).isoformat()
-    summary_count = 0
+    # Collect all summary rows first WITHOUT opening a write transaction, so the
+    # heavy salience/sentence scoring below does not hold the SQLite write lock.
+    # The clear + bulk insert happens in one short transaction at the very end
+    # (see #401: the old code ran DELETE first and held the write lock for the
+    # entire 30-60s computation, causing "database is locked" for concurrent
+    # writers once the 10s busy_timeout was exceeded).
+    rows: list[tuple] = []
 
     # ---- Monthly summaries ----
     by_month: dict[str, list[dict]] = defaultdict(list)
@@ -662,23 +665,16 @@ def build_summaries(conn: sqlite3.Connection) -> int:
         start_date = min(timestamps) if timestamps else f"{month}-01"
         end_date = max(timestamps) if timestamps else f"{month}-28"
 
-        conn.execute(
-            "INSERT INTO summaries "
-            "(period, start_date, end_date, entity, summary, "
-            " key_facts, message_ids, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (
-                "monthly",
-                start_date,
-                end_date,
-                "",
-                summary_text,
-                json.dumps(key_facts),
-                json.dumps(message_ids),
-                now,
-            ),
-        )
-        summary_count += 1
+        rows.append((
+            "monthly",
+            start_date,
+            end_date,
+            "",
+            summary_text,
+            json.dumps(key_facts),
+            json.dumps(message_ids),
+            now,
+        ))
 
     # ---- Per-entity summaries ----
     by_entity: dict[str, list[dict]] = defaultdict(list)
@@ -725,26 +721,53 @@ def build_summaries(conn: sqlite3.Connection) -> int:
             start_date = min(timestamps) if timestamps else f"{month}-01"
             end_date = max(timestamps) if timestamps else f"{month}-28"
 
-            conn.execute(
+            rows.append((
+                "entity_monthly",
+                start_date,
+                end_date,
+                entity,
+                summary_text,
+                json.dumps(key_facts),
+                json.dumps(message_ids),
+                now,
+            ))
+
+    # Short, explicit, atomic write: hold the write lock only for the clear +
+    # bulk insert, not the computation above. We drive the transaction manually
+    # and switch the connection to autocommit (isolation_level=None) for the
+    # duration so pysqlite does NOT also manage transactions implicitly — this
+    # makes our BEGIN IMMEDIATE / COMMIT / ROLLBACK authoritative regardless of
+    # the connection's configured isolation_level (avoids both "cannot start a
+    # transaction within a transaction" and pysqlite's commit()/rollback()
+    # becoming no-ops after a manual BEGIN). Any pending implicit transaction is
+    # flushed first so the write lock is acquired cleanly, and isolation_level
+    # is always restored. Rollback-on-error guarantees the summaries table is
+    # never left emptied without its replacement rows.
+    if conn.in_transaction:
+        conn.commit()
+    prev_isolation = conn.isolation_level
+    try:
+        conn.isolation_level = None
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("DELETE FROM summaries")
+        if rows:
+            conn.executemany(
                 "INSERT INTO summaries "
                 "(period, start_date, end_date, entity, summary, "
                 " key_facts, message_ids, created_at) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    "entity_monthly",
-                    start_date,
-                    end_date,
-                    entity,
-                    summary_text,
-                    json.dumps(key_facts),
-                    json.dumps(message_ids),
-                    now,
-                ),
+                rows,
             )
-            summary_count += 1
-
-    conn.commit()
-    return summary_count
+        conn.execute("COMMIT")
+    except Exception:
+        try:
+            conn.execute("ROLLBACK")
+        except Exception:
+            pass
+        raise
+    finally:
+        conn.isolation_level = prev_isolation
+    return len(rows)
 
 
 def search_contradictions(conn: sqlite3.Connection,

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1297,6 +1297,77 @@ def _start_backlog_drainer() -> None:
     log.info("Backlog drainer started (interval=%ds)", _BACKLOG_DRAIN_INTERVAL_NORMAL)
 
 
+def _is_orphaned(initial_ppid: int | None = None) -> bool:
+    """True if this process has been orphaned (its launching parent died).
+
+    Orphaning is detected as a *transition*: a POSIX process whose parent dies
+    is reparented to init (pid 1 — ``init`` on Linux, ``launchd`` on macOS). We
+    therefore report orphaned only when the parent pid has CHANGED to 1 from a
+    non-1 ``initial_ppid``.
+
+    A process that was launched *directly* by init (``initial_ppid == 1`` — e.g.
+    systemd/launchd units or a container entrypoint) can never be detected as
+    orphaned this way, so callers should not start the watcher in that case.
+    Passing ``initial_ppid=None`` falls back to a bare ``ppid == 1`` check
+    (used only where no baseline is available). Windows has no equivalent
+    reparent signal, so we never report orphaned there.
+    """
+    if sys.platform == "win32" or not hasattr(os, "getppid"):
+        return False
+    try:
+        current = os.getppid()
+    except Exception:
+        return False
+    if initial_ppid is not None:
+        return initial_ppid != 1 and current == 1
+    return current == 1
+
+
+def _start_parent_death_watcher(poll_interval: float = 30.0) -> None:
+    """Self-terminate this MCP server if its launching parent dies.
+
+    The server normally exits when its stdio client disconnects (``mcp.run``
+    returns on EOF; see the finally block in ``main``). But if the parent dies
+    abruptly without closing stdin (e.g. a crash), the server can linger
+    holding a ``memories.db`` connection and contributing to write-lock
+    contention (#401). This watcher records the launching parent pid and exits
+    ONLY the current process once it is reparented to init. It never inspects
+    or signals sibling processes, so it cannot kill a live concurrent session's
+    MCP server. POSIX-only; a no-op on Windows.
+
+    If the server was launched directly by init (``ppid == 1`` at startup —
+    systemd/launchd/container entrypoint), reparent-based orphan detection is
+    impossible, so the watcher is not started (avoids a false-positive
+    self-exit of a perfectly live server).
+    """
+    if os.environ.get("TRUEMEMORY_EXTRACTION"):
+        return
+    if sys.platform == "win32" or not hasattr(os, "getppid"):
+        return
+    try:
+        initial_ppid = os.getppid()
+    except Exception:
+        return
+    if initial_ppid == 1:
+        log.info("Parent-death watcher disabled: launched as a child of init (ppid==1)")
+        return
+
+    def _watch() -> None:
+        while True:
+            if _is_orphaned(initial_ppid):
+                # os._exit(0) without touching the shared DB connection: the
+                # connection may be in use by the main thread, and SQLite WAL
+                # tolerates an abrupt exit. (Matches the os._exit rationale in
+                # main()'s shutdown path.)
+                log.info("MCP server orphaned (parent died); exiting to release the DB connection")
+                os._exit(0)
+            time.sleep(poll_interval)
+
+    t = threading.Thread(target=_watch, daemon=True, name="parent-death-watcher")
+    t.start()
+    log.info("Parent-death watcher started (poll=%.0fs)", poll_interval)
+
+
 # ---------------------------------------------------------------------------
 # Auto-setup for Claude Code and Claude Desktop
 # ---------------------------------------------------------------------------
@@ -1625,6 +1696,11 @@ def main():
     # transcripts every 60s while the MCP server is alive, respecting
     # the spawn cap. Dies automatically when the server exits.
     _start_backlog_drainer()
+
+    # Self-terminate if orphaned (parent died without closing stdin) so we do
+    # not linger holding a memories.db connection. Self-only: never signals
+    # sibling MCP servers, so concurrent live sessions are unaffected (#401).
+    _start_parent_death_watcher()
 
     # Force-exit after mcp.run() to avoid PyTorch teardown deadlocks.
     # PyTorch's C++ threads (OpenMP pools, autograd engine) deadlock against


### PR DESCRIPTION
## What & why

Fixes #401 ("database is locked" under concurrent MCP + ingest load; lingering MCP processes holding `memories.db`). Two targeted changes, deliberately scoped to avoid risky approaches.

### 1. Shrink the consolidation write-lock window (the primary lock cause)

`consolidation.build_summaries` held the SQLite **write lock for its entire 30-60s computation**: it ran `DELETE FROM summaries` first, then did all per-month/per-entity salience + sentence scoring *inside that open write transaction*, committing only at the end. Any concurrent writer (the MCP server, another ingest) then failed once the 10s `busy_timeout` elapsed.

Now it is **compute-then-write**: all summary rows are computed first with **no** write transaction, then a single short atomic write — `BEGIN IMMEDIATE` + `DELETE` + `executemany(INSERT)` + `COMMIT`, with rollback on error. The connection is switched to autocommit (`isolation_level=None`) for that block so the manual transaction control is authoritative regardless of the configured `isolation_level` (avoids pysqlite's implicit-transaction pitfalls), any pending transaction is flushed first, and `isolation_level` is always restored.

### 2. Self-only parent-death watcher

The server already exits on a clean stdio disconnect (`mcp.run` returns on EOF). But an **abrupt** parent death (no stdin EOF) can leave it lingering and holding a `memories.db` connection. The watcher records the launching parent pid and `os._exit(0)`s **only this process** when it is reparented to init (transition: `initial_ppid != 1 and current == 1`). It is **not started** when launched directly under init (`ppid == 1` — systemd/launchd/container), and it never inspects or signals sibling processes, so a **live concurrent session's MCP server is never killed**.

### Explicitly out of scope (by design)
- Startup sibling reaper — too risky; would kill live concurrent Claude sessions.
- `busy_timeout` change — already 10s.
- App-level write-retry wrapper / global single-writer queue — premature; the consolidation fix removes the dominant lock holder. Revisit if contention persists.
- `os._exit(0)` shutdown path — already correct (documented PyTorch teardown reason).

## Tests

- `tests/test_consolidation_lock.py`: a concurrent writer succeeds **while** `build_summaries` is computing (the core regression lock), behavior preserved, atomic rollback on write failure.
- `tests/test_parent_death_watcher.py`: transition detection, no false-positive when launched under init, no-op under extraction, daemon thread when parent alive.
- Existing ingest/L4 consolidation tests still pass (build_summaries runs inside `engine.ingest`).

## Validation

Design and three validation rounds, each by a 7-model panel (gpt-5.3-codex, claude-opus-4.8/4.7/4.6, claude-sonnet-4.6, qwen3.7-max, deepseek-v3.2). Rounds 1-2 surfaced the watcher false-positive (launched-under-init) and the pysqlite transaction hazard; both were fixed. Final consensus: **7/7 satisfied**.
