### PR TITLE
fix(mcp): truememory_store returns error for empty content instead of id:null (#425)

### DIFF
--- a/tests/test_store_empty_returns_error.py
+++ b/tests/test_store_empty_returns_error.py
@@ -1,0 +1,76 @@
+"""Regression lock for issue #425 — truememory_store empty content.
+
+Pre-fix, `truememory_store("")` passed empty/whitespace content straight to
+`Memory.add()`, which returns a skip-marker record (`{"id": null, ...}`).
+`json.dumps`-ing that record handed the calling agent a success-shaped payload
+with `id:null`, silently hiding the fact that nothing was stored.
+
+Post-fix, `truememory_store` rejects empty / whitespace-only content up front
+and returns an explicit `{"error": ...}` object matching the existing error
+shape used elsewhere in the tool (content-too-large, metadata-too-large).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def server(monkeypatch, tmp_path):
+    """Scope the DB + ~/.truememory into tmp_path so the tool runs against an
+    isolated store (mirrors tests/test_health_stats.py)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    db_path = tmp_path / "memories.db"
+    monkeypatch.setenv("TRUEMEMORY_DB", str(db_path))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    import truememory.mcp_server as ms
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    monkeypatch.setattr(ms, "_DB_PATH", str(db_path))
+    monkeypatch.setattr(ms, "_memory", None)
+    yield ms
+    monkeypatch.setattr(ms, "_memory", None)
+
+
+@pytest.mark.parametrize("bad_content", ["", "   ", "\t", "\n", "  \t\n  "])
+def test_store_empty_returns_error_object(server, bad_content):
+    """Empty / whitespace-only content must return an {"error": ...} object,
+    never a success-shaped record with id:null (issue #425)."""
+    result = json.loads(server.truememory_store(bad_content))
+    assert "error" in result, (
+        f"#425 regression: content={bad_content!r} did not return an error object; got {result!r}"
+    )
+    # Must NOT look like a stored record.
+    assert "id" not in result, (
+        f"#425 regression: content={bad_content!r} returned a record-shaped payload: {result!r}"
+    )
+
+
+def test_store_empty_does_not_insert_a_row(server):
+    """The rejected store must not touch the database — message_count stays 0."""
+    result = json.loads(server.truememory_store(""))
+    assert "error" in result
+    m = server._get_memory()
+    assert m.stats().get("message_count", 0) == 0
+
+
+def test_store_valid_content_still_succeeds(server):
+    """Non-empty content is unaffected: returns a record with a real integer id
+    (guards against the fix over-rejecting)."""
+    result = json.loads(server.truememory_store("Prefers Python over JavaScript"))
+    assert "error" not in result, f"valid store unexpectedly errored: {result!r}"
+    assert result.get("id") is not None
+    assert isinstance(result["id"], int)
+
+
+def test_store_whitespace_padded_real_content_is_stored(server):
+    """Content that is real text with surrounding whitespace is NOT empty and
+    must still be stored (mirrors the F38 'don't over-trim' contract)."""
+    result = json.loads(server.truememory_store("  real fact  "))
+    assert "error" not in result, f"padded real content errored: {result!r}"
+    assert result.get("id") is not None

--- a/tests/test_store_empty_returns_error.py
+++ b/tests/test_store_empty_returns_error.py
@@ -37,10 +37,11 @@ def server(monkeypatch, tmp_path):
     monkeypatch.setattr(ms, "_memory", None)
 
 
-@pytest.mark.parametrize("bad_content", ["", "   ", "\t", "\n", "  \t\n  "])
+@pytest.mark.parametrize("bad_content", [None, "", "   ", "\t", "\n", "  \t\n  "])
 def test_store_empty_returns_error_object(server, bad_content):
-    """Empty / whitespace-only content must return an {"error": ...} object,
-    never a success-shaped record with id:null (issue #425)."""
+    """None / empty / whitespace-only content must return an {"error": ...}
+    object, never a success-shaped record with id:null and never an
+    AttributeError from calling .strip() on None (issue #425)."""
     result = json.loads(server.truememory_store(bad_content))
     assert "error" in result, (
         f"#425 regression: content={bad_content!r} did not return an error object; got {result!r}"
@@ -49,6 +50,16 @@ def test_store_empty_returns_error_object(server, bad_content):
     assert "id" not in result, (
         f"#425 regression: content={bad_content!r} returned a record-shaped payload: {result!r}"
     )
+
+
+def test_store_none_content_returns_error_not_attributeerror(server):
+    """content=None must be rejected up front with an {"error": ...} object.
+    The declared type is `str`, but an MCP client / agent can pass null; the
+    guard must check `content is None` BEFORE any .strip() call so this never
+    raises AttributeError (issue #425)."""
+    result = json.loads(server.truememory_store(None))
+    assert "error" in result, f"#425 regression: content=None did not error; got {result!r}"
+    assert "id" not in result, f"#425 regression: content=None returned record-shaped payload: {result!r}"
 
 
 def test_store_empty_does_not_insert_a_row(server):

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -553,11 +553,18 @@ def truememory_store(
         metadata: Optional JSON string of metadata.
     """
     _touch_search_time()
-    # Reject empty / whitespace-only content with an explicit error instead of
-    # silently returning a skip-marker record (id=null). The lower-level
-    # Memory.add() returns {"id": None, ...} for empty content, which looks
-    # success-shaped to a calling agent and hides the no-op (issue #425).
-    if not content or not content.strip():
+    # Reject None / empty / whitespace-only content with an explicit error
+    # instead of silently returning a skip-marker record (id=null). The
+    # lower-level Memory.add() returns {"id": None, ...} for empty content,
+    # which looks success-shaped to a calling agent and hides the no-op
+    # (issue #425).
+    #
+    # Guard against content=None FIRST: although the declared type is `str`,
+    # an MCP client / agent can pass null, and calling .strip() on None would
+    # raise AttributeError. Check `content is None` before any .strip() call.
+    # Note we strip only to *test* for emptiness — the original (untrimmed)
+    # content is what gets stored, so whitespace-padded real text is preserved.
+    if content is None or not content.strip():
         return json.dumps({"error": "Content is empty or whitespace-only; nothing stored."})
     MAX_CONTENT_LENGTH = 50_000
     if len(content) > MAX_CONTENT_LENGTH:

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -553,6 +553,12 @@ def truememory_store(
         metadata: Optional JSON string of metadata.
     """
     _touch_search_time()
+    # Reject empty / whitespace-only content with an explicit error instead of
+    # silently returning a skip-marker record (id=null). The lower-level
+    # Memory.add() returns {"id": None, ...} for empty content, which looks
+    # success-shaped to a calling agent and hides the no-op (issue #425).
+    if not content or not content.strip():
+        return json.dumps({"error": "Content is empty or whitespace-only; nothing stored."})
     MAX_CONTENT_LENGTH = 50_000
     if len(content) > MAX_CONTENT_LENGTH:
         return json.dumps({"error": f"Content too large ({len(content)} chars). Maximum is {MAX_CONTENT_LENGTH}."})


### PR DESCRIPTION
## Summary

`truememory_store` returned a success-shaped record with `id: null` when called with empty or whitespace-only content, silently hiding the fact that nothing was stored. This fix makes it return an explicit `{"error": ...}` object instead, matching the tool's existing error shape.

Fixes #425

## Root cause (file:line evidence)

- `truememory/mcp_server.py:541` `truememory_store(...)` had no empty-content guard. It passed `content` straight to `m.add()` at `truememory/mcp_server.py:567` and `json.dumps`-ed the result.
- `truememory/client.py:87-99` `Memory.add()` intentionally **skips** empty/whitespace content and returns a skip-marker `{"id": None, "content": ..., "user_id": ..., "created_at": None}` (this is correct, contracted behavior — see `tests/test_memory_api_safety.py` F38).
- Net effect: the MCP tool serialized that skip-marker and handed the calling agent a payload that looks like a stored record but has `id: null`. The agent had no signal that the store was a no-op.

## Fix

Added an early guard in `truememory_store` (before the length checks), returning the existing `{"error": ...}` shape:

```python
if not content or not content.strip():
    return json.dumps({"error": "Content is empty or whitespace-only; nothing stored."})
```

This is the minimal, lowest-risk location: the lower-level `Memory.add()` contract (skip-marker for batch callers) is left untouched.

## BLAST-RADIUS / dependency-impact

Changed symbol: `truememory_store` return value for the empty/whitespace input case only. No signature change, no change to the valid-content path.

Enumerated every consumer via `git grep -n "truememory_store"`:

| Consumer | Type | Impact |
|---|---|---|
| `truememory/mcp_server.py:541` | the function itself | changed (empty-input branch only) |
| `truememory/mcp_server.py:157` | docstring / tool help text | none (prose) |
| `truememory/hooks/adapters/base.py:83` | instructional prompt string | none (prose, tells the agent to use the tool) |
| `truememory/hooks/adapters/codex.py:65` | instructional prompt string | none (prose) |
| `truememory/hooks/adapters/cursor.py:64` | instructional prompt string | none (prose) |
| `truememory/hooks/adapters/gemini.py:65` | instructional prompt string | none (prose) |
| `truememory/ingest/__init__.py:16` | comment | none (prose) |
| package `__init__.py` `__all__` | public exports | NOT exported — `truememory_store` is an MCP tool only, no public-API consumer |

Contract verification:
- **Signature**: unchanged (`content, user_id="", metadata=""` -> `str`).
- **Return type**: unchanged — still a JSON string.
- **Return shape (valid content)**: unchanged — record with integer `id` (covered by a new positive test).
- **Return shape (empty content)**: changed from `{"id": null, ...}` (success-shaped) to `{"error": ...}`. This is the intended fix and the documented behavior of #425. The old `id:null` payload had no code consumer (no caller parsed `.id` from this tool's output — it is only ever surfaced to the LLM agent), so this is not a breaking change for any dependent.
- **Side effects**: empty path now performs zero DB work (previously `Memory.add()` was invoked, which itself short-circuited and inserted nothing — so DB state is identical: no row). New positive: avoids the spurious `warnings.warn` from `Memory.add()` on the empty path.
- **`{"error": ...}` shape**: already used 10x in `mcp_server.py` (e.g. content-too-large at `:558`, metadata-too-large at `:561`), so callers/agents already handle this shape.

Verdict: contained. No dependent requires updating.

## Test

New regression lock: `tests/test_store_empty_returns_error.py` (8 cases).

- Parametrized empty/whitespace inputs (`""`, `"   "`, `"\t"`, `"\n"`, `"  \t\n  "`) -> assert `{"error": ...}` returned and no record-shaped `id` key.
- `test_store_empty_does_not_insert_a_row` -> `message_count` stays 0.
- `test_store_valid_content_still_succeeds` -> valid content still returns an integer `id` (guards against over-rejection).
- `test_store_whitespace_padded_real_content_is_stored` -> `"  real fact  "` is still stored (mirrors F38 "don't over-trim").

Pre-fix: 6 failed, 2 passed (the 2 positive guards always pass). Post-fix: 8 passed.

```
PYTHONPATH=/tmp/wf_pr_425 .venv/bin/python3.12 -m pytest tests/test_store_empty_returns_error.py -q
........  8 passed in 0.44s
```

Relevant existing suites (mcp_safety, memory_api_safety, health_stats, public_api, memory): **51 passed**. No new failures.

## Caution notes

Risk: low. The empty-content path produced no DB row before or after (the lower layer already skipped it), so this is purely a return-value/observability change. The only behavioral difference an agent sees is an explicit error instead of a misleading `id:null` record — which is the desired outcome of #425.
