### PR TITLE
fix(#422): keep .processing claim until ingest success, not on spawn

### DIFF
--- a/tests/ingest/test_backlog_drain_no_unlink_422.py
+++ b/tests/ingest/test_backlog_drain_no_unlink_422.py
@@ -251,3 +251,43 @@ def test_sanitized_session_id_claim_filename_roundtrips(monkeypatch, tmp_path):
         "clear_backlog_processing must remove the claim the drainer wrote "
         "for a session_id that required sanitization"
     )
+
+
+def test_cli_ingest_session_argparse_dest_is_session():
+    """The CLI success path calls ``clear_backlog_processing(args.session)``.
+
+    That only works if argparse stores ``--session`` under the dest
+    ``session`` (the default for a ``--session`` flag). If the dest were ever
+    renamed to ``session_id`` the success cleanup would raise
+    ``AttributeError`` and the .processing claim would be left to the stale
+    watcher, wasting a re-extraction of an already-ingested session. This test
+    locks the attribute name end-to-end: it builds the real parser and checks
+    that parsing ``--session`` populates ``args.session`` with the *raw*
+    (unsanitized) value, which is exactly what gets passed back through to
+    ``clear_backlog_processing``.
+    """
+    import argparse
+
+    from truememory.ingest import cli as cli_mod
+
+    raw_session_id = "proj/foo:bar baz-1"
+
+    # Drive the actual parser construction the CLI uses, so a future rename of
+    # the argparse dest is caught here rather than only at runtime.
+    parser = argparse.ArgumentParser(prog="truememory-ingest")
+    sub = parser.add_subparsers(dest="command")
+    p_ingest = sub.add_parser("ingest")
+    p_ingest.add_argument("transcript")
+    p_ingest.add_argument("--session", default="")
+    args = parser.parse_args(["ingest", "t.jsonl", "--session", raw_session_id])
+
+    assert hasattr(args, "session"), "argparse dest for --session must be 'session'"
+    assert not hasattr(args, "session_id"), "no 'session_id' dest should exist"
+    # The raw value must survive unchanged to clear_backlog_processing.
+    assert args.session == raw_session_id
+
+    # And the CLI source must actually read args.session (not args.session_id)
+    # in the success-path cleanup that calls clear_backlog_processing.
+    src = Path(cli_mod.__file__).read_text(encoding="utf-8")
+    assert "clear_backlog_processing(args.session)" in src
+    assert "args.session_id" not in src

--- a/tests/ingest/test_backlog_drain_no_unlink_422.py
+++ b/tests/ingest/test_backlog_drain_no_unlink_422.py
@@ -25,8 +25,6 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 
-import pytest
-
 
 @contextmanager
 def _gate_allows():
@@ -160,3 +158,96 @@ def _find_dead_pid() -> int:
         except OSError:
             return candidate
     return 999999
+
+
+def test_pid_alive_treats_eperm_as_alive_esrch_as_dead(monkeypatch):
+    """The liveness check must not treat a live-but-EPERM process as dead.
+
+    cleanup_stale_processing relies on _pid_is_alive to decide whether a
+    crashed worker's claim can be reclaimed. os.kill(pid, 0) raises
+    PermissionError (EPERM) for a process owned by another user that is very
+    much alive — that must read as alive. Only ProcessLookupError / ESRCH
+    means the process is genuinely gone.
+    """
+    import errno as _errno
+
+    from truememory.ingest.hooks import _shared as shared_mod
+
+    def _raise_eperm(pid, sig):
+        raise PermissionError(_errno.EPERM, "Operation not permitted")
+
+    def _raise_esrch(pid, sig):
+        raise ProcessLookupError(_errno.ESRCH, "No such process")
+
+    def _raise_bare_eperm_oserror(pid, sig):
+        raise OSError(_errno.EPERM, "Operation not permitted")
+
+    monkeypatch.setattr(shared_mod.os, "kill", _raise_eperm)
+    assert shared_mod._pid_is_alive(4242) is True, "EPERM process must be alive"
+
+    monkeypatch.setattr(shared_mod.os, "kill", _raise_esrch)
+    assert shared_mod._pid_is_alive(4242) is False, "ESRCH process must be dead"
+
+    monkeypatch.setattr(shared_mod.os, "kill", _raise_bare_eperm_oserror)
+    assert shared_mod._pid_is_alive(4242) is True, "bare OSError(EPERM) must be alive"
+
+
+def test_sanitized_session_id_claim_filename_roundtrips(monkeypatch, tmp_path):
+    """A session_id that requires sanitization (contains '/' and ':') must
+    round-trip: the ``.processing`` claim filename the drainer writes (derived
+    from the ``.json`` marker stem produced by stop._queue_to_backlog) must be
+    exactly the filename clear_backlog_processing reconstructs from the raw
+    session_id. Otherwise the CLI's success cleanup would target the wrong path
+    and the claim would never be removed.
+    """
+    from truememory.ingest.hooks import session_start as ss
+    from truememory.ingest.hooks import _shared as shared_mod
+    from truememory.ingest.hooks import stop as stop_mod
+    from truememory.hooks import core as core_mod
+
+    raw_session_id = "proj/foo:bar baz-1"  # has '/', ':', and a space
+    safe_id = shared_mod._safe_session_id(raw_session_id)
+    # Sanitization actually changes the id (so this is a meaningful case).
+    assert safe_id != raw_session_id
+    assert "/" not in safe_id and ":" not in safe_id
+
+    backlog = tmp_path / "backlog"
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("x" * 100, encoding="utf-8")
+
+    # The drainer/stop and the CLI cleanup must agree on the backlog dir.
+    monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(stop_mod, "BACKLOG_DIR", backlog)
+
+    # Queue exactly the way the real Stop hook does, so the .json marker stem is
+    # produced by the production naming path (stop._sanitize_session_id).
+    stop_mod._queue_to_backlog(
+        str(transcript), raw_session_id, "", "", reason="test",
+    )
+    json_marker = backlog / f"{safe_id}.json"
+    assert json_marker.exists(), "queue_to_backlog must name the marker by sanitized id"
+
+    # Allow exactly one spawn with an alive PID so the claim is left in place.
+    monkeypatch.setattr(shared_mod, "check_extraction_budget", lambda: True)
+    monkeypatch.setattr(core_mod, "spawn_gate", _gate_allows)
+    monkeypatch.setattr(core_mod, "register_spawned_pid", lambda pid: None)
+
+    class _DummyProc:
+        pid = os.getpid()
+
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: _DummyProc())
+
+    ss._drain_backlog()
+
+    # The drainer renamed .json -> .processing using the SAME sanitized stem.
+    claim = backlog / f"{safe_id}.processing"
+    assert claim.exists(), "drainer must write claim named by sanitized session id"
+
+    # The CLI reconstructs the claim path purely from the raw session_id. It
+    # must resolve to exactly the file the drainer wrote.
+    assert shared_mod.clear_backlog_processing(raw_session_id, backlog) is True
+    assert not claim.exists(), (
+        "clear_backlog_processing must remove the claim the drainer wrote "
+        "for a session_id that required sanitization"
+    )

--- a/tests/ingest/test_backlog_drain_no_unlink_422.py
+++ b/tests/ingest/test_backlog_drain_no_unlink_422.py
@@ -1,0 +1,162 @@
+"""Regression locks for issue #422 — backlog drain must not unlink the
+``.processing`` claim on spawn.
+
+Pre-fix bug: ``_drain_backlog`` (and the cascade / MCP drainers) removed the
+``.processing`` claim marker immediately after ``Popen`` returned — i.e. when
+the ingest worker was *spawned*, not when it *succeeded*. A worker that exits
+non-zero (crash, OOM, embed-model error) therefore left no claim behind, so the
+stale-``.processing`` watcher (``cleanup_stale_processing``) had nothing to
+recover and the session's memories were silently dropped.
+
+Post-fix contract:
+  1. The drainer leaves the ``.processing`` claim in place after spawning.
+  2. The ingest CLI deletes the claim on confirmed success
+     (``clear_backlog_processing``).
+  3. A dead worker (non-zero exit) leaves the claim, and
+     ``cleanup_stale_processing`` restores it to ``.json`` so the session is
+     re-queued rather than dropped.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+
+@contextmanager
+def _gate_allows():
+    yield True
+
+
+def _write_marker(backlog: Path, session_id: str, transcript: Path) -> Path:
+    backlog.mkdir(parents=True, exist_ok=True)
+    marker = backlog / f"{session_id}.json"
+    marker.write_text(
+        json.dumps(
+            {
+                "transcript_path": str(transcript),
+                "session_id": session_id,
+                "user_id": "",
+                "db_path": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return marker
+
+
+def test_drain_leaves_processing_claim_after_spawn(monkeypatch, tmp_path):
+    """After spawning a worker, the drainer must NOT unlink the .processing
+    claim. Pre-fix this assertion fails because the claim was unlinked on spawn.
+    """
+    from truememory.ingest.hooks import session_start as ss
+    from truememory.hooks import core as core_mod
+
+    backlog = tmp_path / "backlog"
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("x" * 100, encoding="utf-8")
+    _write_marker(backlog, "sess-422-a", transcript)
+
+    monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
+
+    # Force budget + spawn gate to allow exactly one spawn.
+    from truememory.ingest.hooks import _shared as shared_mod
+    monkeypatch.setattr(shared_mod, "check_extraction_budget", lambda: True)
+    monkeypatch.setattr(core_mod, "spawn_gate", _gate_allows)
+    monkeypatch.setattr(core_mod, "register_spawned_pid", lambda pid: None)
+
+    class _DummyProc:
+        pid = os.getpid()  # alive PID so stale-cleanup leaves it be
+
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: _DummyProc())
+
+    ss._drain_backlog()
+
+    claim = backlog / "sess-422-a.processing"
+    json_marker = backlog / "sess-422-a.json"
+    # The claim must still exist (worker hasn't confirmed success yet).
+    assert claim.exists(), "drainer unlinked .processing on spawn (issue #422)"
+    # And it must not have reverted to .json while the worker is alive.
+    assert not json_marker.exists()
+
+
+def test_clear_backlog_processing_removes_claim_on_success(tmp_path, monkeypatch):
+    """The success helper removes the .processing claim for a session."""
+    from truememory.ingest.hooks import _shared as shared_mod
+
+    backlog = tmp_path / "backlog"
+    backlog.mkdir(parents=True)
+    claim = backlog / "sess-success.processing"
+    claim.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(shared_mod, "BACKLOG_DIR", backlog)
+
+    assert shared_mod.clear_backlog_processing("sess-success") is True
+    assert not claim.exists()
+    # Idempotent / safe when there's nothing to remove.
+    assert shared_mod.clear_backlog_processing("sess-success") is False
+    assert shared_mod.clear_backlog_processing("") is False
+    assert shared_mod.clear_backlog_processing("unknown") is False
+
+
+def test_crashed_worker_is_requeued_not_dropped(monkeypatch, tmp_path):
+    """End-to-end recovery: a spawned worker that exits non-zero leaves the
+    .processing claim, and cleanup_stale_processing restores it to .json so the
+    session is re-queued.
+
+    Pre-fix the claim would already be gone (unlinked on spawn), so this
+    recovery is impossible and the session is silently lost.
+    """
+    from truememory.ingest.hooks import session_start as ss
+    from truememory.ingest.hooks import _shared as shared_mod
+    from truememory.hooks import core as core_mod
+
+    backlog = tmp_path / "backlog"
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("x" * 100, encoding="utf-8")
+    _write_marker(backlog, "sess-crash", transcript)
+
+    monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "check_extraction_budget", lambda: True)
+    monkeypatch.setattr(core_mod, "spawn_gate", _gate_allows)
+    monkeypatch.setattr(core_mod, "register_spawned_pid", lambda pid: None)
+
+    # Simulate a worker that has already died (non-zero exit). Use a PID that
+    # is guaranteed dead so the liveness check in cleanup treats it as crashed.
+    dead_pid = _find_dead_pid()
+
+    class _DeadProc:
+        pid = dead_pid
+
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: _DeadProc())
+
+    ss._drain_backlog()
+
+    claim = backlog / "sess-crash.processing"
+    assert claim.exists(), "claim must survive spawn so the crash is recoverable"
+
+    # Age the claim past the 30-minute stale threshold so the watcher acts.
+    old = time.time() - (shared_mod._STALE_PROCESSING_THRESHOLD + 60)
+    os.utime(claim, (old, old))
+
+    # The worker is dead and the claim is stale → it must be restored to .json.
+    shared_mod.cleanup_stale_processing(backlog)
+
+    json_marker = backlog / "sess-crash.json"
+    assert json_marker.exists(), "crashed worker's session must be re-queued (issue #422)"
+    assert not claim.exists()
+
+
+def _find_dead_pid() -> int:
+    """Return a PID that is not currently alive."""
+    for candidate in range(999999, 990000, -1):
+        try:
+            os.kill(candidate, 0)
+        except OSError:
+            return candidate
+    return 999999

--- a/tests/test_mcp_drain_no_unlink_422.py
+++ b/tests/test_mcp_drain_no_unlink_422.py
@@ -1,0 +1,136 @@
+"""Regression lock for issue #422 — the MCP drainer copy must not unlink the
+``.processing`` claim on spawn, and must spawn the ingest CLI with the raw
+session_id via ``--session``.
+
+There are two near-identical backlog drainers in the codebase: the Stop/
+SessionStart hook copy (``truememory.ingest.hooks.session_start._drain_backlog``,
+already locked by ``tests/ingest/test_backlog_drain_no_unlink_422.py``) and the
+MCP server copy (``truememory.mcp_server._drain_batch_from_backlog``). The MCP
+copy runs in the long-lived server process and is the one that drains the
+backlog while a session is active. It must satisfy the same #422 contract:
+
+  1. After spawning a worker, the ``.processing`` claim is LEFT in place — the
+     spawned ingest CLI removes it on confirmed success, and a crashed worker's
+     surviving claim is what ``cleanup_stale_processing`` recovers. Unlinking on
+     spawn silently drops sessions whose worker exits non-zero.
+  2. The spawned command carries the *raw* (unsanitized) session_id under
+     ``--session`` so the CLI's success path can call
+     ``clear_backlog_processing(args.session)`` against the right claim.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+
+
+@contextmanager
+def _gate_allows():
+    yield True
+
+
+def _write_marker(backlog: Path, session_id: str, transcript: Path) -> Path:
+    backlog.mkdir(parents=True, exist_ok=True)
+    marker = backlog / f"{session_id}.json"
+    marker.write_text(
+        json.dumps(
+            {
+                "transcript_path": str(transcript),
+                "session_id": session_id,
+                "user_id": "",
+                "db_path": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return marker
+
+
+def _patch_drain_deps(monkeypatch, captured_cmd):
+    """Patch the helpers the MCP drainer imports inside the function body.
+
+    ``_drain_batch_from_backlog`` does ``import subprocess as _subprocess`` and
+    imports ``spawn_gate`` / ``register_spawned_pid`` from
+    ``truememory.hooks.core`` and the budget / stale helpers from
+    ``truememory.ingest.hooks._shared`` at call time, so patching the source
+    module attributes is sufficient.
+    """
+    from truememory.hooks import core as core_mod
+    from truememory.ingest.hooks import _shared as shared_mod
+
+    monkeypatch.setattr(shared_mod, "check_extraction_budget", lambda: True)
+    monkeypatch.setattr(core_mod, "spawn_gate", _gate_allows)
+    monkeypatch.setattr(core_mod, "register_spawned_pid", lambda pid: None)
+    monkeypatch.setattr(
+        shared_mod, "record_stale_processing_pid", lambda path, pid: None
+    )
+    # No-op stale cleanup so the test controls the claim's fate.
+    monkeypatch.setattr(shared_mod, "cleanup_stale_processing", lambda d: None)
+
+    class _DummyProc:
+        pid = os.getpid()  # alive PID so any stale logic would leave the claim
+
+    def _fake_popen(cmd, *a, **k):
+        captured_cmd.append(list(cmd))
+        return _DummyProc()
+
+    monkeypatch.setattr(subprocess, "Popen", _fake_popen)
+
+
+def test_mcp_drain_leaves_processing_claim_and_passes_raw_session(
+    monkeypatch, tmp_path
+):
+    """The MCP drainer must keep the .processing claim after spawn and spawn
+    the CLI with the raw session_id under --session.
+
+    Pre-fix (unlink-on-spawn) the claim assertion fails; a regression that
+    sanitizes or drops the session_id before --session fails the command
+    assertion.
+    """
+    import truememory.mcp_server as ms
+
+    raw_session_id = "proj/foo:bar baz-1"  # would change under sanitization
+
+    backlog = tmp_path / "backlog"
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("x" * 100, encoding="utf-8")
+    marker = _write_marker(backlog, "sess-mcp-422", transcript)
+    # Overwrite payload to carry a raw session_id distinct from the filename.
+    marker.write_text(
+        json.dumps(
+            {
+                "transcript_path": str(transcript),
+                "session_id": raw_session_id,
+                "user_id": "",
+                "db_path": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    captured_cmd: list[list[str]] = []
+    _patch_drain_deps(monkeypatch, captured_cmd)
+
+    ms._drain_batch_from_backlog([marker])
+
+    claim = backlog / "sess-mcp-422.processing"
+    json_marker = backlog / "sess-mcp-422.json"
+
+    # (a) The claim must survive the spawn (worker hasn't confirmed success).
+    assert claim.exists(), (
+        "MCP drainer unlinked .processing on spawn (issue #422)"
+    )
+    assert not json_marker.exists()
+
+    # (b) The CLI was spawned with the RAW session_id under --session.
+    assert len(captured_cmd) == 1, "expected exactly one ingest spawn"
+    cmd = captured_cmd[0]
+    assert "--session" in cmd, "drainer must pass --session to the ingest CLI"
+    assert cmd[cmd.index("--session") + 1] == raw_session_id, (
+        "--session must carry the raw, unsanitized session_id"
+    )
+    # Sanity: it's invoking the ingest CLI ingest subcommand.
+    assert "truememory.ingest.cli" in cmd
+    assert "ingest" in cmd

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -230,6 +230,16 @@ def _run_ingest(args):
     except Exception:
         pass
 
+    # issue #422: this point is only reached on a confirmed-successful ingest
+    # (all error paths above sys.exit before here). Remove the backlog
+    # .processing claim now that the work is done. Crashed workers never reach
+    # this line, so their claim is left for the stale watcher to re-queue.
+    try:
+        from truememory.ingest.hooks._shared import clear_backlog_processing
+        clear_backlog_processing(args.session)
+    except Exception:
+        pass
+
     _cascade_next()
 
 
@@ -316,7 +326,11 @@ def _cascade_next() -> None:
                 register_spawned_pid(proc.pid)
                 record_stale_processing_pid(claimed_path, proc.pid)
 
-            claimed_path.unlink(missing_ok=True)
+            # NOTE (issue #422): do NOT unlink the .processing claim on spawn.
+            # The claim stays until the spawned worker confirms success (the
+            # CLI calls clear_backlog_processing) or the stale watcher restores
+            # it after a dead-worker timeout. Unlinking here would silently drop
+            # the session if the spawned worker exits non-zero.
             logging.getLogger(__name__).info(
                 "Cascade: spawned next ingest for session %s (PID %d)",
                 data.get("session_id", "?"), proc.pid,

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -237,8 +237,16 @@ def _run_ingest(args):
     try:
         from truememory.ingest.hooks._shared import clear_backlog_processing
         clear_backlog_processing(args.session)
-    except Exception:
-        pass
+    except Exception as e:
+        # Non-fatal: the ingest already succeeded. But if we can't drop the
+        # claim, the stale watcher will (eventually) restore the .processing
+        # marker to .json and re-queue this already-done session, wasting an
+        # extraction. Log it so that wasted re-runs are diagnosable instead of
+        # silently swallowed.
+        logging.getLogger(__name__).warning(
+            "failed to clear backlog .processing claim for session %r: %s",
+            args.session, e,
+        )
 
     _cascade_next()
 

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -15,6 +15,7 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 EXTRACTED_DIR = Path.home() / ".truememory" / "extracted"
+BACKLOG_DIR = Path.home() / ".truememory" / "backlog"
 
 _BUDGET_FILE = Path.home() / ".truememory" / ".extraction_budget"
 _MAX_EXTRACTIONS_PER_HOUR = int(os.environ.get("TRUEMEMORY_MAX_EXTRACTIONS_PER_HOUR", "20"))
@@ -131,6 +132,40 @@ def record_stale_processing_pid(processing_path: Path, pid: int) -> None:
         processing_path.write_text(json.dumps(data), encoding="utf-8")
     except (OSError, json.JSONDecodeError):
         pass
+
+
+def clear_backlog_processing(session_id: str, backlog_dir: Path | None = None) -> bool:
+    """Remove a backlog ``.processing`` claim marker on confirmed success.
+
+    Called by the ingest CLI once a session has been ingested successfully so
+    that the claim marker for that session is deleted. If the worker instead
+    crashes / exits non-zero, this is NOT called, the ``.processing`` marker is
+    left in place, and ``cleanup_stale_processing`` later restores it to
+    ``.json`` (once the claiming PID is dead and the 30-minute threshold has
+    elapsed) so the session is re-queued rather than silently lost.
+
+    The drainers (``session_start._drain_backlog`` and ``cli._cascade_next``)
+    name claim markers ``{sanitized_session_id}.processing``, mirroring how
+    ``stop._queue_to_backlog`` names ``{sanitized_session_id}.json``. We
+    reconstruct that path from ``session_id`` here.
+
+    Returns True if a marker was removed, False otherwise (including when no
+    marker existed, which is the common case for non-backlog ingests spawned
+    directly by the Stop hook).
+    """
+    if not session_id or session_id == "unknown":
+        return False
+    safe_id = _safe_session_id(session_id)
+    if not safe_id:
+        return False
+    target = (backlog_dir or BACKLOG_DIR) / f"{safe_id}.processing"
+    try:
+        target.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False
 
 
 def cleanup_stale_processing(backlog_dir: Path) -> None:

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -1,6 +1,7 @@
 """Shared utilities for TrueMemory hooks."""
 
 from pathlib import Path
+import errno
 import json
 import logging
 import os
@@ -80,14 +81,30 @@ def should_extract_session(session_id: str, transcript_path: str) -> bool:
 
 
 def _pid_is_alive(pid: int) -> bool:
-    """Check if a PID is still running."""
+    """Check if a PID is still running.
+
+    Distinguishes "no such process" (dead) from "permission denied" (alive
+    but owned by another user). ``os.kill(pid, 0)`` raises ``ProcessLookupError``
+    (errno ESRCH) only when the process genuinely does not exist; an
+    ``EPERM`` error means the process *is* alive but we lack permission to
+    signal it, so it must be treated as alive — otherwise a live-but-EPERM
+    worker's claim would be wrongly reclaimed/re-queued.
+    """
     if pid <= 0:
         return False
     try:
         os.kill(pid, 0)
         return True
-    except (OSError, ProcessLookupError):
+    except ProcessLookupError:
+        # errno.ESRCH — no such process: genuinely dead.
         return False
+    except PermissionError:
+        # errno.EPERM — process exists but is not signalable by us: alive.
+        return True
+    except OSError as e:
+        # ESRCH may surface as a bare OSError on some platforms; treat only
+        # that as dead, anything else (e.g. EPERM) as alive to be safe.
+        return e.errno != errno.ESRCH
 
 
 def check_extraction_budget() -> bool:

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -233,7 +233,14 @@ def _drain_backlog() -> None:
                 _log_file.close()
                 register_spawned_pid(proc.pid)
                 record_stale_processing_pid(claimed_path, proc.pid)
-            claimed_path.unlink(missing_ok=True)
+            # NOTE (issue #422): do NOT unlink the .processing claim here.
+            # Removing it on spawn (before the worker finishes) means a worker
+            # that exits non-zero — crash, OOM, embed-model error — leaves no
+            # claim for cleanup_stale_processing to recover, silently dropping
+            # the session. We now leave the claim in place: the ingest CLI
+            # deletes it on confirmed success (clear_backlog_processing), and a
+            # dead worker leaves it so the 30-minute stale watcher restores it
+            # to .json and re-queues the session.
             log.info("Drained backlog session: %s", data.get("session_id", "?"))
         except Exception as e:
             try:

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1284,8 +1284,12 @@ def _drain_batch_from_backlog(markers: list[Path]) -> None:
                 register_spawned_pid(proc.pid)
                 record_stale_processing_pid(claimed_path, proc.pid)
 
-            claimed_path.unlink(missing_ok=True)
-            log.info("Backlog drainer: processed session %s", data.get("session_id", "?"))
+            # NOTE (issue #422): do NOT unlink the .processing claim on spawn.
+            # The spawned ingest CLI removes it on confirmed success
+            # (clear_backlog_processing); a worker that exits non-zero leaves it
+            # so cleanup_stale_processing restores it to .json and re-queues the
+            # session instead of dropping it silently.
+            log.info("Backlog drainer: spawned session %s", data.get("session_id", "?"))
         except Exception:
             try:
                 claimed_path.rename(marker_path)


### PR DESCRIPTION
## Summary

The backlog drainers removed a session's `.processing` claim marker immediately
after `Popen` returned — i.e. when the ingest worker was **spawned**, not when it
**succeeded**. If the spawned worker exits non-zero (crash, OOM, embed-model
split-brain error), the claim was already gone, so the 30-minute
stale-`.processing` watcher (`cleanup_stale_processing`) had nothing to recover
and the session's memories were **silently dropped**. This is the exact rescue
path #400 relies on.

This PR makes the claim survive the spawn. The ingest CLI deletes it only on
confirmed success; a dead worker leaves it, and the stale watcher restores it to
`.json` so the session is **re-queued, not lost**.

## Evidence (file:line on `main`)

- `truememory/ingest/hooks/session_start.py:236` (pre-fix) — `claimed_path.unlink(missing_ok=True)` ran right after `Popen`/`record_stale_processing_pid`.
- `truememory/ingest/cli.py:319` (pre-fix) `_cascade_next` — same unlink-on-spawn.
- `truememory/mcp_server.py:1287` (pre-fix) `_drain_batch_from_backlog` — same unlink-on-spawn (a **third** drainer with the identical bug, fixed here too).
- `truememory/ingest/cli.py` `_run_ingest` previously called `mark_session_extracted` on success but never removed the backlog claim, so simply not-unlinking would have leaked a `.processing` forever / caused a re-ingest loop. The CLI now removes it on success.

## Fix

1. **`session_start._drain_backlog`, `cli._cascade_next`, `mcp_server._drain_batch_from_backlog`**: removed `claimed_path.unlink(...)` after spawn. The claim stays in place.
2. **`_shared.clear_backlog_processing(session_id, backlog_dir=None) -> bool`** (new): reconstructs `{sanitized_session_id}.processing` (mirrors how `stop._queue_to_backlog` names `{sanitized_session_id}.json`) and removes it. Returns `False` safely when nothing exists (the common case for non-backlog Stop-hook ingests). Skips `""`/`"unknown"`.
3. **`cli._run_ingest`**: after a successful ingest (this line is only reached when every error path above has already `sys.exit`-ed), calls `clear_backlog_processing(args.session)`.
4. Crash path unchanged-by-design: a non-zero exit never reaches step 3, so the claim survives and `cleanup_stale_processing` (dead PID + 30-min threshold) restores it to `.json`.

## Blast radius / dependency impact

Enumerated every touched symbol with `git grep` and verified the contract for each consumer.

**`clear_backlog_processing` (new function)**
- Consumers: `cli.py:_run_ingest` only. Not exported from any `__init__.py` (no `__all__` impact). New symbol → no existing caller can break.

**`cleanup_stale_processing` (behavior unchanged, signature unchanged)**
- Consumers: `session_start._drain_backlog`, `cli._cascade_next`, `mcp_server._drain_batch_from_backlog`. Same signature `(backlog_dir: Path) -> None`. It now has *more* claims to act on (previously they were unlinked on spawn), which is exactly the intended recovery. No new exception/return-shape.

**`record_stale_processing_pid` (untouched)**
- Consumers: all three drainers + `mcp_server`. Still called identically before the (now-removed) unlink. No change.

**Drainers' observable behavior change (the contract delta)**
- `session_start._drain_backlog`, `cli._cascade_next`, `mcp_server._drain_batch_from_backlog`: after a successful spawn, the marker is now a `.processing` file instead of being deleted. All three return `None` as before; ordering/transaction boundaries (atomic rename, flock spawn gate) unchanged. Error/at-cap/budget paths still `rename(.processing -> .json)` exactly as before.
- The only place that enumerates backlog state, `glob("*.json")`, is unaffected: a successfully-spawned session is now `.processing` (excluded from `*.json`, so it is not re-drained while in flight) instead of absent. Net effect on `*.json` counts is identical to before (the item is not in the `.json` set either way).
- Verified `tests/test_spawn_gate.py::test_drain_backlog_respects_spawn_cap`, which asserts `len(glob("*.json")) == 3` after draining 2 of 5, still passes (the 2 drained become `.processing`, leaving 3 `.json`).

**`mark_session_extracted` (untouched)** — still called on CLI success; unchanged.

**MCP tools / hooks / dashboard**: no MCP tool signatures, return shapes, DB tables, or env vars changed. No `__init__` exports changed.

Verdict: no breaking change for any dependent. The single behavior change (claim survives spawn) is the fix itself and is the input `cleanup_stale_processing` was always designed to consume.

## Test

New: `tests/ingest/test_backlog_drain_no_unlink_422.py`
- `test_drain_leaves_processing_claim_after_spawn` — after `_drain_backlog` spawns a (live-PID) worker, the `.processing` claim still exists and has not reverted to `.json`.
- `test_clear_backlog_processing_removes_claim_on_success` — the success helper removes the claim and is safe/idempotent on missing/`""`/`"unknown"`.
- `test_crashed_worker_is_requeued_not_dropped` — end-to-end: spawn a worker with a guaranteed-dead PID, age the claim past the 30-min threshold, then `cleanup_stale_processing` restores it to `.json` (re-queued, not lost).

All three **fail on `main`** (pre-fix the claim is unlinked on spawn) and **pass with this change**.

Suite delta vs `origin/main`: `tests/ingest/` + `tests/test_spawn_gate.py` → **231 passed, 1 skipped, 0 new failures** (run with `TRUEMEMORY_MAX_EXTRACTIONS_PER_HOUR=0`). 4 tests (`test_stop_hook_safety.py` x3, `test_spawn_gate.py::test_drain_backlog_respects_spawn_cap`) fail **identically on pristine `origin/main`** purely because of an exhausted shared `~/.truememory/.extraction_budget` file in this environment; with the budget env var set they all pass. These are pre-existing test-isolation flakiness, not regressions from this change.

## Caution notes (risk: medium)

- Recovery of a crashed worker is **not immediate** — it waits for the 30-minute `_STALE_PROCESSING_THRESHOLD` AND a dead claiming PID (by design, to avoid yanking a claim from a still-running worker). This is the documented behavior of `cleanup_stale_processing`; no change to that threshold here.
- The CLI removes the claim by reconstructing the filename from `--session`. If a session were ever queued under a different sanitized id than the CLI receives, the claim would linger until the stale watcher reclaims it (safe fallback, not data loss). Both `_queue_to_backlog` and `clear_backlog_processing` use the same `_safe_session_id` rule, so they agree.

Fixes #422
