### PR TITLE
fix(#423): guarded startup reaper for orphaned sibling MCP servers [DRAFT — kills processes, human review]

### DIFF
--- a/tests/test_startup_sibling_reaper.py
+++ b/tests/test_startup_sibling_reaper.py
@@ -1,0 +1,167 @@
+"""Tests for the #423 startup sibling reaper (CONSERVATIVE, guarded).
+
+The self-only #401 watcher exits only the current process when its own parent
+dies; it never reaps OTHER ("sibling") MCP servers from prior sessions that
+keep a memories.db connection open and recreate `database is locked`
+contention. The #423 reaper terminates ONLY sibling servers that are provably
+abandoned: a different process, bound to the same memories.db, whose parent is
+dead (reparented to init, ppid==1). A sibling with a living parent is a live
+concurrent session and must never be touched.
+
+These tests exercise the PURE selection predicate over mocked process lists and
+the opt-in/guard behaviour of the reaper. Nothing is ever actually killed:
+os.kill is monkeypatched to a recorder.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+import truememory.mcp_server as ms
+
+
+DB = "/home/u/.truememory/memories.db"
+OTHER_DB = "/home/u/.truememory/other.db"
+
+
+def _proc(pid, ppid, *, name="TrueMemory MCP", cmdline=None, db=DB):
+    return {
+        "pid": pid,
+        "ppid": ppid,
+        "name": name,
+        "cmdline": cmdline if cmdline is not None else ["python", "-m", "truememory.mcp_server"],
+        "db": db,
+    }
+
+
+# --- pure selection predicate -------------------------------------------------
+
+def test_selects_orphaned_sibling_same_db():
+    """A different MCP process, same DB, parent dead (ppid==1) -> reaped."""
+    procs = [_proc(2222, ppid=1)]
+    assert ms._select_orphaned_siblings(procs, self_pid=1000, self_db=DB) == [2222]
+
+
+def test_never_selects_self():
+    """Even orphaned + same DB, the current process is never selected."""
+    procs = [_proc(1000, ppid=1)]
+    assert ms._select_orphaned_siblings(procs, self_pid=1000, self_db=DB) == []
+
+
+def test_never_selects_live_sibling():
+    """A sibling whose parent is ALIVE (ppid != 1) is a live session -> skip.
+
+    This is the core safety guarantee: live concurrent sessions are untouched.
+    """
+    procs = [_proc(2222, ppid=4321)]  # real, living parent
+    assert ms._select_orphaned_siblings(procs, self_pid=1000, self_db=DB) == []
+
+
+def test_never_selects_different_db():
+    """Orphaned MCP server bound to a DIFFERENT db is a different lock domain."""
+    procs = [_proc(2222, ppid=1, db=OTHER_DB)]
+    assert ms._select_orphaned_siblings(procs, self_pid=1000, self_db=DB) == []
+
+
+def test_never_selects_unknown_db():
+    """If a candidate's DB couldn't be resolved (""), it is not selected."""
+    procs = [_proc(2222, ppid=1, db="")]
+    assert ms._select_orphaned_siblings(procs, self_pid=1000, self_db=DB) == []
+
+
+def test_never_selects_non_mcp_process():
+    """A non-TrueMemory process is ignored even if orphaned w/ same db field."""
+    procs = [_proc(2222, ppid=1, name="bash", cmdline=["bash"])]
+    assert ms._select_orphaned_siblings(procs, self_pid=1000, self_db=DB) == []
+
+
+def test_db_paths_compared_after_realpath(tmp_path):
+    """Equivalent paths (symlink/.. forms) resolve to the same DB and match."""
+    real = tmp_path / "memories.db"
+    real.write_text("")
+    weird = str(tmp_path / "sub" / ".." / "memories.db")
+    procs = [_proc(2222, ppid=1, db=weird)]
+    out = ms._select_orphaned_siblings(procs, self_pid=1000, self_db=str(real))
+    assert out == [2222]
+
+
+def test_mixed_list_selects_only_orphans():
+    procs = [
+        _proc(1000, ppid=1),               # self -> skip
+        _proc(2222, ppid=1),               # orphan, same db -> reap
+        _proc(3333, ppid=9999),            # live sibling -> skip
+        _proc(4444, ppid=1, db=OTHER_DB),  # orphan, other db -> skip
+        _proc(5555, ppid=1, name="bash", cmdline=["bash"]),  # non-mcp -> skip
+    ]
+    assert ms._select_orphaned_siblings(procs, self_pid=1000, self_db=DB) == [2222]
+
+
+# --- _proc_is_truememory_mcp predicate ---------------------------------------
+
+@pytest.mark.parametrize("name,cmdline,expected", [
+    ("TrueMemory MCP", [], True),
+    ("python3.12", ["python", "-m", "truememory.mcp_server"], True),
+    ("truememory-mcp", [], True),
+    ("bash", ["bash", "-l"], False),
+    ("python3.12", ["python", "-m", "some.other.module"], False),
+    ("", None, False),
+])
+def test_proc_is_truememory_mcp(name, cmdline, expected):
+    assert ms._proc_is_truememory_mcp(name, cmdline) is expected
+
+
+# --- guard / opt-in behaviour of the reaper ----------------------------------
+
+def test_reaper_noop_without_optin(monkeypatch):
+    """Default-safe: with TRUEMEMORY_REAP_SIBLINGS unset, reaper does nothing.
+
+    We assert it never even enumerates processes by making _collect_mcp_procs
+    raise if called.
+    """
+    monkeypatch.delenv("TRUEMEMORY_REAP_SIBLINGS", raising=False)
+    monkeypatch.delenv("TRUEMEMORY_EXTRACTION", raising=False)
+    monkeypatch.setattr(ms, "_collect_mcp_procs", lambda: (_ for _ in ()).throw(AssertionError("should not enumerate")))
+    assert ms._reap_orphaned_siblings(db_path=DB) == []
+
+
+def test_reaper_noop_under_extraction(monkeypatch):
+    monkeypatch.setenv("TRUEMEMORY_REAP_SIBLINGS", "1")
+    monkeypatch.setenv("TRUEMEMORY_EXTRACTION", "1")
+    monkeypatch.setattr(ms, "_collect_mcp_procs", lambda: (_ for _ in ()).throw(AssertionError("should not enumerate")))
+    assert ms._reap_orphaned_siblings(db_path=DB) == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="reaper is a no-op on Windows")
+def test_reaper_kills_only_orphan_when_optin(monkeypatch):
+    """End-to-end (mocked): opt-in, signals ONLY the orphaned sibling pid."""
+    monkeypatch.setenv("TRUEMEMORY_REAP_SIBLINGS", "1")
+    monkeypatch.delenv("TRUEMEMORY_EXTRACTION", raising=False)
+    monkeypatch.setattr(ms.os, "getpid", lambda: 1000)
+    procs = [
+        _proc(1000, ppid=1),     # self -> never
+        _proc(2222, ppid=1),     # orphan -> reap
+        _proc(3333, ppid=4321),  # live sibling -> never
+    ]
+    monkeypatch.setattr(ms, "_collect_mcp_procs", lambda: procs)
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(ms.os, "kill", lambda pid, sig: killed.append((pid, sig)))
+    reaped = ms._reap_orphaned_siblings(db_path=DB)
+    assert reaped == [2222]
+    assert killed == [(2222, ms.signal.SIGTERM)]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="reaper is a no-op on Windows")
+def test_reaper_tolerates_already_gone(monkeypatch):
+    """A target that exits between selection and kill is skipped, not raised."""
+    monkeypatch.setenv("TRUEMEMORY_REAP_SIBLINGS", "1")
+    monkeypatch.delenv("TRUEMEMORY_EXTRACTION", raising=False)
+    monkeypatch.setattr(ms.os, "getpid", lambda: 1000)
+    monkeypatch.setattr(ms, "_collect_mcp_procs", lambda: [_proc(2222, ppid=1)])
+
+    def _boom(pid, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(ms.os, "kill", _boom)
+    assert ms._reap_orphaned_siblings(db_path=DB) == []

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 import re
+import signal
 import sys
 import threading
 import time
@@ -1377,6 +1378,161 @@ def _start_parent_death_watcher(poll_interval: float = 30.0) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Startup sibling reaper (#423) — CONSERVATIVE, guarded.
+#
+# The self-only #401 watcher exits the *current* process when its parent dies,
+# but it never reaps OTHER ("sibling") MCP servers left behind by prior shell
+# sessions. Those orphans keep a memories.db connection open and recreate the
+# `database is locked` contention. On launch, this reaper terminates ONLY the
+# sibling servers that are provably abandoned:
+#
+#   1. they are a *different* truememory MCP process (never self), AND
+#   2. they are bound to the *same* memories.db (same DB => same lock domain), AND
+#   3. their parent is dead — they have been reparented to init (ppid == 1).
+#
+# A sibling whose parent is still alive is a LIVE concurrent session and is
+# never touched. Condition (3) is the liveness guard. POSIX-only and disabled
+# by default; opt in with TRUEMEMORY_REAP_SIBLINGS=1.
+# ---------------------------------------------------------------------------
+
+# Substring that identifies a TrueMemory MCP server process. Matches the
+# setproctitle() value set in main() and the `-m truememory.mcp_server`
+# / `truememory-mcp` launch forms.
+_MCP_PROC_MARKERS = ("TrueMemory MCP", "truememory.mcp_server", "truememory-mcp")
+
+
+def _proc_is_truememory_mcp(name: str, cmdline: list[str] | None) -> bool:
+    """True if a process name/cmdline looks like a TrueMemory MCP server.
+
+    Pure predicate over already-collected fields (no psutil access) so it is
+    trivially unit-testable. ``cmdline`` is the argv list (may be ``None`` or
+    empty for zombies / permission-denied processes)."""
+    haystack = " ".join([name or "", *(cmdline or [])])
+    return any(marker in haystack for marker in _MCP_PROC_MARKERS)
+
+
+def _select_orphaned_siblings(
+    procs: list[dict],
+    *,
+    self_pid: int,
+    self_db: str,
+) -> list[int]:
+    """Pure selection predicate: pick ONLY orphaned sibling MCP servers to reap.
+
+    ``procs`` is a list of plain dicts (decoupled from psutil for testability),
+    each with keys: ``pid`` (int), ``ppid`` (int), ``name`` (str), ``cmdline``
+    (list[str]), ``db`` (str — the memories.db this process holds open, or "").
+
+    Returns the pids that are ALL of:
+      * not ``self_pid``                  (never reap ourselves)
+      * a TrueMemory MCP server           (name/cmdline match)
+      * bound to ``self_db``              (same lock domain; resolved paths)
+      * orphaned: ``ppid == 1``           (parent dead — the liveness guard)
+
+    A sibling with a living parent (``ppid != 1``) is a live concurrent session
+    and is deliberately excluded. This function has NO side effects — it never
+    signals a process — so it is safe to exercise directly in tests.
+    """
+    try:
+        self_db_real = os.path.realpath(self_db) if self_db else ""
+    except OSError:
+        self_db_real = self_db or ""
+    selected: list[int] = []
+    for p in procs:
+        pid = p.get("pid")
+        if pid is None or pid == self_pid:
+            continue
+        if not _proc_is_truememory_mcp(p.get("name", ""), p.get("cmdline")):
+            continue
+        # Liveness guard: only reparented-to-init (parent dead) qualifies.
+        if p.get("ppid") != 1:
+            continue
+        db = p.get("db", "") or ""
+        try:
+            db_real = os.path.realpath(db) if db else ""
+        except OSError:
+            db_real = db
+        if not db_real or db_real != self_db_real:
+            continue
+        selected.append(pid)
+    return selected
+
+
+def _collect_mcp_procs() -> list[dict]:
+    """Enumerate candidate MCP processes via psutil into plain dicts.
+
+    Best-effort: processes that vanish or deny access mid-scan are skipped. The
+    ``db`` field is the resolved path of any open file under the process whose
+    basename matches a memories.db (``*.db``/``*.db-wal``/``*.db-shm``); empty
+    when it can't be determined (then the process is simply not selected)."""
+    import psutil  # declared dependency; imported lazily to keep import cheap
+
+    out: list[dict] = []
+    for proc in psutil.process_iter(["pid", "ppid", "name", "cmdline"]):
+        try:
+            info = proc.info
+            if not _proc_is_truememory_mcp(info.get("name", ""), info.get("cmdline")):
+                continue
+            db = ""
+            try:
+                for f in proc.open_files():
+                    base = os.path.basename(f.path)
+                    if base.startswith("memories.db") or base == "memories.db":
+                        db = f.path.split("-wal")[0].split("-shm")[0]
+                        break
+            except (psutil.AccessDenied, psutil.NoSuchProcess, NotImplementedError):
+                db = ""
+            out.append({
+                "pid": info.get("pid"),
+                "ppid": info.get("ppid"),
+                "name": info.get("name", ""),
+                "cmdline": info.get("cmdline") or [],
+                "db": db,
+            })
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return out
+
+
+def _reap_orphaned_siblings(db_path: str = _DB_PATH) -> list[int]:
+    """Terminate ONLY orphaned sibling MCP servers bound to the same DB (#423).
+
+    Guarded and opt-in: returns ``[]`` immediately unless
+    ``TRUEMEMORY_REAP_SIBLINGS`` is truthy, on Windows, or under extraction.
+    Selection is delegated to the pure ``_select_orphaned_siblings`` predicate;
+    only the returned pids (different process, same memories.db, parent dead)
+    are sent SIGTERM. Never signals a live sibling. Returns the pids reaped."""
+    if os.environ.get("TRUEMEMORY_EXTRACTION"):
+        return []
+    if not os.environ.get("TRUEMEMORY_REAP_SIBLINGS"):
+        return []
+    if sys.platform == "win32" or not hasattr(os, "getppid"):
+        return []
+    try:
+        procs = _collect_mcp_procs()
+    except Exception:
+        log.debug("sibling reaper: process enumeration failed", exc_info=True)
+        return []
+    targets = _select_orphaned_siblings(
+        procs, self_pid=os.getpid(), self_db=db_path
+    )
+    reaped: list[int] = []
+    for pid in targets:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            reaped.append(pid)
+            log.warning(
+                "Reaped orphaned sibling MCP server pid=%d (parent dead, "
+                "same memories.db) to release the DB lock (#423)", pid
+            )
+        except ProcessLookupError:
+            continue  # already gone — fine
+        except PermissionError:
+            log.debug("sibling reaper: not permitted to signal pid=%d", pid)
+    return reaped
+
+
+# ---------------------------------------------------------------------------
 # Auto-setup for Claude Code and Claude Desktop
 # ---------------------------------------------------------------------------
 
@@ -1709,6 +1865,16 @@ def main():
     # not linger holding a memories.db connection. Self-only: never signals
     # sibling MCP servers, so concurrent live sessions are unaffected (#401).
     _start_parent_death_watcher()
+
+    # Reap orphaned SIBLING MCP servers left by prior sessions that still hold
+    # the same memories.db and contribute to write-lock contention (#423).
+    # CONSERVATIVE + opt-in (TRUEMEMORY_REAP_SIBLINGS=1): only processes whose
+    # parent is dead (reparented to init) are terminated; live concurrent
+    # sessions are never touched. No-op otherwise.
+    try:
+        _reap_orphaned_siblings()
+    except Exception:
+        log.debug("startup sibling reaper failed", exc_info=True)
 
     # Force-exit after mcp.run() to avoid PyTorch teardown deadlocks.
     # PyTorch's C++ threads (OpenMP pools, autograd engine) deadlock against


### PR DESCRIPTION
> ## CAUTION -- HUMAN REVIEW REQUIRED (this PR KILLS PROCESSES)
>
> This change sends `SIGTERM` to other processes on the machine. It is opened as
> a **DRAFT** specifically so a human reviews the kill logic before it can merge.
> Please scrutinize the selection predicate and the guards below.
>
> Safety design (all must hold before any process is signalled):
> 1. **Opt-in.** No-op unless `TRUEMEMORY_REAP_SIBLINGS=1` is set. Default behaviour is unchanged.
> 2. **Never self.** The current process pid is always excluded.
> 3. **Never a live sibling.** Only processes reparented to init (`ppid == 1`, i.e. their launching parent is *dead*) qualify. A sibling whose parent is alive is a live concurrent session and is never touched -- this is the core liveness guard.
> 4. **Same DB only.** Only processes holding the *same* `memories.db` (realpath-compared) are candidates -- same lock domain.
> 5. **MCP only.** Only processes whose name/cmdline match a TrueMemory MCP server.
> 6. **POSIX only**, skipped under extraction, graceful `SIGTERM` (not `SIGKILL`).
>
> Worst-case if a guard is wrong: a *live* MCP session could be terminated. The
> `ppid == 1` requirement is what prevents this; please review it closely.

## Summary

Implements the guarded startup sibling reaper proposed in #423.

The existing self-only #401 watcher (`_start_parent_death_watcher`) exits **only
the current process** when its own parent dies. It never reaps **other**
("sibling") MCP servers left behind by prior shell sessions. Those orphans keep
a `memories.db` connection open and recreate the `database is locked`
contention (5-8 stale siblings were observed live during the audit that filed
this issue).

This PR adds a conservative, opt-in reaper that, on launch, terminates **only**
sibling MCP servers that are provably abandoned.

## Evidence (bug present at HEAD)

`truememory/mcp_server.py` (before this PR):
- `_start_parent_death_watcher` (~L1334) and its docstring state it is self-only: *"It never inspects or signals sibling processes"* and self-`os._exit(0)` on `_is_orphaned`. No sibling scan/reap anywhere in the module (`git grep` for `reap` only found `_reap_children`, which reaps this process's own zombie *children*, not sibling servers).
- `main()` (~L1711) wired only `_start_parent_death_watcher()`; nothing scanned for stale siblings.

## Fix

`truememory/mcp_server.py`:
- `_proc_is_truememory_mcp(name, cmdline)` -- pure predicate: does a process look like a TrueMemory MCP server.
- `_select_orphaned_siblings(procs, *, self_pid, self_db)` -- **pure, side-effect-free** selection predicate. Given plain process dicts, returns the pids that are (not self) AND (a TrueMemory MCP server) AND (bound to the same `memories.db`, realpath-compared) AND (orphaned: `ppid == 1`). This is the unit under test.
- `_collect_mcp_procs()` -- best-effort psutil enumeration into plain dicts (decoupled from the predicate for testability).
- `_reap_orphaned_siblings(db_path=_DB_PATH)` -- guarded entry point: no-op unless `TRUEMEMORY_REAP_SIBLINGS=1`, POSIX-only, skipped under extraction; sends `SIGTERM` to **only** the pids returned by the predicate; tolerates `ProcessLookupError`/`PermissionError`.
- `main()` calls `_reap_orphaned_siblings()` right after the #401 watcher, wrapped in try/except so a reaper failure can never break startup.
- Added `import signal`.

## BLAST-RADIUS / dependency-impact

`git grep` was run for every new/changed symbol across the repo (`*.py`, `*.md`, `*.toml`).

| Symbol | Kind | Consumers | Contract verdict |
| --- | --- | --- | --- |
| `_select_orphaned_siblings` | new private fn | `mcp_server.py` (def + call in `_reap_orphaned_siblings`) and the new test only | No external consumers. Pure, no side effects. |
| `_reap_orphaned_siblings` | new private fn | `mcp_server.py` (def + one call in `main`) and the new test only | No external consumers. Returns `list[int]`. |
| `_collect_mcp_procs` | new private fn | `mcp_server.py` (def + call) and the new test (monkeypatched) | No external consumers. |
| `_proc_is_truememory_mcp` | new private fn | `mcp_server.py` (def + 2 calls) and the new test | No external consumers. |
| `_MCP_PROC_MARKERS` | new private const | `mcp_server.py` only | No external consumers. |
| `TRUEMEMORY_REAP_SIBLINGS` | **new** env var | introduced here; zero prior consumers | New opt-in flag; absent => identical behaviour to before. |
| `_DB_PATH` | existing const, **read only** | docs, hooks (`compact/session_start/stop/user_prompt_submit` read `TRUEMEMORY_DB_PATH`, not the const), tests that monkeypatch `ms._DB_PATH`, and `_get_memory` | **Unchanged**: same definition, value, type. I only reference it as a default arg value. Tests that `monkeypatch.setattr(ms, "_DB_PATH", ...)` still work (the reaper reads `_DB_PATH` at call time via the default arg, so a monkeypatched value is honored). No contract change. |
| `signal` | new stdlib import | `mcp_server.py` | Additive import; no conflict. |

**Verdict:** all new identifiers are private and self-contained within
`mcp_server.py`; no `__init__` exports, MCP tools, hooks, dashboard, or other
tests consume them. No signature/return-shape/side-effect/ordering change to any
existing symbol. The only new external surface is the opt-in `TRUEMEMORY_REAP_SIBLINGS`
env var, which is a no-op when unset -- so existing behaviour is byte-for-byte
preserved by default. **Non-breaking.**

## Tests

New file `tests/test_startup_sibling_reaper.py` (mirrors the style of
`tests/test_parent_death_watcher.py`). All assertions run against **mocked
process lists** and a monkeypatched `os.kill` recorder -- **nothing is ever
actually killed**.

Covers the selection predicate (orphaned-only):
- selects an orphaned sibling on the same DB;
- **never** selects self;
- **never** selects a live sibling (`ppid != 1`) -- the key safety guarantee;
- never selects a different DB / unknown DB / non-MCP process;
- realpath-normalizes DB paths before comparison;
- a mixed list yields exactly the one orphan.

Plus guard/opt-in behaviour: no-op without `TRUEMEMORY_REAP_SIBLINGS`, no-op
under extraction (both asserted to not even enumerate processes), opt-in kills
only the orphan pid via `SIGTERM`, and tolerates a target that exits between
selection and kill.

Pre-fix: the test errors at collection (`_select_orphaned_siblings` is absent on
`origin/main`). Post-fix: **24 passed** (new file + existing
`test_parent_death_watcher.py`).

Relevant existing suites for the touched area also pass (`test_mcp_safety.py`,
`test_health_stats.py`, `test_configure_tier_persist.py`,
`test_configure_reembed.py`, `test_parent_death_watcher.py`): **47 passed**.

Fixes #423
