### PR TITLE
fix: case-normalize user_id in summaries delete

### DIFF
--- a/tests/test_issue_501_summary_case.py
+++ b/tests/test_issue_501_summary_case.py
@@ -1,0 +1,52 @@
+"""Regression test for M4 #501: delete_all summaries cleanup not case-normalized.
+
+Entity profiles, style vectors, and relationships all use .lower() for
+delete cleanup but summaries did not, leaving orphaned summary rows.
+"""
+
+import sqlite3
+import unittest
+
+
+class TestDeleteAllSummaryCaseNormalization(unittest.TestCase):
+
+    def _make_engine(self):
+        from truememory.engine import TrueMemoryEngine
+        import tempfile, os
+        tmp = tempfile.mkdtemp()
+        db_path = os.path.join(tmp, "test.db")
+        e = TrueMemoryEngine(db_path=db_path)
+        e._ensure_connection()
+        return e, tmp
+
+    def test_delete_all_user_cleans_summaries_case_insensitive(self):
+        e, tmp = self._make_engine()
+        e.add("test memory", sender="Alice")
+        try:
+            e.conn.execute(
+                "INSERT INTO summaries (entity, summary, updated_at) VALUES (?, ?, ?)",
+                ("alice", "Alice is a test user", "2026-01-01"),
+            )
+            e.conn.commit()
+        except Exception:
+            self.skipTest("summaries table not available")
+        e.delete_all(user_id="Alice")
+        rows = e.conn.execute(
+            "SELECT * FROM summaries WHERE entity = ?", ("alice",)
+        ).fetchall()
+        self.assertEqual(len(rows), 0, "Summaries for 'alice' should be deleted when user_id='Alice'")
+
+    def test_delete_all_user_source_uses_lower(self):
+        """Verify the source code normalizes user_id for summaries delete."""
+        import inspect
+        from truememory.engine import TrueMemoryEngine
+        source = inspect.getsource(TrueMemoryEngine.delete_all)
+        summaries_idx = source.find("DELETE FROM summaries WHERE entity")
+        self.assertGreater(summaries_idx, -1, "Should have summaries delete")
+        nearby = source[summaries_idx:summaries_idx + 100]
+        self.assertIn(".lower()", nearby,
+                       "summaries delete should use user_id.lower()")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -703,7 +703,7 @@ class TrueMemoryEngine:
                 # Clean summaries scoped to this user
                 try:
                     self.conn.execute(
-                        "DELETE FROM summaries WHERE entity = ?", (user_id,)
+                        "DELETE FROM summaries WHERE entity = ?", (user_id.lower(),)
                     )
                 except Exception:
                     logger.warning("Failed to clean summaries for user %s", user_id, exc_info=True)


### PR DESCRIPTION
## Summary
- **M4 #501**: `delete_all(user_id)` summaries cleanup uses raw `user_id` instead of `.lower()`
- All other entity-scoped deletes already normalize — summaries was the only one missed
- One-character fix: `(user_id,)` → `(user_id.lower(),)`

Fixes #501

## Test plan
- [x] Source verification: `.lower()` present near summaries DELETE
- [x] TDD: test failed before fix, passes after