### PR TITLE
fix(gemini-adapter): correct hook structure with nested format and type field

### DIFF
--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -128,16 +128,53 @@ def test_install_hooks_creates_entries(tmp_path, monkeypatch):
 
     data = json.loads(config_path.read_text(encoding="utf-8"))
     hooks = data["hooks"]
+    # Correct event names
     assert "SessionStart" in hooks
     assert "SessionEnd" in hooks
     assert "PreCompress" in hooks
+    assert "BeforeAgent" in hooks
+    # UserPromptSubmit should NOT be present (invalid event name)
+    assert "UserPromptSubmit" not in hooks
+    # Each event has exactly one HookDefinition
     assert len(hooks["SessionStart"]) == 1
-    assert "truememory" in hooks["SessionStart"][0]["command"].lower()
+    # Verify nested HookDefinition format
+    hook_def = hooks["SessionStart"][0]
+    assert "hooks" in hook_def, "HookDefinition must contain 'hooks' sub-array"
+    inner = hook_def["hooks"]
+    assert len(inner) == 1
+    assert inner[0]["type"] == "command"
+    assert "truememory" in inner[0]["command"].lower()
+    assert "name" in inner[0]
+    assert "timeout" in inner[0]
+
+
+def test_install_hooks_nested_format_structure(tmp_path, monkeypatch):
+    """Verify the exact nested structure matches Gemini CLI's HookDefinition type."""
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    for event_name, entries in data["hooks"].items():
+        for hook_def in entries:
+            # Top level is HookDefinition with 'hooks' array
+            assert isinstance(hook_def, dict)
+            assert "hooks" in hook_def
+            assert isinstance(hook_def["hooks"], list)
+            for hc in hook_def["hooks"]:
+                # Each inner entry is a CommandHookConfig
+                assert hc["type"] == "command"
+                assert isinstance(hc["command"], str)
+                assert isinstance(hc.get("timeout", 0), int)
 
 
 def test_install_hooks_preserves_existing(tmp_path, monkeypatch):
     from truememory.hooks.adapters import gemini as gemini_mod
     config_path = tmp_path / "settings.json"
+    # Pre-existing hook in legacy flat format (user's own hook, not TrueMemory)
     config_path.write_text(json.dumps({
         "hooks": {
             "SessionStart": [
@@ -153,8 +190,15 @@ def test_install_hooks_preserves_existing(tmp_path, monkeypatch):
 
     data = json.loads(config_path.read_text(encoding="utf-8"))
     assert data["theme"] == "dark"
+    # Original hook preserved + TrueMemory hook added
     assert len(data["hooks"]["SessionStart"]) == 2
+    # First entry is the pre-existing one (flat format, preserved as-is)
     assert data["hooks"]["SessionStart"][0]["command"] == "my-custom-hook"
+    # Second entry is TrueMemory in correct nested format
+    tm_entry = data["hooks"]["SessionStart"][1]
+    assert "hooks" in tm_entry
+    assert tm_entry["hooks"][0]["type"] == "command"
+    assert "truememory" in tm_entry["hooks"][0]["command"].lower()
 
 
 def test_install_hooks_idempotent(tmp_path, monkeypatch):
@@ -187,8 +231,13 @@ def test_uninstall_removes_entries(tmp_path, monkeypatch):
     data = json.loads(config_path.read_text(encoding="utf-8"))
     assert "truememory" not in data.get("mcpServers", {})
     hooks = data.get("hooks", {})
-    for entries in hooks.values():
+    for event_name, entries in hooks.items():
         for h in entries:
+            # Check nested format
+            inner = h.get("hooks", [])
+            for hc in inner:
+                assert "truememory" not in hc.get("command", "").lower()
+            # Check flat format
             assert "truememory" not in h.get("command", "").lower()
 
 
@@ -219,6 +268,28 @@ def test_uninstall_preserves_other_entries(tmp_path, monkeypatch):
     assert data["theme"] == "dark"
     assert len(data["hooks"]["SessionStart"]) == 1
     assert data["hooks"]["SessionStart"][0]["command"] == "my-hook"
+
+
+def test_uninstall_removes_nested_format(tmp_path, monkeypatch):
+    """Verify uninstall correctly removes hooks in the nested HookDefinition format."""
+    from truememory.hooks.adapters import gemini as gemini_mod
+    config_path = tmp_path / "settings.json"
+    config_path.write_text(json.dumps({
+        "hooks": {
+            "SessionStart": [
+                {"hooks": [{"type": "command", "command": "my-hook", "timeout": 5000}]},
+                {"hooks": [{"type": "command", "command": "/path/to/truememory/session_start.py", "timeout": 10000, "name": "truememory-sessionstart"}]},
+            ]
+        },
+    }), encoding="utf-8")
+    monkeypatch.setattr(gemini_mod, "_CONFIG_PATH", config_path)
+    from truememory.hooks.adapters.gemini import GeminiAdapter
+    adapter = GeminiAdapter()
+    adapter.uninstall()
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert len(data["hooks"]["SessionStart"]) == 1
+    assert data["hooks"]["SessionStart"][0]["hooks"][0]["command"] == "my-hook"
 
 
 # -- is_configured --

--- a/truememory/hooks/adapters/gemini.py
+++ b/truememory/hooks/adapters/gemini.py
@@ -1,10 +1,14 @@
-"""Gemini CLI adapter — MCP config + JSON lifecycle hooks.
+"""Gemini CLI adapter -- MCP config + JSON lifecycle hooks.
 
 Gemini CLI uses:
 - ~/.gemini/settings.json for BOTH MCP server registration AND hook registration
 - MCP under mcpServers key (Claude Desktop-compatible format)
-- Hooks under hooks key with PascalCase event names
+- Hooks under hooks key with PascalCase event names, nested HookDefinition format
 - Same JSON stdin/stdout hook protocol as Claude Code
+
+Hook format (from google-gemini/gemini-cli TypeScript types):
+  HookDefinition: { matcher?: string, sequential?: bool, hooks: HookConfig[] }
+  CommandHookConfig: { type: "command", command: string, name?: string, timeout?: number }
 """
 from __future__ import annotations
 
@@ -28,7 +32,7 @@ _HOOK_EVENTS = {
         "script": "stop.py",
         "timeout": 5000,
     },
-    "UserPromptSubmit": {
+    "BeforeAgent": {
         "script": "user_prompt_submit.py",
         "timeout": 5000,
     },
@@ -41,7 +45,7 @@ _HOOK_EVENTS = {
 _TRUEMEMORY_MARKER = "truememory"
 
 _SYSTEM_PROMPT_TEMPLATE = """\
-# TrueMemory — Persistent Memory
+# TrueMemory -- Persistent Memory
 
 TrueMemory is the **primary long-horizon memory** for this user. \
 It persists facts, preferences, decisions, and corrections across \
@@ -54,7 +58,7 @@ When the `truememory` MCP server is connected, follow these rules:
 broad query about the user to load relevant memories before responding.
 - Before making recommendations, check TrueMemory for stored preferences.
 - When the user asks anything about past conversations or personal \
-facts — search TrueMemory first.
+facts -- search TrueMemory first.
 
 ## Auto-Store (during conversation)
 - When the user shares a personal preference, store it immediately \
@@ -70,7 +74,7 @@ debugging context.
 background processing.
 - The SessionEnd hook captures the full transcript and runs deep extraction \
 after sessions end.
-- You do NOT need to store everything manually — focus on \
+- You do NOT need to store everything manually -- focus on \
 in-conversation corrections and explicit preferences.
 """
 
@@ -139,8 +143,12 @@ class GeminiAdapter(CLIAdapter):
             script_path = hooks_dir / info["script"]
             cmd = self._build_command(py, script_path, user_id, db_path)
             event_list.append({
-                "command": cmd,
-                "timeout": info["timeout"],
+                "hooks": [{
+                    "type": "command",
+                    "command": cmd,
+                    "name": f"truememory-{event.lower()}",
+                    "timeout": info["timeout"],
+                }],
             })
 
         self._write_config(settings)
@@ -162,10 +170,7 @@ class GeminiAdapter(CLIAdapter):
                     continue
                 cleaned = [
                     h for h in entries
-                    if not (
-                        isinstance(h, dict)
-                        and _TRUEMEMORY_MARKER in h.get("command", "").lower()
-                    )
+                    if not self._definition_has_truememory(h)
                 ]
                 if cleaned:
                     hooks[event] = cleaned
@@ -249,9 +254,34 @@ class GeminiAdapter(CLIAdapter):
         return False
 
     @staticmethod
+    def _definition_has_truememory(hook_def: object) -> bool:
+        """Check if a HookDefinition contains a TrueMemory hook config.
+
+        Handles both the correct nested format:
+            {"hooks": [{"type": "command", "command": "...truememory..."}]}
+        and the legacy flat format (for migration):
+            {"command": "...truememory...", "timeout": 10000}
+        """
+        if not isinstance(hook_def, dict):
+            return False
+        # Correct nested format: check inside hooks sub-array
+        inner_hooks = hook_def.get("hooks", [])
+        if isinstance(inner_hooks, list):
+            for hc in inner_hooks:
+                if (
+                    isinstance(hc, dict)
+                    and _TRUEMEMORY_MARKER in hc.get("command", "").lower()
+                ):
+                    return True
+        # Legacy flat format fallback
+        if _TRUEMEMORY_MARKER in hook_def.get("command", "").lower():
+            return True
+        return False
+
+    @staticmethod
     def _event_has_truememory(entries: list) -> bool:
+        """Check if any HookDefinition in the event list is a TrueMemory hook."""
         return any(
-            isinstance(h, dict)
-            and _TRUEMEMORY_MARKER in h.get("command", "").lower()
+            GeminiAdapter._definition_has_truememory(h)
             for h in entries
         )


### PR DESCRIPTION
## Summary

Fixes the Gemini CLI adapter to use the correct nested hook format with `type` field. The adapter was writing flat `{command, timeout}` objects that Gemini CLI doesn't recognize.

Fixes #429

## Changes
- `truememory/hooks/adapters/gemini.py` — corrected hook structure to nested format with `type = "command"`, fixed event names.
- `tests/test_gemini_adapter.py` — expanded test coverage.

## Evidence
Based on google-gemini/gemini-cli source code and settings.json schema.