### PR TITLE
fix: enable PRAGMA foreign_keys=ON on all SQLite connections (#491)

### DIFF
--- a/tests/test_issue_491_foreign_keys.py
+++ b/tests/test_issue_491_foreign_keys.py
@@ -1,0 +1,90 @@
+"""Issue #491: PRAGMA foreign_keys is never enabled.
+
+The schema defines FK constraints (fact_timeline, landmark_events, causal_edges)
+but SQLite requires ``PRAGMA foreign_keys = ON`` per connection for enforcement.
+Without it, FK constraints are decorative.
+
+This test verifies that every connection-creation path enables foreign keys.
+"""
+
+import sqlite3
+
+import pytest
+
+
+class TestIssue491ForeignKeys:
+    """Verify PRAGMA foreign_keys = ON on all connection paths."""
+
+    def test_create_db_enables_foreign_keys(self, tmp_path):
+        """create_db() must return a connection with foreign_keys = 1."""
+        from truememory.storage import create_db
+
+        conn = create_db(tmp_path / "fk_test.db")
+        result = conn.execute("PRAGMA foreign_keys").fetchone()
+        assert result is not None
+        assert result[0] == 1, (
+            f"PRAGMA foreign_keys should be 1 (ON) after create_db(), got {result[0]}"
+        )
+        conn.close()
+
+    def test_create_db_memory_enables_foreign_keys(self):
+        """create_db(':memory:') must also enable foreign keys."""
+        from truememory.storage import create_db
+
+        conn = create_db(":memory:")
+        result = conn.execute("PRAGMA foreign_keys").fetchone()
+        assert result is not None
+        assert result[0] == 1
+        conn.close()
+
+    def test_foreign_keys_enforced_on_insert(self, tmp_path):
+        """Inserting a fact_timeline row with a bad source_message_id must fail."""
+        from truememory.storage import create_db
+
+        conn = create_db(tmp_path / "fk_enforce.db")
+
+        # Confirm foreign_keys is on
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
+        # Insert into fact_timeline with a source_message_id that doesn't
+        # exist in messages — this must raise IntegrityError.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO fact_timeline (subject, fact, source_message_id, timestamp) "
+                "VALUES (?, ?, ?, ?)",
+                ("test_subject", "test_fact", 99999, "2026-01-01"),
+            )
+
+        conn.close()
+
+    def test_engine_ensure_connection_enables_foreign_keys(self, tmp_path):
+        """TrueMemoryEngine._ensure_connection() must enable foreign keys."""
+        from truememory.engine import TrueMemoryEngine
+
+        engine = TrueMemoryEngine(db_path=tmp_path / "engine_fk.db")
+        engine._ensure_connection()
+        result = engine.conn.execute("PRAGMA foreign_keys").fetchone()
+        assert result is not None
+        assert result[0] == 1, (
+            f"PRAGMA foreign_keys should be 1 after _ensure_connection(), got {result[0]}"
+        )
+
+    def test_wal_mode_preserved(self, tmp_path):
+        """FK pragma must not break WAL mode."""
+        from truememory.storage import create_db
+
+        conn = create_db(tmp_path / "wal_fk.db")
+        journal = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert journal.lower() == "wal", f"Expected WAL mode, got {journal}"
+        conn.close()
+
+    def test_busy_timeout_preserved(self, tmp_path):
+        """FK pragma must not break busy_timeout."""
+        from truememory.storage import create_db, DEFAULT_BUSY_TIMEOUT_MS
+
+        conn = create_db(tmp_path / "timeout_fk.db")
+        timeout = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        assert timeout == DEFAULT_BUSY_TIMEOUT_MS, (
+            f"Expected busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}, got {timeout}"
+        )
+        conn.close()

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -441,6 +441,7 @@ class TrueMemoryEngine:
                                             _conn = _sql.connect(str(db_path), check_same_thread=False)
                                             _conn.execute("PRAGMA journal_mode=WAL")
                                             _conn.execute("PRAGMA busy_timeout=30000")
+                                            _conn.execute("PRAGMA foreign_keys=ON")
                                             # Issue #499: load sqlite-vec on the
                                             # background thread's connection so
                                             # vec virtual tables are available.
@@ -1100,6 +1101,7 @@ class TrueMemoryEngine:
         self.conn.row_factory = None  # Use default tuple rows
         self.conn.execute("PRAGMA journal_mode=WAL")
         self.conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
+        self.conn.execute("PRAGMA foreign_keys=ON")
         self.conn.execute("PRAGMA synchronous=NORMAL")
         self.conn.execute("PRAGMA cache_size=-64000")
         self.conn.execute("PRAGMA mmap_size=268435456")

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -348,6 +348,7 @@ def create_db(db_path: str | Path) -> sqlite3.Connection:
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
+    conn.execute("PRAGMA foreign_keys=ON")
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA cache_size=-64000")
     conn.execute("PRAGMA mmap_size=268435456")

--- a/truememory/tier_switch/manager.py
+++ b/truememory/tier_switch/manager.py
@@ -58,6 +58,7 @@ def _open_db(db_path: Path | None = None) -> sqlite3.Connection:
     conn = sqlite3.connect(str(path), check_same_thread=False)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
+    conn.execute("PRAGMA foreign_keys=ON")
     conn.execute("PRAGMA synchronous=NORMAL")
 
     import sqlite_vec


### PR DESCRIPTION
## Summary
- Schema defines FK constraints on `fact_timeline`, `landmark_events`, `causal_edges`, `surprise_scores`, and `message_clusters` but SQLite requires `PRAGMA foreign_keys = ON` per connection for enforcement. Without it, FK constraints were decorative.
- Added `PRAGMA foreign_keys=ON` to all four connection-creation sites: `storage.create_db()`, `engine.open()`, `engine._bg_reembed()`, and `tier_switch.manager._open_db()`.
- Placed after `busy_timeout`, before `synchronous` -- does not affect WAL mode or busy_timeout settings.

## Test plan
- [x] `test_create_db_enables_foreign_keys` -- verifies `PRAGMA foreign_keys` returns 1 after `create_db()`
- [x] `test_create_db_memory_enables_foreign_keys` -- same for `:memory:` databases
- [x] `test_foreign_keys_enforced_on_insert` -- verifies `IntegrityError` on FK violation (bad `source_message_id`)
- [x] `test_engine_ensure_connection_enables_foreign_keys` -- verifies via `TrueMemoryEngine._ensure_connection()`
- [x] `test_wal_mode_preserved` -- confirms WAL mode not broken by FK pragma
- [x] `test_busy_timeout_preserved` -- confirms busy_timeout not broken by FK pragma
- [x] All existing `test_storage.py` tests pass (26/26)

Closes #491