### PR TITLE
fix: add missing tables to base schema DDL

### DIFF
--- a/tests/test_issue_510_schema.py
+++ b/tests/test_issue_510_schema.py
@@ -1,0 +1,43 @@
+"""Regression tests for M13 #510 and M22 #519: schema consolidation.
+
+M13: surprise_scores table not in base schema (storage.py)
+M22: Schema fragmented across 4+ files — tables should be in storage.py DDL
+"""
+
+import unittest
+
+
+class TestSchemaConsolidation(unittest.TestCase):
+
+    def test_surprise_scores_in_base_schema(self):
+        from truememory import storage
+        self.assertIn("surprise_scores", storage._SCHEMA_SQL,
+                       "surprise_scores DDL should be in storage.py _SCHEMA")
+
+    def test_message_clusters_in_base_schema(self):
+        from truememory import storage
+        self.assertIn("message_clusters", storage._SCHEMA_SQL,
+                       "message_clusters DDL should be in storage.py _SCHEMA")
+
+    def test_cluster_centroids_in_base_schema(self):
+        from truememory import storage
+        self.assertIn("cluster_centroids", storage._SCHEMA_SQL,
+                       "cluster_centroids DDL should be in storage.py _SCHEMA")
+
+    def test_tables_created_on_create_db(self):
+        from truememory.storage import create_db
+        import sqlite3
+        conn = create_db(":memory:")
+        tables = {
+            row[0] for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        for expected in ("surprise_scores", "message_clusters", "cluster_centroids"):
+            self.assertIn(expected, tables,
+                          f"{expected} should be created by create_db()")
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -162,7 +162,32 @@ CREATE TABLE IF NOT EXISTS metadata (
     updated_at TEXT
 );
 
+-- Surprise scores for L5 predictive layer (MEMORIST)
+CREATE TABLE IF NOT EXISTS surprise_scores (
+    message_id INTEGER PRIMARY KEY,
+    surprise    REAL NOT NULL DEFAULT 0.0,
+    fact_count  INTEGER NOT NULL DEFAULT 0,
+    new_fact_count INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (message_id) REFERENCES messages(id)
+);
+
+-- Clustering (HDBSCAN episode clusters)
+CREATE TABLE IF NOT EXISTS message_clusters (
+    message_id   INTEGER PRIMARY KEY REFERENCES messages(id),
+    cluster_id   INTEGER NOT NULL,
+    noise        INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS cluster_centroids (
+    cluster_id   INTEGER PRIMARY KEY,
+    centroid     BLOB NOT NULL,
+    message_count INTEGER DEFAULT 0,
+    session_range TEXT DEFAULT '',
+    summary      TEXT DEFAULT ''
+);
+
 CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender);
+CREATE INDEX IF NOT EXISTS idx_cluster_id ON message_clusters(cluster_id);
 CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages(timestamp);
 CREATE INDEX IF NOT EXISTS idx_messages_episode_id ON messages(episode_id);
 CREATE INDEX IF NOT EXISTS idx_messages_category ON messages(category);


### PR DESCRIPTION
## Summary
- **M13 #510**: `surprise_scores` only created by `build_surprise_index()`, not in base DDL
- **M22 #519**: `message_clusters` and `cluster_centroids` only in `clustering.py`
- All 3 tables now in `storage._SCHEMA_SQL` — created automatically by `create_db()`

Fixes #510, #519

## Test plan
- [x] 4 regression tests in `tests/test_issue_510_schema.py`
- [x] All 3 tables present in `_SCHEMA_SQL` string
- [x] All 3 tables created by `create_db(":memory:")`