### PR TITLE
fix: move embedding outside write lock in update()

### DIFF
--- a/tests/test_issue_496_update_lock.py
+++ b/tests/test_issue_496_update_lock.py
@@ -1,0 +1,74 @@
+"""Regression test for H10 #496: update() holds write lock during model inference.
+
+The fix pre-computes embeddings outside the lock (like add() does),
+then only holds _write_lock for the DB writes.
+"""
+
+import inspect
+import threading
+import time
+import unittest
+
+
+class TestUpdateLockScope(unittest.TestCase):
+    """Verify update() does not hold _write_lock during embedding."""
+
+    def test_update_computes_embedding_outside_lock(self):
+        """The embed call must happen BEFORE 'with self._write_lock'."""
+        from truememory.engine import TrueMemoryEngine
+        source = inspect.getsource(TrueMemoryEngine.update)
+        lock_pos = source.find("self._write_lock")
+        self.assertGreater(lock_pos, -1, "update() should use _write_lock")
+        embed_call = source.find("embed_single")
+        if embed_call != -1:
+            self.fail(
+                "update() should NOT call embed_single() inside the lock — "
+                "it should pre-compute embeddings like add() does"
+            )
+
+    def test_update_pre_computes_like_add(self):
+        """update() should use _encode_with_mps_fallback before the lock."""
+        from truememory.engine import TrueMemoryEngine
+        source = inspect.getsource(TrueMemoryEngine.update)
+        self.assertIn("_encode_with_mps_fallback", source,
+                       "update() should pre-compute embeddings with _encode_with_mps_fallback")
+
+    def test_update_concurrent_not_blocked_by_inference(self):
+        """Two concurrent update() calls should not serialize on inference."""
+        import tempfile, os
+        from truememory.engine import TrueMemoryEngine
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = os.path.join(tmp, "test.db")
+            e = TrueMemoryEngine(db_path=db_path)
+            e._ensure_connection()
+
+        m1 = e.add("first message", sender="alice")
+        m2 = e.add("second message", sender="bob")
+
+        results = [None, None]
+        errors = [None, None]
+
+        def do_update(idx, mid, text):
+            try:
+                results[idx] = e.update(mid, content=text)
+            except Exception as ex:
+                errors[idx] = ex
+
+        t1 = threading.Thread(target=do_update, args=(0, m1["id"], "updated first"))
+        t2 = threading.Thread(target=do_update, args=(1, m2["id"], "updated second"))
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        self.assertIsNone(errors[0], f"update 1 failed: {errors[0]}")
+        self.assertIsNone(errors[1], f"update 2 failed: {errors[1]}")
+        self.assertIsNotNone(results[0])
+        self.assertIsNotNone(results[1])
+        self.assertEqual(results[0]["content"], "updated first")
+        self.assertEqual(results[1]["content"], "updated second")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -892,6 +892,29 @@ class TrueMemoryEngine:
             Updated memory dict, or None if not found.
         """
         self._ensure_connection()
+
+        pre_embedding = None
+        pre_sep_embedding = None
+        if content is not None and self._has_vectors:
+            try:
+                from truememory.vector_search import (
+                    get_model, _encode_with_mps_fallback, _build_sep_text,
+                )
+                model = get_model()
+                pre_embedding = _encode_with_mps_fallback(model, [content])[0]
+                row = self.conn.execute(
+                    "SELECT sender, recipient, timestamp FROM messages WHERE id = ?",
+                    (memory_id,),
+                ).fetchone()
+                if row:
+                    sender_val = fields.get("sender", row[0])
+                    recipient_val = fields.get("recipient", row[1])
+                    timestamp_val = fields.get("timestamp", row[2])
+                    sep_text = _build_sep_text(sender_val, recipient_val, timestamp_val, content)
+                    pre_sep_embedding = _encode_with_mps_fallback(model, [sep_text])[0]
+            except Exception:
+                logger.debug("Failed to pre-compute embedding during update()", exc_info=True)
+
         with self._write_lock:
             if content is not None:
                 fields["content"] = content
@@ -900,29 +923,35 @@ class TrueMemoryEngine:
             if not ok:
                 return None
 
-            # Re-embed if content changed
-            if content is not None and self._has_vectors:
+            if pre_embedding is not None:
                 try:
-                    from truememory.vector_search import embed_single
-                    # Remove old embeddings from both vector tables, insert new
+                    from truememory.vector_search import (
+                        serialize_f32, _active_vec_table, _active_sep_table,
+                        _write_embedder_metadata,
+                    )
+                    vec_tbl = _active_vec_table(self.conn)
                     try:
-                        _vec_tbl, _sep_tbl = _resolve_vec_tables(self.conn)
-                    except Exception:
-                        logger.warning("_resolve_vec_tables failed in update(memory_id=%d); falling back to legacy table names", memory_id, exc_info=True)
-                        _vec_tbl, _sep_tbl = "vec_messages", "vec_messages_sep"
-                    try:
-                        self.conn.execute(f"DELETE FROM {_vec_tbl} WHERE rowid = ?", (memory_id,))
+                        self.conn.execute(f"DELETE FROM {vec_tbl} WHERE rowid = ?", (memory_id,))
                     except Exception:
                         logger.debug("Failed to delete old vector embedding for message %d", memory_id, exc_info=True)
-                    try:
-                        self.conn.execute(f"DELETE FROM {_sep_tbl} WHERE rowid = ?", (memory_id,))
-                    except Exception:
-                        logger.debug("Failed to delete old sep vector for message %d", memory_id, exc_info=True)
-                    embed_single(self.conn, memory_id, content)
+                    self.conn.execute(
+                        f"INSERT INTO {vec_tbl}(rowid, embedding) VALUES (?, ?)",
+                        (memory_id, serialize_f32(pre_embedding)),
+                    )
+                    if pre_sep_embedding is not None:
+                        sep_tbl = _active_sep_table(self.conn)
+                        try:
+                            self.conn.execute(f"DELETE FROM {sep_tbl} WHERE rowid = ?", (memory_id,))
+                        except Exception:
+                            logger.debug("Failed to delete old sep vector for message %d", memory_id, exc_info=True)
+                        self.conn.execute(
+                            f"INSERT INTO {sep_tbl}(rowid, embedding) VALUES (?, ?)",
+                            (memory_id, serialize_f32(pre_sep_embedding)),
+                        )
+                    _write_embedder_metadata(self.conn)
                 except Exception:
                     logger.warning("Vector embedding failed for message %d", memory_id, exc_info=True)
 
-            # Persist vector embedding and any profile updates
             self.conn.commit()
 
         return self.get(memory_id)


### PR DESCRIPTION
## Summary
- **H10 #496**: `update()` holds `_write_lock` during full model inference via `embed_single()`, blocking all concurrent writes
- Mirrors the fix from PR #468 which did the same for `add()`
- Pre-computes embeddings with `_encode_with_mps_fallback()` before acquiring the lock
- Inside the lock: only DB operations (DELETE old vectors + INSERT new + commit)

Fixes #496

## Test plan
- [x] 3 regression tests in `tests/test_issue_496_update_lock.py`
- [x] Source verification: `embed_single` no longer called inside update()
- [x] Source verification: `_encode_with_mps_fallback` used for pre-computation
- [x] Concurrent update test: two threads update simultaneously without deadlock
- [x] TDD: tests failed before fix, pass after