### PR TITLE
feat: add truememory_consolidate MCP tool for L2-L5 layer rebuild

### DIFF
--- a/tests/test_issue_455_consolidation_mcp.py
+++ b/tests/test_issue_455_consolidation_mcp.py
@@ -1,0 +1,102 @@
+"""Regression tests for issue #455: L5 consolidation dead for MCP users.
+
+MCP users call add() which only does insert + embed (4/14 build steps).
+The truememory_consolidate tool fills the gap by rebuilding L2-L5 layers.
+"""
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import pytest
+
+
+class TestIssue455ConsolidationMCP:
+    """Verify that truememory_consolidate rebuilds L5 layers."""
+
+    def _make_engine_with_messages(self, n=10):
+        """Create a Memory engine with n messages, using only add()."""
+        from truememory.client import Memory
+
+        m = Memory(path=":memory:")
+        fake_embedding = np.random.rand(256).astype(np.float32)
+
+        mock_model = MagicMock()
+        mock_model.encode = lambda texts, **kw: np.array(
+            [fake_embedding] * len(texts)
+        )
+
+        with patch("truememory.vector_search.get_model", return_value=mock_model):
+            for i in range(n):
+                m.add(
+                    content=f"I had a meeting with person_{i % 3} about project_{i % 2}",
+                    user_id="alice",
+                )
+        return m
+
+    def test_issue_455_consolidate_tool_exists(self):
+        """truememory_consolidate must be registered as an MCP tool."""
+        from truememory.mcp_server import mcp
+
+        tool_names = []
+        for tool in mcp._tool_manager.list_tools():
+            tool_names.append(tool.name)
+
+        assert "truememory_consolidate" in tool_names, (
+            "truememory_consolidate tool not registered — MCP users have no "
+            "way to trigger consolidation after add()"
+        )
+
+    def test_issue_455_add_only_leaves_summaries_empty(self):
+        """After only add() calls, summaries table should be empty."""
+        m = self._make_engine_with_messages(5)
+        conn = m._engine.conn
+
+        has_summaries = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='summaries'"
+        ).fetchone()
+
+        if has_summaries:
+            count = conn.execute("SELECT COUNT(*) FROM summaries").fetchone()[0]
+            assert count == 0, (
+                f"summaries has {count} rows after add()-only — "
+                "consolidation is running from add() (if this passes, issue #455 is already fixed)"
+            )
+
+    def test_issue_455_consolidate_populates_tables(self):
+        """After calling consolidate, at least one L5 table should have data."""
+        m = self._make_engine_with_messages(10)
+        conn = m._engine.conn
+
+        from truememory.mcp_server import truememory_consolidate
+
+        with patch("truememory.mcp_server._get_memory", return_value=m):
+            result = truememory_consolidate()
+
+        import json
+        stats = json.loads(result)
+
+        has_error_only = all(
+            "ERROR" in str(v) or "SKIPPED" in str(v)
+            for v in stats.values()
+        )
+        assert not has_error_only, (
+            f"All consolidation steps failed or skipped: {stats}. "
+            "At least one L5 layer should succeed."
+        )
+
+    def test_issue_455_consolidate_returns_timing_stats(self):
+        """Consolidate tool must return per-step timing stats."""
+        m = self._make_engine_with_messages(5)
+
+        from truememory.mcp_server import truememory_consolidate
+
+        with patch("truememory.mcp_server._get_memory", return_value=m):
+            result = truememory_consolidate()
+
+        import json
+        stats = json.loads(result)
+
+        assert isinstance(stats, dict), "Consolidate must return JSON object"
+        assert len(stats) > 0, "Consolidate must return at least one stat"

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1014,6 +1014,131 @@ def truememory_entity_profile(entity: str) -> str:
         return json.dumps({"error": str(e)})
 
 
+@mcp.tool()
+@_tracked("tool_consolidate")
+def truememory_consolidate() -> str:
+    """Rebuild all consolidation layers (L2-L5) on existing memories.
+
+    This fills the gap left by add() which only does basic insert + embed.
+    Call after batch additions or at session end (via hooks) to enable:
+    - Fact timeline with contradiction detection
+    - Monthly and entity summaries
+    - Surprise scoring for predictive retrieval
+    - Episode detection and landmark events
+    - Structured fact extraction
+    - Dunbar relationship hierarchy
+
+    Returns timing stats for each step.
+    """
+    m = _get_memory()
+    m._engine._ensure_connection()
+    conn = m._engine.conn
+    stats: dict[str, str] = {}
+
+    try:
+        from truememory.consolidation import (
+            build_summaries,
+            detect_contradictions,
+            build_structured_facts,
+        )
+        has_consolidation = True
+    except (ImportError, ModuleNotFoundError):
+        has_consolidation = False
+
+    try:
+        from truememory.predictive import build_surprise_index
+        has_predictive = True
+    except (ImportError, ModuleNotFoundError):
+        has_predictive = False
+
+    try:
+        from truememory.temporal import detect_episodes, detect_landmark_events
+        has_temporal = True
+    except (ImportError, ModuleNotFoundError):
+        has_temporal = False
+
+    try:
+        from truememory.personality import build_dunbar_hierarchy
+        has_personality = True
+    except (ImportError, ModuleNotFoundError):
+        has_personality = False
+
+    if has_consolidation:
+        try:
+            t0 = time.time()
+            build_summaries(conn)
+            stats["build_summaries"] = f"{time.time() - t0:.3f}s"
+        except Exception as exc:
+            stats["build_summaries"] = f"ERROR: {exc}"
+
+        try:
+            t0 = time.time()
+            detect_contradictions(conn)
+            stats["detect_contradictions"] = f"{time.time() - t0:.3f}s"
+        except Exception as exc:
+            stats["detect_contradictions"] = f"ERROR: {exc}"
+
+        try:
+            t0 = time.time()
+            n = build_structured_facts(conn)
+            stats["structured_facts"] = f"{n} facts in {time.time() - t0:.3f}s"
+        except Exception as exc:
+            stats["structured_facts"] = f"ERROR: {exc}"
+    else:
+        stats["consolidation"] = "SKIPPED (module not available)"
+
+    if has_predictive:
+        try:
+            t0 = time.time()
+            build_surprise_index(conn)
+            stats["build_surprise_index"] = f"{time.time() - t0:.3f}s"
+        except Exception as exc:
+            stats["build_surprise_index"] = f"ERROR: {exc}"
+    else:
+        stats["build_surprise_index"] = "SKIPPED (module not available)"
+
+    if has_temporal:
+        try:
+            t0 = time.time()
+            ep = detect_episodes(conn)
+            stats["detect_episodes"] = f"{ep} episodes in {time.time() - t0:.3f}s"
+        except Exception as exc:
+            stats["detect_episodes"] = f"ERROR: {exc}"
+
+        try:
+            t0 = time.time()
+            lm = detect_landmark_events(conn)
+            stats["detect_landmarks"] = f"{lm} events in {time.time() - t0:.3f}s"
+        except Exception as exc:
+            stats["detect_landmarks"] = f"ERROR: {exc}"
+    else:
+        stats["temporal"] = "SKIPPED (module not available)"
+
+    if has_personality:
+        try:
+            t0 = time.time()
+            primary = None
+            try:
+                row = conn.execute(
+                    "SELECT sender, COUNT(*) as cnt FROM messages "
+                    "WHERE sender != '' AND sender IS NOT NULL "
+                    "GROUP BY sender ORDER BY cnt DESC LIMIT 1"
+                ).fetchone()
+                if row and row[0] and row[0].strip():
+                    primary = row[0]
+            except Exception:
+                pass
+            result = build_dunbar_hierarchy(conn, primary_entity=primary)
+            n = len(result) if isinstance(result, dict) else result
+            stats["dunbar_hierarchy"] = f"{n} relationships in {time.time() - t0:.3f}s"
+        except Exception as exc:
+            stats["dunbar_hierarchy"] = f"ERROR: {exc}"
+    else:
+        stats["dunbar_hierarchy"] = "SKIPPED (module not available)"
+
+    return json.dumps(stats, indent=2)
+
+
 # ---------------------------------------------------------------------------
 # Background model preloading
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Adds `truememory_consolidate` MCP tool** that rebuilds all L2-L5 consolidation layers missing from the `add()` path.
- **Closes the biggest product gap**: MCP users (the majority) only got 4/14 build steps, leaving fact_timeline, summaries, surprise_scores, episodes, and entity_relationships permanently empty.
- **Published benchmarks (87.71% LoCoMo) include L5 contributions** that real MCP users never saw — this fix restores parity.

## What the tool does

Calls all consolidation functions that `ingest()` runs but `add()` skips:

| Step | Module | Tables |
|------|--------|--------|
| `build_summaries()` | consolidation | summaries |
| `detect_contradictions()` | consolidation | fact_timeline |
| `build_structured_facts()` | consolidation | summaries (structured_fact) |
| `build_surprise_index()` | predictive | surprise_scores |
| `detect_episodes()` | temporal | episodes |
| `detect_landmark_events()` | temporal | landmark_events |
| `build_dunbar_hierarchy()` | personality | entity_relationships |

Returns per-step timing stats as JSON. Each step is independently guarded — a failure in one doesn't block the others.

## Design

Option 2 from the issue (lowest risk): expose as an MCP tool rather than changing `add()` behavior. Users/hooks can call it after session end or periodically.

## Test plan

- [x] `truememory_consolidate` tool is registered in MCP server
- [x] `add()` alone leaves summaries table empty (documents the gap)
- [x] After calling consolidate, at least one L5 layer has data
- [x] Tool returns per-step timing stats as JSON
- [x] TDD gate: test fails without fix, passes with fix

Closes #455