### PR TITLE
fix(cursor-adapter): correct event names and timeout units

### DIFF
--- a/tests/test_cursor_adapter.py
+++ b/tests/test_cursor_adapter.py
@@ -402,3 +402,121 @@ def test_hook_timeouts_are_in_seconds(tmp_path, monkeypatch):
                     f"Timeout for {event_name!r} is {timeout}; expected 1-120 seconds, "
                     f"not milliseconds"
                 )
+
+
+def test_install_migrates_stale_user_prompt_submit(tmp_path, monkeypatch):
+    """Upgrade migration: old userPromptSubmit entries are removed, replaced by
+    beforeSubmitPrompt. Stale event should not remain in hooks.json."""
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+
+    # Pre-seed with the old buggy config
+    old_config = {
+        "version": 1,
+        "hooks": {
+            "sessionStart": [
+                {"command": "/usr/bin/python3 /path/to/truememory/session_start.py", "timeout": 10000}
+            ],
+            "stop": [
+                {"command": "/usr/bin/python3 /path/to/truememory/stop.py", "timeout": 5000}
+            ],
+            "userPromptSubmit": [
+                {"command": "/usr/bin/python3 /path/to/truememory/user_prompt_submit.py", "timeout": 5000}
+            ],
+            "preCompact": [
+                {"command": "/usr/bin/python3 /path/to/truememory/compact.py", "timeout": 5000}
+            ],
+        },
+    }
+    hook_path.write_text(json.dumps(old_config), encoding="utf-8")
+
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(hook_path.read_text(encoding="utf-8"))
+    hooks = data["hooks"]
+
+    # Stale event must be gone
+    assert "userPromptSubmit" not in hooks, (
+        "userPromptSubmit should be removed during migration"
+    )
+    # Correct event must exist
+    assert "beforeSubmitPrompt" in hooks
+    assert len(hooks["beforeSubmitPrompt"]) == 1
+    assert "truememory" in hooks["beforeSubmitPrompt"][0]["command"].lower()
+
+
+def test_install_updates_stale_millisecond_timeouts(tmp_path, monkeypatch):
+    """Upgrade migration: existing TrueMemory hooks with old millisecond timeout
+    values should be updated to seconds on re-install."""
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+
+    # Pre-seed with old ms-based timeouts
+    old_config = {
+        "version": 1,
+        "hooks": {
+            "sessionStart": [
+                {"command": "/usr/bin/python3 /path/to/truememory/session_start.py", "timeout": 10000}
+            ],
+            "stop": [
+                {"command": "/usr/bin/python3 /path/to/truememory/stop.py", "timeout": 5000}
+            ],
+            "preCompact": [
+                {"command": "/usr/bin/python3 /path/to/truememory/compact.py", "timeout": 5000}
+            ],
+        },
+    }
+    hook_path.write_text(json.dumps(old_config), encoding="utf-8")
+
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(hook_path.read_text(encoding="utf-8"))
+    hooks = data["hooks"]
+
+    # All timeouts should now be in seconds
+    assert hooks["sessionStart"][0]["timeout"] == 10
+    assert hooks["stop"][0]["timeout"] == 5
+    assert hooks["preCompact"][0]["timeout"] == 5
+
+
+def test_install_preserves_non_truememory_hooks(tmp_path, monkeypatch):
+    """Migration must not remove hooks that belong to other tools."""
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+
+    # Pre-seed with mixed config: TrueMemory + user's own hook
+    old_config = {
+        "version": 1,
+        "hooks": {
+            "userPromptSubmit": [
+                {"command": "/usr/bin/python3 /path/to/truememory/user_prompt_submit.py", "timeout": 5000},
+                {"command": "/usr/local/bin/my-custom-linter", "timeout": 10},
+            ],
+            "sessionStart": [
+                {"command": "/usr/bin/python3 /path/to/truememory/session_start.py", "timeout": 10000}
+            ],
+        },
+    }
+    hook_path.write_text(json.dumps(old_config), encoding="utf-8")
+
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(hook_path.read_text(encoding="utf-8"))
+    hooks = data["hooks"]
+
+    # User's custom linter under the stale event name should survive
+    assert "userPromptSubmit" in hooks
+    assert len(hooks["userPromptSubmit"]) == 1
+    assert "my-custom-linter" in hooks["userPromptSubmit"][0]["command"]
+
+    # TrueMemory should now be under the correct event
+    assert "beforeSubmitPrompt" in hooks

--- a/tests/test_cursor_adapter.py
+++ b/tests/test_cursor_adapter.py
@@ -129,6 +129,7 @@ def test_install_hooks_creates_entries(tmp_path, monkeypatch):
     hooks = data["hooks"]
     assert "sessionStart" in hooks
     assert "stop" in hooks
+    assert "beforeSubmitPrompt" in hooks
     assert "preCompact" in hooks
     assert len(hooks["sessionStart"]) == 1
     assert "truememory" in hooks["sessionStart"][0]["command"].lower()
@@ -361,3 +362,43 @@ def test_hook_events_are_camelcase(tmp_path, monkeypatch):
     event_names = list(data["hooks"].keys())
     for name in event_names:
         assert name[0].islower(), f"Event {name!r} should be camelCase, not PascalCase"
+
+
+def test_hook_uses_before_submit_prompt_not_user_prompt_submit(tmp_path, monkeypatch):
+    """Regression: Cursor's event is beforeSubmitPrompt, not userPromptSubmit."""
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(hook_path.read_text(encoding="utf-8"))
+    hooks = data["hooks"]
+    assert "beforeSubmitPrompt" in hooks, "Expected beforeSubmitPrompt event"
+    assert "userPromptSubmit" not in hooks, (
+        "userPromptSubmit is a Claude Code event name, not a Cursor event"
+    )
+    assert len(hooks["beforeSubmitPrompt"]) == 1
+    assert "truememory" in hooks["beforeSubmitPrompt"][0]["command"].lower()
+
+
+def test_hook_timeouts_are_in_seconds(tmp_path, monkeypatch):
+    """Cursor hook timeouts are in seconds. Values like 5000 or 10000 are wrong
+    (those would be interpreted as 5000/10000 seconds). Sane values are 1-120."""
+    from truememory.hooks.adapters import cursor as cursor_mod
+    hook_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(cursor_mod, "_HOOK_CONFIG", hook_path)
+    from truememory.hooks.adapters.cursor import CursorAdapter
+    adapter = CursorAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(hook_path.read_text(encoding="utf-8"))
+    for event_name, entries in data["hooks"].items():
+        for entry in entries:
+            timeout = entry.get("timeout")
+            if timeout is not None:
+                assert 1 <= timeout <= 120, (
+                    f"Timeout for {event_name!r} is {timeout}; expected 1-120 seconds, "
+                    f"not milliseconds"
+                )

--- a/truememory/hooks/adapters/cursor.py
+++ b/truememory/hooks/adapters/cursor.py
@@ -3,7 +3,7 @@
 Cursor uses TWO separate config files:
 - ~/.cursor/mcp.json for MCP server registration
 - ~/.cursor/hooks.json for hook registration (with "version": 1 top-level key)
-- camelCase event names: sessionStart, stop, preCompact
+- camelCase event names: sessionStart, stop, beforeSubmitPrompt, preCompact
 """
 from __future__ import annotations
 
@@ -22,19 +22,19 @@ _HOOK_CONFIG = _CURSOR_DIR / "hooks.json"
 _HOOK_EVENTS = {
     "sessionStart": {
         "script": "session_start.py",
-        "timeout": 10000,
+        "timeout": 10,
     },
     "stop": {
         "script": "stop.py",
-        "timeout": 5000,
+        "timeout": 5,
     },
-    "userPromptSubmit": {
+    "beforeSubmitPrompt": {
         "script": "user_prompt_submit.py",
-        "timeout": 5000,
+        "timeout": 5,
     },
     "preCompact": {
         "script": "compact.py",
-        "timeout": 5000,
+        "timeout": 5,
     },
 }
 

--- a/truememory/hooks/adapters/cursor.py
+++ b/truememory/hooks/adapters/cursor.py
@@ -38,6 +38,9 @@ _HOOK_EVENTS = {
     },
 }
 
+# Legacy event names from prior buggy versions that must be cleaned up.
+_STALE_EVENTS = ("userPromptSubmit",)
+
 _TRUEMEMORY_MARKER = "truememory"
 
 _SYSTEM_PROMPT_TEMPLATE = """\
@@ -152,6 +155,36 @@ class CursorAdapter(CLIAdapter):
         if not isinstance(hooks, dict):
             hooks = {}
             existing["hooks"] = hooks
+
+        # --- Migration: remove stale event names from prior versions ---
+        for stale in _STALE_EVENTS:
+            stale_list = hooks.get(stale)
+            if not isinstance(stale_list, list):
+                continue
+            cleaned = [
+                h for h in stale_list
+                if not (
+                    isinstance(h, dict)
+                    and _TRUEMEMORY_MARKER in h.get("command", "").lower()
+                )
+            ]
+            if cleaned:
+                hooks[stale] = cleaned
+            else:
+                hooks.pop(stale, None)
+
+        # --- Migration: update existing TrueMemory hook timeouts ---
+        for event, info in _HOOK_EVENTS.items():
+            event_list = hooks.get(event)
+            if not isinstance(event_list, list):
+                continue
+            for entry in event_list:
+                if (
+                    isinstance(entry, dict)
+                    and _TRUEMEMORY_MARKER in entry.get("command", "").lower()
+                    and entry.get("timeout") != info["timeout"]
+                ):
+                    entry["timeout"] = info["timeout"]
 
         for event, info in _HOOK_EVENTS.items():
             event_list = hooks.setdefault(event, [])


### PR DESCRIPTION
## Summary

Fixes two bugs in the Cursor adapter: wrong event name (`userPromptSubmit` should be `beforeSubmitPrompt`) and timeout values in milliseconds instead of seconds.

Fixes #428

## Changes
- `truememory/hooks/adapters/cursor.py` — corrected event name, converted timeouts to seconds, added migration logic for stale entries.
- `tests/test_cursor_adapter.py` — added tests for the corrected format and migration.