### PR TITLE
fix: optimize add() write path — single commit, CPU work outside lock

### DIFF
--- a/tests/test_issue_511_write_path_opt.py
+++ b/tests/test_issue_511_write_path_opt.py
@@ -1,0 +1,61 @@
+"""Regression tests for write-path optimizations (M14 #511, M15 #512, M16 #513).
+
+M14: Triple conn.commit() per add() — personality and style_vec had their own commits
+M15: compute_style_vector runs inside write lock — should be pre-computed outside
+M16: Fallback embed_single inside write lock — removed in favor of skip-and-log
+"""
+
+import inspect
+import unittest
+
+
+class TestM14NoRedundantCommits(unittest.TestCase):
+    """M14: personality and style_vec incremental functions must not commit."""
+
+    def test_personality_incremental_no_commit(self):
+        from truememory.personality import update_entity_profile_incremental
+        source = inspect.getsource(update_entity_profile_incremental)
+        self.assertNotIn("conn.commit()", source,
+                         "update_entity_profile_incremental should not call conn.commit()")
+
+    def test_style_vec_incremental_no_commit(self):
+        from truememory.personality_style_vec import update_entity_style_vector_incremental
+        source = inspect.getsource(update_entity_style_vector_incremental)
+        self.assertNotIn("conn.commit()", source,
+                         "update_entity_style_vector_incremental should not call conn.commit()")
+
+
+class TestM15StyleVecOutsideLock(unittest.TestCase):
+    """M15: compute_style_vector should run outside write lock."""
+
+    def test_add_precomputes_style_vec(self):
+        from truememory.engine import TrueMemoryEngine
+        source = inspect.getsource(TrueMemoryEngine.add)
+        lock_pos = source.find("self._write_lock")
+        precompute_pos = source.find("compute_style_vector")
+        self.assertGreater(precompute_pos, -1,
+                           "add() should reference compute_style_vector for pre-computation")
+        self.assertLess(precompute_pos, lock_pos,
+                        "compute_style_vector call should appear before _write_lock")
+
+    def test_style_vec_accepts_precomputed(self):
+        from truememory.personality_style_vec import update_entity_style_vector_incremental
+        source = inspect.getsource(update_entity_style_vector_incremental)
+        self.assertIn("_pre_computed_vec", source,
+                       "Should accept _pre_computed_vec parameter")
+
+
+class TestM16NoFallbackEmbedInsideLock(unittest.TestCase):
+    """M16: embed_single should not be called inside the write lock in add()."""
+
+    def test_no_embed_single_in_add_lock_section(self):
+        from truememory.engine import TrueMemoryEngine
+        source = inspect.getsource(TrueMemoryEngine.add)
+        lock_pos = source.find("self._write_lock")
+        lock_section = source[lock_pos:]
+        self.assertNotIn("embed_single", lock_section,
+                         "embed_single should not appear inside the _write_lock section of add()")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -541,6 +541,14 @@ class TrueMemoryEngine:
             except Exception:
                 logger.debug("Failed to pre-compute embedding during add()", exc_info=True)
 
+        pre_style_vec = None
+        if self._has_style_vec and sender:
+            try:
+                from truememory.personality_style_vec import compute_style_vector
+                pre_style_vec = compute_style_vector(content)
+            except Exception:
+                logger.debug("Failed to pre-compute style vector during add()", exc_info=True)
+
         with self._write_lock:
             msg = {
                 "content": content,
@@ -572,12 +580,6 @@ class TrueMemoryEngine:
                     _write_embedder_metadata(self.conn)
                 except Exception:
                     logger.debug("Failed to store embedding for message %s during add()", new_id, exc_info=True)
-            elif self._has_vectors:
-                try:
-                    from truememory.vector_search import embed_single
-                    embed_single(self.conn, new_id, content)
-                except Exception:
-                    logger.debug("Failed to embed message %s during add()", new_id, exc_info=True)
 
             # Incrementally update entity profile
             if self._has_personality and sender:
@@ -587,14 +589,13 @@ class TrueMemoryEngine:
                 except Exception:
                     logger.debug("Failed to update entity profile for %s during add()", sender, exc_info=True)
 
-            # Incrementally update style vector (L0 char-n-gram)
-            if self._has_style_vec and sender:
+            # Store pre-computed style vector (DB write only, computation happened outside lock)
+            if pre_style_vec is not None:
                 try:
-                    _update_style_vec(self.conn, sender, content)
+                    _update_style_vec(self.conn, sender, content, _pre_computed_vec=pre_style_vec)
                 except Exception:
                     logger.debug("Failed to update style vector for %s during add()", sender, exc_info=True)
 
-            # Persist vector embedding and any profile updates
             self.conn.commit()
 
         return {

--- a/truememory/personality.py
+++ b/truememory/personality.py
@@ -1032,7 +1032,6 @@ def update_entity_profile_incremental(
             json.dumps(topics), json.dumps(old_rels), now,
         ),
     )
-    conn.commit()
 
 
 def get_entity_profile(conn: sqlite3.Connection,

--- a/truememory/personality_style_vec.py
+++ b/truememory/personality_style_vec.py
@@ -164,6 +164,7 @@ def build_entity_style_vectors(conn: sqlite3.Connection) -> dict[str, list[float
 
 def update_entity_style_vector_incremental(
     conn: sqlite3.Connection, entity: str, new_message: str,
+    *, _pre_computed_vec: list[float] | None = None,
 ) -> None:
     """Incrementally update an entity's style vector with a new message.
 
@@ -178,6 +179,7 @@ def update_entity_style_vector_incremental(
         conn:        Open database connection.
         entity:      Entity name (sender).
         new_message: The new message text.
+        _pre_computed_vec: If provided, skip compute_style_vector() call.
     """
     if not entity or not new_message:
         return
@@ -194,7 +196,7 @@ def update_entity_style_vector_incremental(
         )"""
     )
 
-    new_vec = compute_style_vector(new_message)
+    new_vec = _pre_computed_vec if _pre_computed_vec is not None else compute_style_vector(new_message)
     now = datetime.now(timezone.utc).isoformat()
 
     row = conn.execute(
@@ -229,8 +231,6 @@ def update_entity_style_vector_incremental(
                VALUES (?, ?, ?, ?)""",
             (entity, json.dumps(merged), new_count, now),
         )
-
-    conn.commit()
 
 
 def get_entity_style_vector(


### PR DESCRIPTION
## Summary
- **M14 #511**: Remove redundant `conn.commit()` from `personality.py` and `personality_style_vec.py` — the caller commits once
- **M15 #512**: Pre-compute `compute_style_vector()` outside `_write_lock`, pass result via `_pre_computed_vec` kwarg
- **M16 #513**: Remove `embed_single` fallback from inside the lock — if pre-compute fails, store message without vector

Fixes #511, #512, #513

## Test plan
- [x] 5 regression tests in `tests/test_issue_511_write_path_opt.py`
- [x] No redundant commits in personality or style_vec incremental functions
- [x] Style vector pre-computation happens before lock acquisition
- [x] No embed_single call inside the lock section of add()