### PR TITLE
fix: validate embeddings for NaN/Inf before insert

### DIFF
--- a/tests/test_issue_492_nan_validation.py
+++ b/tests/test_issue_492_nan_validation.py
@@ -1,0 +1,64 @@
+"""Regression tests for H6 #492: NaN/Inf validation on embeddings before insert.
+
+serialize_f32() is the single choke point for all vector insertions.
+It must reject NaN and Inf values to prevent corrupted embeddings from
+entering the database.
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+
+class TestSerializeF32NaNValidation(unittest.TestCase):
+    """serialize_f32 must reject NaN/Inf embeddings."""
+
+    def test_rejects_nan_in_list(self):
+        from truememory.vector_search import serialize_f32
+        with self.assertRaises(ValueError):
+            serialize_f32([0.1, float("nan"), 0.3])
+
+    def test_rejects_inf_in_list(self):
+        from truememory.vector_search import serialize_f32
+        with self.assertRaises(ValueError):
+            serialize_f32([0.1, float("inf"), 0.3])
+
+    def test_rejects_neg_inf_in_list(self):
+        from truememory.vector_search import serialize_f32
+        with self.assertRaises(ValueError):
+            serialize_f32([0.1, float("-inf"), 0.3])
+
+    def test_rejects_nan_in_numpy(self):
+        from truememory.vector_search import serialize_f32
+        arr = np.array([0.1, np.nan, 0.3], dtype=np.float32)
+        with self.assertRaises(ValueError):
+            serialize_f32(arr)
+
+    def test_rejects_inf_in_numpy(self):
+        from truememory.vector_search import serialize_f32
+        arr = np.array([0.1, np.inf, 0.3], dtype=np.float32)
+        with self.assertRaises(ValueError):
+            serialize_f32(arr)
+
+    def test_accepts_valid_embedding(self):
+        from truememory.vector_search import serialize_f32
+        result = serialize_f32([0.1, 0.2, 0.3])
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(len(result), 12)  # 3 floats * 4 bytes
+
+    def test_accepts_valid_numpy(self):
+        from truememory.vector_search import serialize_f32
+        arr = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+        result = serialize_f32(arr)
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(len(result), 12)
+
+    def test_accepts_zeros(self):
+        from truememory.vector_search import serialize_f32
+        result = serialize_f32([0.0, 0.0, 0.0])
+        self.assertIsInstance(result, bytes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import math
 import os
 import re
 import struct
@@ -415,9 +416,16 @@ def serialize_f32(vector) -> bytes:
 
     Accepts any array-like (list, tuple, numpy array).  Returns a
     ``struct``-packed blob of 32-bit floats.
+
+    Raises ValueError if any element is NaN or Inf.
     """
     if isinstance(vector, np.ndarray):
+        if not np.all(np.isfinite(vector)):
+            raise ValueError("Embedding contains NaN or Inf values")
         vector = vector.tolist()
+    else:
+        if any(math.isnan(v) or math.isinf(v) for v in vector):
+            raise ValueError("Embedding contains NaN or Inf values")
     return struct.pack(f"{len(vector)}f", *vector)
 
 


### PR DESCRIPTION
## Summary
- **H6 #492**: No NaN/Inf validation on embeddings before vector insert
- Added validation in `serialize_f32()` — the single choke point for all vector writes
- Uses `np.isfinite()` for numpy arrays, `math.isnan()`/`math.isinf()` for lists
- Raises `ValueError` with clear message on bad values

Fixes #492

## Test plan
- [x] 8 regression tests in `tests/test_issue_492_nan_validation.py`
- [x] Rejects NaN in list and numpy array
- [x] Rejects Inf and -Inf in list and numpy array
- [x] Accepts valid embeddings (list, numpy, zeros)
- [x] TDD: 5 tests failed before fix, all 8 pass after