### PR TITLE
fix: complete case normalization for recipients, Dunbar, summaries

### DIFF
--- a/tests/test_issue_495_case_normalize.py
+++ b/tests/test_issue_495_case_normalize.py
@@ -1,0 +1,56 @@
+"""Regression tests for H9 #495: PR #467 case normalization incomplete.
+
+Gaps: recipients in personality profiles, build_dunbar_hierarchy(),
+and summary entity normalization all missed .lower().
+"""
+
+import inspect
+import unittest
+
+
+class TestRecipientNormalization(unittest.TestCase):
+    """Recipient keys in relationship tracking must be lowercased."""
+
+    def test_incremental_profile_lowercases_recipient(self):
+        from truememory.personality import update_entity_profile_incremental
+        source = inspect.getsource(update_entity_profile_incremental)
+        rel_section = source[source.find("Relationships"):]
+        self.assertIn("recipient.lower()", rel_section,
+                       "Recipient should be lowercased in relationship tracking")
+
+    def test_recipient_key_is_lowercase(self):
+        from truememory.personality import update_entity_profile_incremental
+        source = inspect.getsource(update_entity_profile_incremental)
+        self.assertIn("recipient_key", source,
+                       "Should use a lowercased recipient_key variable")
+
+
+class TestDunbarHierarchyNormalization(unittest.TestCase):
+    """build_dunbar_hierarchy must normalize entity names."""
+
+    def test_primary_entity_lowercased(self):
+        from truememory.personality import build_dunbar_hierarchy
+        source = inspect.getsource(build_dunbar_hierarchy)
+        self.assertIn("primary_entity.lower()", source,
+                       "primary_entity should be lowercased")
+
+    def test_contact_names_lowercased(self):
+        from truememory.personality import build_dunbar_hierarchy
+        source = inspect.getsource(build_dunbar_hierarchy)
+        self.assertIn("LOWER(name)", source,
+                       "Contact names should be lowercased in SQL query")
+
+
+class TestSummaryEntityNormalization(unittest.TestCase):
+    """Summary entity column must use lowercase sender names."""
+
+    def test_summary_entity_is_lowercase(self):
+        from truememory.consolidation import build_summaries
+        source = inspect.getsource(build_summaries)
+        entity_grouping = source[source.find("Per-entity summaries"):]
+        self.assertIn('.lower()', entity_grouping[:200],
+                       "Entity grouping should use sender.lower()")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/truememory/consolidation.py
+++ b/truememory/consolidation.py
@@ -680,7 +680,7 @@ def build_summaries(conn: sqlite3.Connection) -> int:
     by_entity: dict[str, list[dict]] = defaultdict(list)
     for msg in all_msgs:
         if msg["sender"]:
-            by_entity[msg["sender"]].append(msg)
+            by_entity[msg["sender"].lower()].append(msg)
 
     for entity, messages in by_entity.items():
         if len(messages) < 10:

--- a/truememory/personality.py
+++ b/truememory/personality.py
@@ -1006,7 +1006,8 @@ def update_entity_profile_incremental(
 
     # ── Relationships ─────────────────────────────────────────────────
     if recipient:
-        rel = old_rels.get(recipient, {"message_count": 0, "primary_topic": "general"})
+        recipient_key = recipient.lower()
+        rel = old_rels.get(recipient_key, {"message_count": 0, "primary_topic": "general"})
         rel["message_count"] = rel.get("message_count", 0) + 1
         lower = message.lower()
         if any(w in lower for w in ("code", "deploy", "api", "database", "bug", "server")):
@@ -1017,7 +1018,7 @@ def update_entity_profile_incremental(
             rel["primary_topic"] = "social"
         elif any(w in lower for w in ("revenue", "investor", "pricing", "customer")):
             rel["primary_topic"] = "business"
-        old_rels[recipient] = rel
+        old_rels[recipient_key] = rel
 
     # ── Store ─────────────────────────────────────────────────────────
     now = datetime.now(timezone.utc).isoformat()
@@ -1233,14 +1234,16 @@ def build_dunbar_hierarchy(conn, primary_entity=None):
     if primary_entity is None:
         return {}
 
+    primary_entity = primary_entity.lower()
+
     # Count messages per contact
     rows = conn.execute(
         """
-        SELECT name, COUNT(*) as cnt, MAX(ts) as last_ts FROM (
-            SELECT recipient as name, timestamp as ts FROM messages WHERE LOWER(sender) = LOWER(?) AND recipient != ''
+        SELECT LOWER(name) as name, COUNT(*) as cnt, MAX(ts) as last_ts FROM (
+            SELECT recipient as name, timestamp as ts FROM messages WHERE LOWER(sender) = ? AND recipient != ''
             UNION ALL
-            SELECT sender as name, timestamp as ts FROM messages WHERE LOWER(recipient) = LOWER(?) AND sender != ''
-        ) GROUP BY name ORDER BY cnt DESC
+            SELECT sender as name, timestamp as ts FROM messages WHERE LOWER(recipient) = ? AND sender != ''
+        ) GROUP BY LOWER(name) ORDER BY cnt DESC
         """,
         (primary_entity, primary_entity)
     ).fetchall()
@@ -1250,7 +1253,7 @@ def build_dunbar_hierarchy(conn, primary_entity=None):
 
     # Clear existing relationships for this entity
     conn.execute(
-        "DELETE FROM entity_relationships WHERE LOWER(entity_a) = LOWER(?)",
+        "DELETE FROM entity_relationships WHERE entity_a = ?",
         (primary_entity,)
     )
 


### PR DESCRIPTION
## Summary
- **H9 #495**: PR #467 case normalization missed 3 areas
- Recipients: relationship tracking in `update_entity_profile_incremental` now uses `recipient.lower()`
- Dunbar: `build_dunbar_hierarchy` normalizes `primary_entity` and uses `LOWER(name)` in SQL grouping
- Summaries: `build_summaries` entity grouping key now uses `sender.lower()`

Fixes #495

## Test plan
- [x] 5 regression tests in `tests/test_issue_495_case_normalize.py`
- [x] Source verification for all 3 normalization gaps