### PR TITLE
fix: add auto-consolidation trigger after N adds

### DIFF
--- a/tests/test_issue_498_auto_consolidate.py
+++ b/tests/test_issue_498_auto_consolidate.py
@@ -1,0 +1,37 @@
+"""Regression test for M1 #498: auto-consolidation trigger.
+
+Consolidation should run automatically after a configurable number of
+add() calls, not require manual truememory_consolidate invocation.
+"""
+
+import inspect
+import unittest
+
+
+class TestAutoConsolidation(unittest.TestCase):
+
+    def test_auto_consolidate_threshold_exists(self):
+        from truememory.engine import TrueMemoryEngine
+        source = inspect.getsource(TrueMemoryEngine.__init__)
+        self.assertIn("_auto_consolidate_threshold", source)
+        self.assertIn("TRUEMEMORY_AUTO_CONSOLIDATE_EVERY", source)
+
+    def test_add_calls_maybe_auto_consolidate(self):
+        from truememory.engine import TrueMemoryEngine
+        source = inspect.getsource(TrueMemoryEngine.add)
+        self.assertIn("_maybe_auto_consolidate", source,
+                       "add() should call _maybe_auto_consolidate()")
+
+    def test_maybe_auto_consolidate_checks_threshold(self):
+        from truememory.engine import TrueMemoryEngine
+        source = inspect.getsource(TrueMemoryEngine._maybe_auto_consolidate)
+        self.assertIn("_auto_consolidate_threshold", source)
+        self.assertIn("_has_consolidation", source)
+
+    def test_bg_consolidate_exists(self):
+        from truememory.engine import TrueMemoryEngine
+        self.assertTrue(hasattr(TrueMemoryEngine, "_bg_consolidate"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -362,6 +362,13 @@ class TrueMemoryEngine:
         # Coordination flag for background NaN re-embed thread (#485).
         self._nan_migration_in_progress = False
 
+        # Auto-consolidation: run L5 consolidation every N adds (#498)
+        self._adds_since_consolidation = 0
+        self._auto_consolidate_threshold = int(
+            os.environ.get("TRUEMEMORY_AUTO_CONSOLIDATE_EVERY", "100")
+        )
+        self._consolidation_thread: threading.Thread | None = None
+
     # ──────────────────────────────────────────────────────────────────────
     # Auto-connect (production API)
     # ──────────────────────────────────────────────────────────────────────
@@ -633,6 +640,8 @@ class TrueMemoryEngine:
 
             self.conn.commit()
 
+        self._maybe_auto_consolidate()
+
         return {
             "id": new_id,
             "content": content,
@@ -641,6 +650,31 @@ class TrueMemoryEngine:
             "timestamp": timestamp,
             "category": category,
         }
+
+    def _maybe_auto_consolidate(self) -> None:
+        """Trigger background consolidation after threshold adds."""
+        self._adds_since_consolidation += 1
+        if self._adds_since_consolidation < self._auto_consolidate_threshold:
+            return
+        if not self._has_consolidation:
+            return
+        if (self._consolidation_thread is not None
+                and self._consolidation_thread.is_alive()):
+            return
+        self._adds_since_consolidation = 0
+        self._consolidation_thread = threading.Thread(
+            target=self._bg_consolidate,
+            daemon=True,
+            name="auto-consolidate",
+        )
+        self._consolidation_thread.start()
+
+    def _bg_consolidate(self) -> None:
+        """Run consolidation in a background thread with its own connection."""
+        try:
+            self.consolidate()
+        except Exception:
+            logger.debug("Auto-consolidation failed", exc_info=True)
 
     def delete(self, memory_id: int) -> bool:
         """Delete a memory by ID.


### PR DESCRIPTION
## Summary
- **M1 #498**: Consolidation is manual-only — no automatic trigger
- Added `_maybe_auto_consolidate()` called after every `add()`
- Background thread runs `consolidate()` every 100 adds (configurable via `TRUEMEMORY_AUTO_CONSOLIDATE_EVERY`)
- Skips if consolidation unavailable or previous run still active

Fixes #498

## Test plan
- [x] 4 regression tests in `tests/test_issue_498_auto_consolidate.py`
- [x] Threshold config exists with env var
- [x] add() calls _maybe_auto_consolidate
- [x] Threshold and capability checks in trigger method