### PR TITLE
fix(kimi-adapter): convert timeout values from milliseconds to seconds

### DIFF
--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -203,3 +203,47 @@ def test_build_command_with_user_and_db():
     assert "--user" in cmd
     assert "alice" in cmd
     assert "--db" in cmd
+
+
+# -- Timeout values (regression test for ms-vs-seconds bug) --
+
+def test_hook_timeout_values_are_seconds(tmp_path, monkeypatch):
+    """Kimi CLI interprets timeout as seconds; verify we don't emit milliseconds."""
+    from truememory.hooks.adapters import kimi as kimi_mod
+    hook_config = tmp_path / "config.toml"
+    monkeypatch.setattr(kimi_mod, "_HOOK_CONFIG", hook_config)
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+    adapter.install_hooks(python_path="/usr/bin/python3")
+
+    text = hook_config.read_text(encoding="utf-8")
+    # SessionStart gets 10s, everything else gets 5s
+    assert "timeout = 10" in text
+    assert "timeout = 5" in text
+    # Must NOT contain millisecond values
+    assert "timeout = 10000" not in text
+    assert "timeout = 5000" not in text
+
+
+# -- Uninstall with blank lines in TOML (regression test) --
+
+def test_uninstall_handles_blank_lines_in_hook_block(tmp_path, monkeypatch):
+    """Hook blocks with internal blank lines must be fully removed."""
+    from truememory.hooks.adapters import kimi as kimi_mod
+    hook_config = tmp_path / "config.toml"
+    mcp_path = tmp_path / "mcp.json"
+    # Write a hook block that has a blank line inside it
+    hook_config.write_text(
+        '[[hooks]]\nevent = "SessionStart"\ncommand = "python truememory/ingest/hooks/session_start.py"\n\ntimeout = 10\n',
+        encoding="utf-8",
+    )
+    mcp_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(kimi_mod, "_HOOK_CONFIG", hook_config)
+    monkeypatch.setattr(kimi_mod, "_MCP_CONFIG", mcp_path)
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+    adapter.uninstall()
+
+    text = hook_config.read_text(encoding="utf-8")
+    assert "truememory" not in text.lower()
+    assert "timeout" not in text

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -247,3 +247,37 @@ def test_uninstall_handles_blank_lines_in_hook_block(tmp_path, monkeypatch):
     text = hook_config.read_text(encoding="utf-8")
     assert "truememory" not in text.lower()
     assert "timeout" not in text
+
+
+# -- Uninstall preserves non-TrueMemory content (regression test) --
+
+def test_uninstall_preserves_unrelated_hooks_and_tables(tmp_path, monkeypatch):
+    """Uninstall must not delete user hooks or unrelated TOML tables."""
+    from truememory.hooks.adapters import kimi as kimi_mod
+    hook_config = tmp_path / "config.toml"
+    mcp_path = tmp_path / "mcp.json"
+    hook_config.write_text(
+        '[[hooks]]\nevent = "SessionStart"\n'
+        'command = "python truememory/ingest/hooks/session_start.py"\n\n'
+        'timeout = 10\n\n'
+        '[[hooks]]\nevent = "Stop"\n'
+        'command = "my-own-script.sh"\ntimeout = 30\n\n'
+        '[settings]\ntheme = "dark"\n',
+        encoding="utf-8",
+    )
+    mcp_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(kimi_mod, "_HOOK_CONFIG", hook_config)
+    monkeypatch.setattr(kimi_mod, "_MCP_CONFIG", mcp_path)
+    from truememory.hooks.adapters.kimi import KimiAdapter
+    adapter = KimiAdapter()
+    adapter.uninstall()
+
+    text = hook_config.read_text(encoding="utf-8")
+    # TrueMemory hook must be gone
+    assert "truememory" not in text.lower()
+    # User's own hook must survive
+    assert "my-own-script.sh" in text
+    assert 'event = "Stop"' in text
+    # Unrelated TOML table must survive
+    assert "[settings]" in text
+    assert 'theme = "dark"' in text

--- a/truememory/hooks/adapters/kimi.py
+++ b/truememory/hooks/adapters/kimi.py
@@ -25,19 +25,19 @@ _HOOK_CONFIG = _KIMI_DIR / "config.toml"
 _HOOK_EVENTS = {
     "SessionStart": {
         "script": "session_start.py",
-        "timeout": 10000,
+        "timeout": 10,  # seconds (Kimi CLI convention)
     },
     "Stop": {
         "script": "stop.py",
-        "timeout": 5000,
+        "timeout": 5,  # seconds
     },
     "UserPromptSubmit": {
         "script": "user_prompt_submit.py",
-        "timeout": 5000,
+        "timeout": 5,  # seconds
     },
     "PreCompact": {
         "script": "compact.py",
-        "timeout": 5000,
+        "timeout": 5,  # seconds
     },
 }
 
@@ -264,7 +264,7 @@ class KimiAdapter(CLIAdapter):
             if stripped == "[[hooks]]":
                 block_lines = [line]
                 i += 1
-                while i < len(lines) and lines[i].strip() and not lines[i].strip().startswith("[["):
+                while i < len(lines) and not lines[i].strip().startswith("[["):
                     block_lines.append(lines[i])
                     i += 1
 

--- a/truememory/hooks/adapters/kimi.py
+++ b/truememory/hooks/adapters/kimi.py
@@ -264,7 +264,7 @@ class KimiAdapter(CLIAdapter):
             if stripped == "[[hooks]]":
                 block_lines = [line]
                 i += 1
-                while i < len(lines) and not lines[i].strip().startswith("[["):
+                while i < len(lines) and not lines[i].strip().startswith("["):
                     block_lines.append(lines[i])
                     i += 1
 


### PR DESCRIPTION
## Summary

Fixes the Kimi CLI adapter's timeout values from milliseconds (10000, 5000) to seconds (10, 5). Kimi CLI interprets the timeout field as seconds, so the old values created ~2.7 hour timeouts.

Fixes #430

## Changes
- `truememory/hooks/adapters/kimi.py` — converted timeout values to seconds, fixed uninstall parser.
- `tests/test_kimi_adapter.py` — added tests for correct timeout values.