### PR TITLE
fix(install): remove redundant 2>$null redirect in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -87,7 +87,7 @@ if ($LASTEXITCODE -ne 0) {
 
 # ---------- step 3: install truememory as a uv tool ----------
 Say "installing $PKG_SPEC (~3-5 min on first run, downloads all tier models)..."
-& uv tool uninstall truememory 2>$null *> $null
+& uv tool uninstall truememory *> $null
 if ($LASTEXITCODE -gt 1) {
     Warn "uv tool uninstall returned $LASTEXITCODE — proceeding, but result may be partial"
 }


### PR DESCRIPTION
## Summary

Removes the redundant `2>$null` before `*>$null` on the `uv tool uninstall` line in `install.ps1`. Since `*>$null` already suppresses all PowerShell output streams (stdout, stderr, verbose, warning, debug), the preceding `2>$null` has no effect.

## Credit

Issue spotted by @shivamverma1999 in #414 — committed under their authorship.