### PR TITLE
fix: add missing 'id' key to L5 consolidation search results

### DIFF
--- a/tests/test_issue_482_l5_search_id.py
+++ b/tests/test_issue_482_l5_search_id.py
@@ -1,0 +1,120 @@
+"""Regression tests for issue #482: L5 search results silently dropped.
+
+search_contradictions() and search_consolidated() return dicts without
+an 'id' key, causing engine.py to silently discard all L5 results.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from truememory.consolidation import search_contradictions, search_consolidated
+from truememory.storage import create_db
+
+
+def _make_db_with_facts():
+    """Create an in-memory DB with fact_timeline and summaries data."""
+    conn = create_db(":memory:")
+
+    conn.execute(
+        "INSERT INTO messages (id, content, sender, timestamp) "
+        "VALUES (1, 'CarbonSense uses PostgreSQL', 'alice', '2025-01-01')"
+    )
+    conn.execute(
+        "INSERT INTO messages (id, content, sender, timestamp) "
+        "VALUES (2, 'CarbonSense migrated to ClickHouse', 'alice', '2025-06-01')"
+    )
+
+    conn.execute(
+        "INSERT INTO fact_timeline (subject, fact, timestamp, source_message_id) "
+        "VALUES ('CarbonSense database', 'PostgreSQL', '2025-01-01', 1)"
+    )
+    conn.execute(
+        "INSERT INTO fact_timeline (subject, fact, timestamp, superseded_by, source_message_id) "
+        "VALUES ('CarbonSense database', 'PostgreSQL', '2025-01-01', 2, 1)"
+    )
+    conn.execute(
+        "INSERT INTO fact_timeline (subject, fact, timestamp, source_message_id) "
+        "VALUES ('CarbonSense database', 'ClickHouse', '2025-06-01', 2)"
+    )
+
+    conn.execute(
+        "INSERT INTO summaries (period, start_date, end_date, entity, summary, key_facts, message_ids) "
+        "VALUES ('monthly', '2025-01-01', '2025-01-31', 'alice', "
+        "'Alice discussed CarbonSense database migration', "
+        "'[\"migrated from PostgreSQL to ClickHouse\"]', '[1,2]')"
+    )
+    conn.commit()
+    return conn
+
+
+class TestIssue482L5SearchId:
+    """Verify L5 search results include 'id' key for engine merging."""
+
+    def test_issue_482_contradiction_results_have_id(self):
+        """search_contradictions() results must have an 'id' key."""
+        conn = _make_db_with_facts()
+        results = search_contradictions(conn, "What database does CarbonSense use?")
+        assert len(results) > 0, "Expected contradiction results for CarbonSense query"
+        for r in results:
+            assert "id" in r, (
+                f"Contradiction result missing 'id' key. Keys: {list(r.keys())}"
+            )
+
+    def test_issue_482_consolidated_results_have_id(self):
+        """search_consolidated() results must have an 'id' key."""
+        conn = _make_db_with_facts()
+        results = search_consolidated(conn, "CarbonSense database migration")
+        assert len(results) > 0, "Expected consolidated results for CarbonSense query"
+        for r in results:
+            assert "id" in r, (
+                f"Consolidated result missing 'id' key. Keys: {list(r.keys())}"
+            )
+
+    def test_issue_482_l5_results_merged_into_search(self):
+        """Integration: L5 results must appear in engine search output."""
+        from unittest.mock import patch, MagicMock
+        import numpy as np
+        from truememory.client import Memory
+
+        m = Memory(path=":memory:")
+        fake_embedding = np.random.rand(256).astype(np.float32)
+        mock_model = MagicMock()
+        mock_model.encode = lambda texts, **kw: np.array(
+            [fake_embedding] * len(texts)
+        )
+
+        with patch("truememory.vector_search.get_model", return_value=mock_model):
+            m.add(content="CarbonSense uses PostgreSQL for analytics", user_id="alice")
+            m.add(content="CarbonSense migrated to ClickHouse last month", user_id="alice")
+
+        conn = m._engine.conn
+        conn.execute(
+            "INSERT INTO fact_timeline (subject, fact, timestamp, superseded_by, source_message_id) "
+            "VALUES ('CarbonSense database', 'PostgreSQL', '2025-01-01', 2, 1)"
+        )
+        conn.execute(
+            "INSERT INTO fact_timeline (subject, fact, timestamp, source_message_id) "
+            "VALUES ('CarbonSense database', 'ClickHouse', '2025-06-01', 2)"
+        )
+        conn.execute(
+            "INSERT INTO summaries (period, start_date, end_date, entity, summary, key_facts, message_ids) "
+            "VALUES ('monthly', '2025-01-01', '2025-01-31', '', "
+            "'CarbonSense database migration from PostgreSQL to ClickHouse', "
+            "'[\"ClickHouse\"]', '[1,2]')"
+        )
+        conn.commit()
+
+        m._engine._has_consolidation = True
+
+        results = m.search("What database does CarbonSense use?")
+
+        sources = [r.get("source", "") for r in results]
+        has_l5 = any(
+            s in ("contradiction", "summary", "fact_timeline")
+            for s in sources
+        )
+        assert has_l5, (
+            f"No L5 results in search output. Sources found: {sources}"
+        )

--- a/truememory/consolidation.py
+++ b/truememory/consolidation.py
@@ -859,6 +859,7 @@ def search_contradictions(conn: sqlite3.Connection,
                 continue
 
             results.append({
+                "id": latest["source_message_id"],
                 "subject": subject,
                 "current_fact": latest["fact"],
                 "current_timestamp": latest["timestamp"],
@@ -975,6 +976,7 @@ def search_consolidated(conn: sqlite3.Connection, query: str,
         score = overlap + time_bonus
         if score > 0:
             results.append({
+                "id": f"summary_{row[0]}",
                 "content": summary_text,
                 "period": row[1],
                 "start_date": row[2],
@@ -997,6 +999,7 @@ def search_consolidated(conn: sqlite3.Connection, query: str,
         history_text = "\n".join(history_text_parts)
 
         results.append({
+            "id": cr["id"],
             "content": f"[Fact Timeline: {cr['subject']}]\n"
                        f"Current: {cr['current_fact']}\n"
                        f"History:\n{history_text}",
@@ -1017,6 +1020,7 @@ def search_consolidated(conn: sqlite3.Connection, query: str,
             fts_results = _fts_search(conn, fts_query, limit=limit)
             for r in fts_results:
                 results.append({
+                    "id": r.get("id"),
                     "content": r["content"],
                     "period": "message",
                     "start_date": r["timestamp"],


### PR DESCRIPTION
## Summary
Adds the missing `id` key to dicts returned by `search_contradictions()` and `search_consolidated()`, unlocking the entire L5 contradiction/summary search feature which was silently dead code.

Fixes #482

## Root Cause
`search_contradictions()` returned dicts with `source_message_id` but no `id` key. `search_consolidated()` likewise had no `id` in summary or fact_timeline results. `engine.py:1566,1578` checks `cr.get("id")` which returned `None`, causing all L5 results to be silently discarded.

## Fix
Added `"id"` key to all return dicts in `consolidation.py`:
- `search_contradictions()`: `"id": latest["source_message_id"]`
- `search_consolidated()` summaries: `"id": f"summary_{row[0]}"`
- `search_consolidated()` fact_timeline: `"id": cr["id"]`
- `search_consolidated()` FTS fallback: `"id": r.get("id")`

## Dependency Impact
- `engine.py:1561` — calls `search_contradictions()`, now receives dicts with `id` key, dedup check works correctly
- `engine.py:1573` — calls `search_consolidated()`, now receives dicts with `id` key, dedup check works correctly
- `engine.py:1762` — `cid = cr.get("id")` in `search_agentic()` also benefits from the fix
- `__init__.py:54,108` — re-exports both functions, no signature change
- `consolidation.py:991` — internal call from `search_consolidated` to `search_contradictions`, benefits from the fix

Full ripgrep output:
```
truememory/engine.py:193:        search_contradictions,
truememory/engine.py:194:        search_consolidated,
truememory/engine.py:897:        # surfaced by search_consolidated
truememory/engine.py:1561:                contradiction_results = search_contradictions(self.conn, query)
truememory/engine.py:1573:                consolidated = search_consolidated(self.conn, query, limit=3)
truememory/__init__.py:54:    search_contradictions, search_consolidated,
truememory/__init__.py:108:    "search_contradictions", "search_consolidated",
truememory/consolidation.py:773:def search_contradictions
truememory/consolidation.py:876:def search_consolidated
truememory/consolidation.py:991:    contradiction_results = search_contradictions(conn, query)
```

Contract preserved: purely additive change (new key in return dicts), no signature changes, no removed keys.

## Test Plan
- `test_issue_482_contradiction_results_have_id` — verifies search_contradictions() returns dicts with 'id' key. Fails pre-fix, passes post-fix.
- `test_issue_482_consolidated_results_have_id` — verifies search_consolidated() returns dicts with 'id' key. Fails pre-fix, passes post-fix.
- `test_issue_482_l5_results_merged_into_search` — integration test: add memories, create fact_timeline + summaries, search, verify L5 results appear in output.
- Full suite: 447 pass, 0 new failures (2 pre-existing failures excluded: test_cli_preflight and test_issue_460)

## Validation
Panel advisory: 4/4 satisfied (GPT-4.1, Claude Sonnet 4, Qwen 3 235B, DeepSeek V3)
Deterministic gates: all pass (regression test verified bidirectional, suite green, callers checked)