### PR TITLE
fix: NaN thread safety - flag after success, load sqlite-vec

### DIFF
--- a/tests/test_issue_485_nan_thread.py
+++ b/tests/test_issue_485_nan_thread.py
@@ -1,0 +1,218 @@
+"""Regression tests for issues #485 and #499: NaN background thread safety.
+
+Issue #485 — Background NaN Re-embed Drops Tables Mid-Search:
+    The qwen3_nan_fix_applied metadata flag is set BEFORE the background thread
+    starts.  If the thread fails, the flag is already committed, so NaN vectors
+    persist permanently with no way to retry.
+
+Issue #499 — Background Thread Doesn't Load sqlite-vec:
+    The background thread opens a new SQLite connection but never calls
+    sqlite_vec.load(), so build_vectors() / build_separation_vectors() fail
+    because the virtual-table module is missing.
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import pytest
+
+
+def _make_mock_model():
+    """Return a mock embedding model that produces valid 256-d vectors."""
+    mock = MagicMock()
+    def _encode(texts, **kw):
+        return np.array(
+            [np.random.rand(256).astype(np.float32)] * len(texts)
+        )
+    mock.encode = _encode
+    return mock
+
+
+def _seed_db(db_path: Path, n: int = 3) -> None:
+    """Seed *n* messages into a fresh TrueMemory database at *db_path*.
+
+    Uses the Memory client so schema, FTS, vec tables, and the metadata row
+    are all created normally.
+    """
+    from truememory.client import Memory
+
+    mock_model = _make_mock_model()
+    with patch("truememory.vector_search.get_model", return_value=mock_model):
+        m = Memory(path=str(db_path))
+        for i in range(n):
+            m.add(content=f"message {i}", user_id="alice")
+
+
+def _clear_nan_flag(db_path: Path) -> None:
+    """Remove the qwen3_nan_fix_applied flag so next init triggers migration."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("DELETE FROM metadata WHERE key = 'qwen3_nan_fix_applied'")
+    conn.commit()
+    conn.close()
+
+
+class TestIssue485NanFlagAfterCompletion:
+    """qwen3_nan_fix_applied must only be set AFTER successful re-embed."""
+
+    def test_issue_485_nan_flag_set_after_completion(self):
+        """Flag must not exist until the background thread finishes OK."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+
+            mock_model = _make_mock_model()
+            with patch("truememory.vector_search.get_model", return_value=mock_model):
+                _seed_db(db_path, n=2)
+
+            _clear_nan_flag(db_path)
+
+            # Use an event to control when build_vectors proceeds
+            proceed_event = threading.Event()
+            flag_before_build = []
+
+            from truememory import vector_search as _vs
+            _real_bv = _vs.build_vectors
+
+            def _checking_build(conn_arg, **kw):
+                """Check whether the flag exists before build_vectors runs."""
+                # Read the flag from a separate connection to avoid locking
+                check_conn = sqlite3.connect(str(db_path))
+                row = check_conn.execute(
+                    "SELECT value FROM metadata WHERE key = 'qwen3_nan_fix_applied'"
+                ).fetchone()
+                check_conn.close()
+                flag_before_build.append(row is not None)
+                proceed_event.set()
+                return _real_bv(conn_arg, **kw)
+
+            with patch("truememory.vector_search.get_model", return_value=mock_model):
+                with patch.object(_vs, "build_vectors", side_effect=_checking_build):
+                    from truememory.client import Memory
+                    m = Memory(path=str(db_path))
+                    # Trigger lazy _ensure_connection
+                    m.search(query="test", user_id="alice")
+
+                    # Wait for the background thread to reach build_vectors
+                    proceed_event.wait(timeout=5.0)
+                    # Give it a bit more to finish
+                    time.sleep(1.0)
+
+            assert len(flag_before_build) > 0, (
+                "build_vectors was never called — test setup is wrong"
+            )
+            assert not flag_before_build[0], (
+                "qwen3_nan_fix_applied flag was set BEFORE build_vectors — "
+                "if the thread crashes, the flag is stuck and NaN vectors "
+                "persist forever (issue #485)"
+            )
+
+
+class TestIssue485ThreadFailureAllowsRetry:
+    """A failed background thread must NOT set the flag, so next init retries."""
+
+    def test_issue_485_nan_thread_failure_allows_retry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+
+            mock_model = _make_mock_model()
+            with patch("truememory.vector_search.get_model", return_value=mock_model):
+                _seed_db(db_path, n=2)
+
+            _clear_nan_flag(db_path)
+
+            # Make build_vectors crash inside the thread
+            crash_event = threading.Event()
+            from truememory import vector_search as _vs
+
+            def _crashing_build(*a, **kw):
+                crash_event.set()
+                raise RuntimeError("simulated GPU OOM")
+
+            with patch("truememory.vector_search.get_model", return_value=mock_model):
+                with patch.object(_vs, "build_vectors", side_effect=_crashing_build):
+                    from truememory.client import Memory
+                    m = Memory(path=str(db_path))
+                    # Trigger lazy _ensure_connection
+                    m.search(query="test", user_id="alice")
+
+                    # Wait for the background thread to crash
+                    crash_event.wait(timeout=5.0)
+                    time.sleep(1.0)
+
+            # The flag must NOT be set after a failure
+            conn = sqlite3.connect(str(db_path))
+            row = conn.execute(
+                "SELECT value FROM metadata WHERE key = 'qwen3_nan_fix_applied'"
+            ).fetchone()
+            conn.close()
+
+            assert row is None, (
+                "qwen3_nan_fix_applied flag was set despite thread failure — "
+                "future inits will never retry, leaving NaN vectors "
+                "permanently (issue #485)"
+            )
+
+
+class TestIssue499NanThreadLoadsSqliteVec:
+    """Background thread must load sqlite-vec before calling build_vectors."""
+
+    def test_issue_499_nan_thread_loads_sqlite_vec(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+
+            mock_model = _make_mock_model()
+            with patch("truememory.vector_search.get_model", return_value=mock_model):
+                _seed_db(db_path, n=2)
+
+            _clear_nan_flag(db_path)
+
+            # Track whether sqlite_vec.load is called inside the thread
+            vec_load_calls = []
+            done_event = threading.Event()
+
+            try:
+                import sqlite_vec as _real_sv
+                original_load = _real_sv.load
+            except ImportError:
+                pytest.skip("sqlite_vec not installed")
+
+            def _tracking_load(conn_arg):
+                vec_load_calls.append(threading.current_thread().name)
+                return original_load(conn_arg)
+
+            from truememory import vector_search as _vs
+            _real_bv = _vs.build_vectors
+
+            def _signaling_build(conn_arg, **kw):
+                result = _real_bv(conn_arg, **kw)
+                done_event.set()
+                return result
+
+            with patch("truememory.vector_search.get_model", return_value=mock_model):
+                with patch("sqlite_vec.load", side_effect=_tracking_load):
+                    with patch.object(_vs, "build_vectors", side_effect=_signaling_build):
+                        from truememory.client import Memory
+                        m = Memory(path=str(db_path))
+                        # Trigger lazy _ensure_connection
+                        m.search(query="test", user_id="alice")
+
+                        # Give background thread time to complete
+                        done_event.wait(timeout=5.0)
+                        time.sleep(0.5)
+
+            # sqlite_vec.load must have been called from a non-main thread
+            # (i.e., the background migration thread loaded the extension)
+            bg_calls = [
+                name for name in vec_load_calls
+                if name != threading.main_thread().name
+            ]
+            assert len(bg_calls) > 0, (
+                "sqlite_vec.load was never called from the background thread — "
+                "build_vectors() will fail because vec virtual tables "
+                "are not available (issue #499)"
+            )

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -359,6 +359,9 @@ class TrueMemoryEngine:
         self._has_clustering = _HAS_CLUSTERING
         self._has_style_vec = _HAS_STYLE_VEC
 
+        # Coordination flag for background NaN re-embed thread (#485).
+        self._nan_migration_in_progress = False
+
     # ──────────────────────────────────────────────────────────────────────
     # Auto-connect (production API)
     # ──────────────────────────────────────────────────────────────────────
@@ -424,12 +427,6 @@ class TrueMemoryEngine:
                                 _msg_count = self.conn.execute(
                                     "SELECT COUNT(*) FROM messages"
                                 ).fetchone()[0] if "messages" in _tables else 0
-                                self.conn.execute(
-                                    "INSERT OR REPLACE INTO metadata (key, value) "
-                                    "VALUES (?, ?)",
-                                    ("qwen3_nan_fix_applied", "1"),
-                                )
-                                self.conn.commit()
                                 if _msg_count > 0:
                                     def _bg_reembed(db_path):
                                         import sqlite3 as _sql
@@ -437,6 +434,13 @@ class TrueMemoryEngine:
                                             _conn = _sql.connect(str(db_path), check_same_thread=False)
                                             _conn.execute("PRAGMA journal_mode=WAL")
                                             _conn.execute("PRAGMA busy_timeout=30000")
+                                            # Issue #499: load sqlite-vec on the
+                                            # background thread's connection so
+                                            # vec virtual tables are available.
+                                            import sqlite_vec as _sv
+                                            _conn.enable_load_extension(True)
+                                            _sv.load(_conn)
+                                            _conn.enable_load_extension(False)
                                             from truememory.vector_search import (
                                                 build_vectors as _bv,
                                                 build_separation_vectors as _bsv,
@@ -448,6 +452,15 @@ class TrueMemoryEngine:
                                             _ivt(_conn)
                                             _bv(_conn)
                                             _bsv(_conn)
+                                            # Issue #485: only set the flag AFTER
+                                            # successful re-embed so a failed
+                                            # thread allows retry on next init.
+                                            _conn.execute(
+                                                "INSERT OR REPLACE INTO metadata "
+                                                "(key, value) VALUES (?, ?)",
+                                                ("qwen3_nan_fix_applied", "1"),
+                                            )
+                                            _conn.commit()
                                             _conn.close()
                                             logger.warning(
                                                 "Qwen3 NaN fix: re-embedded %d vectors "
@@ -455,13 +468,20 @@ class TrueMemoryEngine:
                                             )
                                         except Exception:
                                             logger.warning(
-                                                "Qwen3 NaN background migration failed",
+                                                "Qwen3 NaN background migration failed — "
+                                                "will retry on next startup",
                                                 exc_info=True,
                                             )
                                     _db = self.db_path
                                     if str(_db) != ":memory:":
+                                        self._nan_migration_in_progress = True
+                                        def _bg_wrapper(db_path):
+                                            try:
+                                                _bg_reembed(db_path)
+                                            finally:
+                                                self._nan_migration_in_progress = False
                                         _t = threading.Thread(
-                                            target=_bg_reembed, args=(_db,),
+                                            target=_bg_wrapper, args=(_db,),
                                             daemon=True,
                                         )
                                         _t.start()
@@ -481,9 +501,24 @@ class TrueMemoryEngine:
                                         _ivt(self.conn)
                                         _bv(self.conn)
                                         _bsv(self.conn)
+                                        self.conn.execute(
+                                            "INSERT OR REPLACE INTO metadata "
+                                            "(key, value) VALUES (?, ?)",
+                                            ("qwen3_nan_fix_applied", "1"),
+                                        )
+                                        self.conn.commit()
                                         logger.warning(
                                             "Qwen3 NaN fix: re-embedded all vectors",
                                         )
+                                else:
+                                    # No messages — just set the flag to skip
+                                    # future checks.
+                                    self.conn.execute(
+                                        "INSERT OR REPLACE INTO metadata "
+                                        "(key, value) VALUES (?, ?)",
+                                        ("qwen3_nan_fix_applied", "1"),
+                                    )
+                                    self.conn.commit()
                 except Exception:
                     logger.warning(
                         "Qwen3 NaN migration failed — run "


### PR DESCRIPTION
## Summary

- **#485**: The `qwen3_nan_fix_applied` metadata flag was set BEFORE the background re-embed thread started. If the thread failed (OOM, crash, etc.), the flag was already committed, so NaN vectors persisted permanently with no way to retry on next startup. Now the flag is set INSIDE the thread, AFTER successful completion.
- **#499**: The background thread opened a new SQLite connection but never loaded the sqlite-vec extension explicitly. Added `sqlite_vec.load()` at the top of the thread before any vec table operations.
- Added `_nan_migration_in_progress` coordination flag for future use by search to detect in-progress migrations.
- For empty databases (0 messages), the flag is set immediately without spawning a thread.

Fixes #485
Fixes #499

## Test plan

- [x] `test_issue_485_nan_flag_set_after_completion` -- verifies flag is NOT set before `build_vectors` runs
- [x] `test_issue_485_nan_thread_failure_allows_retry` -- verifies failed thread does not set flag, allowing retry
- [x] `test_issue_499_nan_thread_loads_sqlite_vec` -- verifies `sqlite_vec.load()` is called from the background thread
- [x] All 3 tests confirmed to FAIL on unfixed code, PASS on fixed code
- [x] Existing `test_issue_465_qwen3_nan_async` tests still pass
- [x] Full test suite: 114 passed, 1 skipped, 1 pre-existing failure (unrelated `test_spawn_cap_blocks_when_at_cap`)