### PR TITLE
fix: write embedder metadata in embed_single to prevent warm re-embed (#460)

### DIFF
--- a/tests/test_issue_460_warm_search.py
+++ b/tests/test_issue_460_warm_search.py
@@ -1,0 +1,103 @@
+"""Regression tests for issue #460: warm search 15x slower than cold search.
+
+Root cause: embed_single() (used by add()) does not write embedder metadata.
+On the next process startup, _check_embedder_compatibility logs the "without
+embedder metadata" warning, and the Qwen3 NaN fix path sees no flag and
+re-embeds ALL vectors — making the "warm" path far slower than cold.
+
+Fix: embed_single() must call _write_embedder_metadata() so subsequent
+opens skip the NaN re-embed.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import pytest
+
+
+class TestIssue460WarmSearch:
+    """Verify embedder metadata is written after embed_single."""
+
+    def _make_mock_model(self):
+        mock_model = MagicMock()
+        mock_model.encode = lambda texts, **kw: np.array(
+            [np.random.rand(256).astype(np.float32)] * len(texts)
+        )
+        return mock_model
+
+    def test_issue_460_embed_single_writes_metadata(self):
+        """After add() via embed_single, embedder metadata must exist."""
+        from truememory.client import Memory
+        from truememory.vector_search import _read_embedder_metadata
+
+        m = Memory(path=":memory:")
+        mock_model = self._make_mock_model()
+
+        with patch("truememory.vector_search.get_model", return_value=mock_model):
+            m.add(content="test memory", user_id="alice")
+
+        stored_model, stored_dim = _read_embedder_metadata(m._engine.conn)
+        assert stored_model is not None, (
+            "embed_single did not write embed_model metadata — warm search "
+            "will trigger unnecessary Qwen3 NaN re-embed on next startup"
+        )
+        assert stored_dim is not None, (
+            "embed_single did not write embed_dim metadata"
+        )
+
+    def test_issue_460_no_reembed_on_warm_connect(self):
+        """Second engine connecting to same DB must NOT trigger re-embed."""
+        import tempfile, sqlite3
+        from pathlib import Path
+        from truememory.client import Memory
+        from truememory.vector_search import _read_embedder_metadata
+
+        mock_model = self._make_mock_model()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+
+            with patch("truememory.vector_search.get_model", return_value=mock_model):
+                m1 = Memory(path=str(db_path))
+                m1.add(content="first memory", user_id="alice")
+                m1.add(content="second memory", user_id="alice")
+
+            stored_model, _ = _read_embedder_metadata(m1._engine.conn)
+            assert stored_model is not None, "metadata should be set after add()"
+
+            encode_call_count = [0]
+            original_encode = mock_model.encode
+
+            def counting_encode(texts, **kw):
+                encode_call_count[0] += len(texts)
+                return np.array(
+                    [np.random.rand(256).astype(np.float32)] * len(texts)
+                )
+
+            mock_model.encode = counting_encode
+
+            with patch("truememory.vector_search.get_model", return_value=mock_model):
+                m2 = Memory(path=str(db_path))
+                m2.search("first memory")
+
+            assert encode_call_count[0] <= 2, (
+                f"Second engine re-encoded {encode_call_count[0]} texts — "
+                "warm search is re-embedding all vectors due to missing metadata"
+            )
+
+    def test_issue_460_metadata_survives_multiple_adds(self):
+        """Metadata must persist across multiple add() calls."""
+        from truememory.client import Memory
+        from truememory.vector_search import _read_embedder_metadata
+
+        m = Memory(path=":memory:")
+        mock_model = self._make_mock_model()
+
+        with patch("truememory.vector_search.get_model", return_value=mock_model):
+            for i in range(5):
+                m.add(content=f"memory {i}", user_id="alice")
+
+        stored_model, stored_dim = _read_embedder_metadata(m._engine.conn)
+        assert stored_model is not None
+        assert stored_dim is not None

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -884,6 +884,7 @@ def embed_single(conn: sqlite3.Connection, message_id: int, content: str) -> Non
             )
     except Exception:
         logger.warning("Failed to create separation vector for message %d", message_id, exc_info=True)
+    _write_embedder_metadata(conn)
     # Caller is responsible for committing
 
 


### PR DESCRIPTION
## Summary
- `embed_single()` (used by `add()`) did not call `_write_embedder_metadata()`, leaving the DB with vectors but no model metadata
- On next process startup, the Qwen3 NaN fix saw no `qwen3_nan_fix_applied` flag and re-embedded ALL vectors — making warm search 15x slower than cold
- 1-line fix: call `_write_embedder_metadata(conn)` at the end of `embed_single()`

## Test plan
- [x] TDD: test fails before fix (metadata is None after add())
- [x] TDD: test passes after fix
- [x] Full suite: 799 passed, 0 new failures
- [x] Metadata persists after single add()
- [x] Second engine connecting to same DB does NOT re-embed
- [x] Metadata survives multiple sequential add() calls

Closes #460