### PR TITLE
fix: model server hardening — dtype, size, PID, rebuild lock

### DIFF
--- a/tests/test_issue_514_model_server.py
+++ b/tests/test_issue_514_model_server.py
@@ -1,0 +1,81 @@
+"""Regression tests for model server group (M17 #514, M18 #515, M19 #516, M20 #517).
+
+M17: dtype whitelist in JSON deserialization
+M18: Outbound response size check
+M19: PermissionError in PID check
+M20: flock-based rebuild lock
+"""
+
+import inspect
+import unittest
+
+
+class TestM17DtypeWhitelist(unittest.TestCase):
+    """M17: Only allowed dtypes should be accepted."""
+
+    def test_rejects_disallowed_dtype(self):
+        from truememory.model_server import _json_object_hook
+        import base64
+        obj = {
+            "__ndarray__": base64.b64encode(b"\x00" * 4).decode(),
+            "dtype": "object",
+            "shape": [1],
+        }
+        with self.assertRaises(ValueError):
+            _json_object_hook(obj)
+
+    def test_accepts_float32(self):
+        from truememory.model_server import _json_object_hook
+        import base64, struct
+        data = struct.pack("f", 1.0)
+        obj = {
+            "__ndarray__": base64.b64encode(data).decode(),
+            "dtype": "float32",
+            "shape": [1],
+        }
+        result = _json_object_hook(obj)
+        self.assertAlmostEqual(float(result[0]), 1.0)
+
+    def test_whitelist_exists(self):
+        from truememory.model_server import _ALLOWED_DTYPES
+        self.assertIn("float32", _ALLOWED_DTYPES)
+        self.assertNotIn("object", _ALLOWED_DTYPES)
+
+
+class TestM18OutboundSizeCheck(unittest.TestCase):
+    """M18: Response size should be checked."""
+
+    def test_send_response_has_size_check(self):
+        from truememory.model_server import ModelServer
+        source = inspect.getsource(ModelServer._send_response)
+        self.assertIn("_MAX_MESSAGE_SIZE", source,
+                       "_send_response should check against _MAX_MESSAGE_SIZE")
+
+
+class TestM19PermissionError(unittest.TestCase):
+    """M19: PID check should catch PermissionError."""
+
+    def test_pid_check_catches_permission_error(self):
+        from truememory.model_server import main
+        source = inspect.getsource(main)
+        self.assertIn("PermissionError", source,
+                       "main() PID check should catch PermissionError")
+
+
+class TestM20RebuildLock(unittest.TestCase):
+    """M20: Rebuild should use flock-based locking."""
+
+    def test_rebuild_uses_flock(self):
+        from truememory.tier_switch.manager import RebuildManager
+        source = inspect.getsource(RebuildManager.run_rebuild_sync)
+        self.assertIn("fcntl.flock", source,
+                       "run_rebuild_sync should use fcntl.flock")
+
+    def test_flock_imported(self):
+        import truememory.tier_switch.manager as mgr
+        source = inspect.getsource(mgr)
+        self.assertIn("import fcntl", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -75,11 +75,17 @@ def _json_default(obj):
     raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
+_ALLOWED_DTYPES = frozenset({"float32", "float64", "float16", "int32", "int64"})
+
+
 def _json_object_hook(obj):
     """Decode base64-encoded numpy arrays from JSON."""
     if "__ndarray__" in obj:
+        dtype_str = obj["dtype"]
+        if dtype_str not in _ALLOWED_DTYPES:
+            raise ValueError(f"Disallowed dtype: {dtype_str}")
         data = base64.b64decode(obj["__ndarray__"])
-        return np.frombuffer(data, dtype=np.dtype(obj["dtype"])).reshape(obj["shape"])
+        return np.frombuffer(data, dtype=np.dtype(dtype_str)).reshape(obj["shape"])
     return obj
 
 
@@ -305,6 +311,8 @@ class ModelServer:
 
     def _send_response(self, conn: socket.socket, response: dict):
         data = json.dumps(response, default=_json_default).encode("utf-8")
+        if len(data) > _MAX_MESSAGE_SIZE:
+            data = json.dumps({"ok": False, "error": "Response too large"}).encode("utf-8")
         header = struct.pack(_HEADER_FMT, len(data))
         conn.sendall(header + data)
 
@@ -405,7 +413,7 @@ def main():
             os.kill(old_pid, 0)
             log.error("Model server already running (pid=%d)", old_pid)
             sys.exit(1)
-        except (ProcessLookupError, ValueError):
+        except (ProcessLookupError, PermissionError, ValueError):
             PID_PATH.unlink(missing_ok=True)
             if SOCK_PATH.exists():
                 SOCK_PATH.unlink(missing_ok=True)

--- a/truememory/tier_switch/manager.py
+++ b/truememory/tier_switch/manager.py
@@ -5,6 +5,7 @@ execution, file-based locking, and status queries. Background threads
 create their own SQLite connections for thread safety.
 """
 
+import fcntl
 import json
 import logging
 import os
@@ -150,6 +151,29 @@ class RebuildManager:
         db_path: Path | None = None,
     ) -> bool:
         """Run a synchronous rebuild (CLI path). Returns True on success."""
+        _LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+        lock_fd = open(_LOCK_PATH, "w")
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            log.error("Another rebuild is already running (lock held)")
+            lock_fd.close()
+            return False
+        try:
+            return self._run_rebuild_sync_inner(
+                target_tier, force, progress_callback, db_path,
+            )
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            lock_fd.close()
+
+    def _run_rebuild_sync_inner(
+        self,
+        target_tier: str,
+        force: bool = False,
+        progress_callback=None,
+        db_path: Path | None = None,
+    ) -> bool:
         conn = _open_db(db_path)
         to_group = tier_group(target_tier)
 


### PR DESCRIPTION
## Summary
- **M17 #514**: Unvalidated dtype in JSON protocol — added `_ALLOWED_DTYPES` whitelist
- **M18 #515**: No outbound response size check — added `_MAX_MESSAGE_SIZE` check in `_send_response`
- **M19 #516**: PID check missing `PermissionError` — added to except clause
- **M20 #517**: Rebuild lock path defined but never used — added `fcntl.flock()` in `run_rebuild_sync`

Fixes #514, #515, #516, #517

## Test plan
- [x] 7 regression tests in `tests/test_issue_514_model_server.py`
- [x] dtype: rejects "object", accepts "float32", whitelist exists
- [x] Size check: _send_response references _MAX_MESSAGE_SIZE
- [x] PID: PermissionError in main() catch clause
- [x] Rebuild: fcntl.flock in run_rebuild_sync, fcntl imported