### PR TITLE
fix: prevent TypeError from mixed timezones in detect_episodes

### DIFF
--- a/tests/test_issue_508_timezone.py
+++ b/tests/test_issue_508_timezone.py
@@ -1,0 +1,73 @@
+"""Regression test for M11 #508: timezone mixing in detect_episodes.
+
+Timestamps with negative UTC offsets (e.g., -05:00) create aware datetimes
+while Z-suffixed ones become naive after the strip logic, causing TypeError
+on comparison.
+"""
+
+import sqlite3
+import unittest
+
+
+def _make_db_with_messages(timestamps):
+    """Create an in-memory DB with messages at the given timestamps."""
+    from truememory.storage import create_db
+    conn = create_db(":memory:")
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS episodes "
+            "(id INTEGER PRIMARY KEY, start_time TEXT, end_time TEXT, message_count INTEGER)"
+        )
+    except Exception:
+        pass
+    try:
+        conn.execute("ALTER TABLE messages ADD COLUMN episode_id INTEGER")
+    except Exception:
+        pass
+    for i, ts in enumerate(timestamps):
+        conn.execute(
+            "INSERT INTO messages (content, sender, recipient, timestamp, category, modality) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (f"message {i}", "alice", "bob", ts, "", ""),
+        )
+    conn.commit()
+    return conn
+
+
+class TestDetectEpisodesTimezone(unittest.TestCase):
+
+    def test_mixed_tz_correctly_groups_episodes(self):
+        """Mixed timezones must produce correct episode groupings, not silent misgroups."""
+        from truememory.temporal import detect_episodes
+        conn = _make_db_with_messages([
+            "2026-01-15T10:00:00Z",
+            "2026-01-15T11:00:00-05:00",
+            "2026-01-16T23:00:00+03:00",
+        ])
+        count = detect_episodes(conn)
+        self.assertEqual(count, 2,
+                         "Messages 12+ hours apart should be in separate episodes even with mixed TZs")
+
+    def test_negative_offset_not_silently_kept(self):
+        """Negative-offset timestamps must not create aware datetimes."""
+        from truememory.temporal import detect_episodes
+        conn = _make_db_with_messages([
+            "2026-01-15T10:00:00Z",
+            "2026-01-15T10:30:00-05:00",
+        ])
+        count = detect_episodes(conn)
+        self.assertGreater(count, 0)
+
+    def test_all_naive_still_works(self):
+        from truememory.temporal import detect_episodes
+        conn = _make_db_with_messages([
+            "2026-01-15T10:00:00",
+            "2026-01-15T10:30:00",
+            "2026-01-16T20:00:00",
+        ])
+        count = detect_episodes(conn)
+        self.assertEqual(count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/truememory/temporal.py
+++ b/truememory/temporal.py
@@ -560,6 +560,19 @@ def get_timeline(
 # Episode boundaries (B1: 6-hour gap heuristic)
 # ---------------------------------------------------------------------------
 
+_TZ_SUFFIX_RE = re.compile(r'([+-]\d{2}:\d{2}|Z)$')
+
+
+def _parse_naive(ts: str) -> datetime:
+    """Parse an ISO timestamp to a naive (tz-unaware) datetime.
+
+    Strips any timezone suffix (Z, +HH:MM, -HH:MM) to guarantee all
+    results are naive, avoiding TypeError on mixed-tz comparisons.
+    """
+    stripped = _TZ_SUFFIX_RE.sub('', ts)
+    return datetime.fromisoformat(stripped)
+
+
 def detect_episodes(conn, gap_hours=6):
     """
     Group messages into episodes using a time-gap heuristic.
@@ -594,9 +607,8 @@ def detect_episodes(conn, gap_hours=6):
         prev_id, prev_ts = rows[i - 1]
 
         try:
-            # Parse timestamps (handle both date-only and datetime formats)
-            curr_dt = datetime.fromisoformat(ts.replace('Z', '+00:00').split('+')[0])
-            prev_dt = datetime.fromisoformat(prev_ts.replace('Z', '+00:00').split('+')[0])
+            curr_dt = _parse_naive(ts)
+            prev_dt = _parse_naive(prev_ts)
 
             if (curr_dt - prev_dt) > gap_delta:
                 # New episode


### PR DESCRIPTION
## Summary
- **M11 #508**: Mixed timezone-aware and naive timestamps cause TypeError in `detect_episodes()`
- Old code: `.split('+')[0]` strips positive offsets but leaves negative ones, creating aware datetimes
- Fix: `_parse_naive()` regex strips Z, +HH:MM, and -HH:MM consistently

Fixes #508

## Test plan
- [x] 3 regression tests in `tests/test_issue_508_timezone.py`
- [x] Mixed TZ timestamps correctly group into episodes (was 1 episode, now 2)
- [x] Negative offset handled correctly
- [x] All-naive timestamps still work
- [x] TDD: mixed TZ test failed before fix (1 != 2), passes after