### PR TITLE
fix: run Qwen3 NaN re-embed in background thread (#465)

### DIFF
--- a/tests/test_issue_465_qwen3_nan_async.py
+++ b/tests/test_issue_465_qwen3_nan_async.py
@@ -1,0 +1,100 @@
+"""Regression tests for issue #465: Qwen3 NaN fix blocks MCP synchronously.
+
+The NaN fix should:
+1. Not block _ensure_connection() for minutes
+2. Skip on fresh/empty databases
+3. Set the flag immediately to prevent re-runs
+4. Run re-embedding in background for file-backed DBs
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import pytest
+
+
+class TestIssue465Qwen3NanAsync:
+    """Verify NaN fix doesn't block MCP startup."""
+
+    def _make_mock_model(self, delay=0.0):
+        mock_model = MagicMock()
+        def slow_encode(texts, **kw):
+            if delay > 0:
+                time.sleep(delay)
+            return np.array(
+                [np.random.rand(256).astype(np.float32)] * len(texts)
+            )
+        mock_model.encode = slow_encode
+        return mock_model
+
+    def test_issue_465_fresh_db_not_blocked(self):
+        """Fresh database should not trigger NaN re-embed."""
+        from truememory.client import Memory
+
+        mock_model = self._make_mock_model(delay=0.5)
+
+        start = time.monotonic()
+        with patch("truememory.vector_search.get_model", return_value=mock_model):
+            m = Memory(path=":memory:")
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 2.0, (
+            f"Fresh DB init took {elapsed:.1f}s — NaN fix likely triggered "
+            "on empty database"
+        )
+
+    def test_issue_465_flag_set_immediately(self):
+        """The qwen3_nan_fix_applied flag must be set before re-embedding."""
+        from truememory.client import Memory
+
+        mock_model = self._make_mock_model()
+
+        with patch("truememory.vector_search.get_model", return_value=mock_model):
+            m = Memory(path=":memory:")
+            m.add(content="test", user_id="alice")
+
+        conn = m._engine.conn
+        row = conn.execute(
+            "SELECT value FROM metadata WHERE key = 'qwen3_nan_fix_applied'"
+        ).fetchone()
+        assert row is not None, (
+            "qwen3_nan_fix_applied flag not set — NaN fix will re-run"
+        )
+
+    def test_issue_465_second_connection_fast(self):
+        """Second connection to same DB must not re-run NaN fix."""
+        import tempfile
+        from pathlib import Path
+        from truememory.client import Memory
+
+        mock_model = self._make_mock_model()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+
+            with patch("truememory.vector_search.get_model", return_value=mock_model):
+                m1 = Memory(path=str(db_path))
+                m1.add(content="first", user_id="alice")
+
+            encode_count = [0]
+            original_encode = mock_model.encode
+
+            def counting_encode(texts, **kw):
+                encode_count[0] += 1
+                return np.array(
+                    [np.random.rand(256).astype(np.float32)] * len(texts)
+                )
+
+            mock_model.encode = counting_encode
+
+            start = time.monotonic()
+            with patch("truememory.vector_search.get_model", return_value=mock_model):
+                with patch("truememory.vector_search._model", None):
+                    m2 = Memory(path=str(db_path))
+            elapsed = time.monotonic() - start
+
+            assert elapsed < 2.0, (
+                f"Second connection took {elapsed:.1f}s — NaN fix re-ran"
+            )

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -421,27 +421,69 @@ class TrueMemoryEngine:
                                 "SELECT value FROM metadata WHERE key = 'qwen3_nan_fix_applied'"
                             ).fetchone()
                             if _row is None:
-                                from truememory.vector_search import (
-                                    build_vectors as _bv,
-                                    build_separation_vectors as _bsv,
-                                    init_vec_table as _ivt,
-                                )
-                                self.conn.execute("DROP TABLE IF EXISTS vec_messages")
-                                self.conn.execute("DROP TABLE IF EXISTS vec_messages_sep")
-                                self.conn.commit()
-                                _ivt(self.conn)
-                                _bv(self.conn)
-                                _bsv(self.conn)
-                                logger.warning(
-                                    "Qwen3 NaN fix: re-embedded all vectors with "
-                                    "eager attention (one-time macOS migration)"
-                                )
+                                _msg_count = self.conn.execute(
+                                    "SELECT COUNT(*) FROM messages"
+                                ).fetchone()[0] if "messages" in _tables else 0
                                 self.conn.execute(
                                     "INSERT OR REPLACE INTO metadata (key, value) "
                                     "VALUES (?, ?)",
                                     ("qwen3_nan_fix_applied", "1"),
                                 )
                                 self.conn.commit()
+                                if _msg_count > 0:
+                                    def _bg_reembed(db_path):
+                                        import sqlite3 as _sql
+                                        try:
+                                            _conn = _sql.connect(str(db_path), check_same_thread=False)
+                                            _conn.execute("PRAGMA journal_mode=WAL")
+                                            _conn.execute("PRAGMA busy_timeout=30000")
+                                            from truememory.vector_search import (
+                                                build_vectors as _bv,
+                                                build_separation_vectors as _bsv,
+                                                init_vec_table as _ivt,
+                                            )
+                                            _conn.execute("DROP TABLE IF EXISTS vec_messages")
+                                            _conn.execute("DROP TABLE IF EXISTS vec_messages_sep")
+                                            _conn.commit()
+                                            _ivt(_conn)
+                                            _bv(_conn)
+                                            _bsv(_conn)
+                                            _conn.close()
+                                            logger.warning(
+                                                "Qwen3 NaN fix: re-embedded %d vectors "
+                                                "in background", _msg_count,
+                                            )
+                                        except Exception:
+                                            logger.warning(
+                                                "Qwen3 NaN background migration failed",
+                                                exc_info=True,
+                                            )
+                                    _db = self.db_path
+                                    if str(_db) != ":memory:":
+                                        _t = threading.Thread(
+                                            target=_bg_reembed, args=(_db,),
+                                            daemon=True,
+                                        )
+                                        _t.start()
+                                        logger.info(
+                                            "Qwen3 NaN fix: re-embedding %d vectors "
+                                            "in background thread", _msg_count,
+                                        )
+                                    else:
+                                        from truememory.vector_search import (
+                                            build_vectors as _bv,
+                                            build_separation_vectors as _bsv,
+                                            init_vec_table as _ivt,
+                                        )
+                                        self.conn.execute("DROP TABLE IF EXISTS vec_messages")
+                                        self.conn.execute("DROP TABLE IF EXISTS vec_messages_sep")
+                                        self.conn.commit()
+                                        _ivt(self.conn)
+                                        _bv(self.conn)
+                                        _bsv(self.conn)
+                                        logger.warning(
+                                            "Qwen3 NaN fix: re-embedded all vectors",
+                                        )
                 except Exception:
                     logger.warning(
                         "Qwen3 NaN migration failed — run "


### PR DESCRIPTION
## Summary
- Qwen3 NaN fix ran synchronously in `_ensure_connection()`, blocking MCP for minutes on large DBs
- Now skips empty/fresh databases (no messages to re-embed)
- Sets `qwen3_nan_fix_applied` flag immediately to prevent re-runs
- Runs re-embedding in a background thread for file-backed DBs
- In-memory DBs still run synchronously (no separate connection possible)

## Test plan
- [x] 3 regression tests
- [x] Fresh DB not blocked by NaN fix
- [x] Flag set immediately before re-embedding
- [x] Second connection to same DB does not re-run NaN fix

Closes #465