### PR TITLE
fix: config cache, atomic write, write lock, HyDE tier check

### DIFF
--- a/tests/test_issue_502_config.py
+++ b/tests/test_issue_502_config.py
@@ -1,0 +1,296 @@
+"""Regression tests for config-group issues #502–#505.
+
+#502 (M5): _load_config() reads disk on every search — 2x JSON parse per query.
+           Cache the config in memory with a timestamp; only re-read after staleness.
+
+#503 (M6): Config write is not atomic — a crash during write can corrupt config.json.
+           Use atomic write pattern: write to temp file, then os.replace().
+
+#504 (M7): Config write race between MCP and tier switch.
+           Use fcntl.flock() or threading.Lock around config writes.
+
+#505 (M8): truememory_configure reports ``hyde_search: enabled`` regardless of tier.
+           Should check whether the tier actually supports HyDE (Pro only).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+
+@pytest.fixture
+def server(monkeypatch, tmp_path):
+    """Provide an isolated mcp_server module with a fresh temp config dir."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    db_path = tmp_path / "memories.db"
+    monkeypatch.setenv("TRUEMEMORY_DB", str(db_path))
+    monkeypatch.setenv("TRUEMEMORY_EMBED_MODEL", "edge")
+    import truememory.mcp_server as ms
+
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    monkeypatch.setattr(ms, "_DB_PATH", str(db_path))
+    monkeypatch.setattr(ms, "_memory", None)
+    # Reset config cache so each test starts clean
+    ms._config_cache = None
+    ms._config_cache_mtime = 0.0
+    ms._config_cache_time = 0.0
+    yield ms
+    if ms._memory is not None:
+        try:
+            ms._memory.close()
+        except Exception:
+            pass
+    ms._memory = None
+    import truememory.vector_search as vs
+
+    vs.set_embedding_model("edge")
+
+
+def _no_op_model(server, monkeypatch):
+    """Stub out model/reranker side effects so the test stays unit-level."""
+    import truememory.vector_search as vs
+    import truememory.reranker as rr
+
+    monkeypatch.setattr(vs, "set_embedding_model", lambda tier: None)
+    monkeypatch.setattr(rr, "set_active_tier", lambda tier: None)
+    monkeypatch.setattr(server, "_set_reranker", lambda name: None)
+
+
+# -----------------------------------------------------------------------
+# M5 (#502) — Config caching
+# -----------------------------------------------------------------------
+
+
+class TestIssue502ConfigCache:
+    """_load_config() should cache in memory and not re-read disk every call."""
+
+    def test_load_config_returns_cached_copy(self, server, monkeypatch):
+        """Two rapid _load_config() calls should return the same data without
+        re-reading from disk the second time when mtime hasn't changed."""
+        cfg = {"tier": "base", "anthropic_api_key": "sk-test-12345"}
+        server._CONFIG_PATH.write_text(json.dumps(cfg), encoding="utf-8")
+        # Reset cache
+        server._config_cache = None
+        server._config_cache_mtime = 0.0
+        server._config_cache_time = 0.0
+
+        result1 = server._load_config()
+
+        # Second call within staleness window, file NOT modified on disk
+        # (mtime unchanged) — should use cache, no disk read
+        read_count = 0
+        original_read_text = type(server._CONFIG_PATH).read_text
+
+        def counting_read(self_path, *args, **kwargs):
+            nonlocal read_count
+            read_count += 1
+            return original_read_text(self_path, *args, **kwargs)
+
+        monkeypatch.setattr(type(server._CONFIG_PATH), "read_text", counting_read)
+
+        result2 = server._load_config()
+        assert result1 == result2, (
+            "_load_config() did not return cached result within staleness window"
+        )
+        assert read_count == 0, (
+            f"_load_config() re-read disk {read_count} times within staleness window"
+        )
+        assert result1["tier"] == "base"
+
+    def test_load_config_refreshes_after_staleness(self, server, monkeypatch):
+        """After the staleness window, _load_config() should re-read disk."""
+        cfg = {"tier": "base"}
+        server._CONFIG_PATH.write_text(json.dumps(cfg), encoding="utf-8")
+        server._config_cache = None
+        server._config_cache_mtime = 0.0
+        server._config_cache_time = 0.0
+
+        result1 = server._load_config()
+        assert result1["tier"] == "base"
+
+        # Write a new config
+        server._CONFIG_PATH.write_text(
+            json.dumps({"tier": "pro"}), encoding="utf-8"
+        )
+        # Force staleness by backdating the cache time
+        server._config_cache_time = time.monotonic() - 10.0
+        server._config_cache_mtime = 0.0  # force mtime mismatch
+
+        result2 = server._load_config()
+        assert result2["tier"] == "pro", (
+            "_load_config() did not refresh after staleness window expired"
+        )
+
+
+# -----------------------------------------------------------------------
+# M6 (#503) — Atomic config write
+# -----------------------------------------------------------------------
+
+
+class TestIssue503AtomicWrite:
+    """_save_config() must use atomic write (temp file + os.replace)."""
+
+    def test_save_config_is_atomic(self, server, monkeypatch):
+        """After _save_config(), the file should contain valid JSON even if
+        we simulate observing it mid-write. We verify by checking that
+        os.replace (or os.rename) is used instead of direct write."""
+        calls = []
+        original_replace = os.replace
+
+        def tracking_replace(src, dst):
+            calls.append((src, dst))
+            return original_replace(src, dst)
+
+        monkeypatch.setattr(os, "replace", tracking_replace)
+
+        server._save_config({"tier": "base"})
+        assert len(calls) >= 1, (
+            "_save_config() did not use os.replace() for atomic write"
+        )
+        # The destination should be the config path
+        assert str(calls[0][1]) == str(server._CONFIG_PATH)
+
+    def test_save_config_produces_valid_json(self, server):
+        """After _save_config(), the file must contain valid JSON."""
+        server._save_config({"tier": "pro", "anthropic_api_key": "sk-test"})
+        data = json.loads(server._CONFIG_PATH.read_text(encoding="utf-8"))
+        assert data["tier"] == "pro"
+        assert data["anthropic_api_key"] == "sk-test"
+
+    def test_save_config_no_partial_write_on_crash(self, server, monkeypatch):
+        """If the write to temp file fails, the original config should survive."""
+        # Write initial config
+        server._save_config({"tier": "base"})
+
+        # Make json.dump raise an error to simulate a crash during write.
+        # _save_config uses os.fdopen + json.dump, so we intercept json.dump.
+        original_json_dump = json.dump
+        call_count = 0
+
+        def failing_dump(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 0:
+                raise OSError("Simulated disk full")
+            return original_json_dump(*args, **kwargs)
+
+        monkeypatch.setattr(json, "dump", failing_dump)
+
+        with pytest.raises(OSError, match="Simulated disk full"):
+            server._save_config({"tier": "pro", "corrupt": True})
+
+        # Restore json.dump so we can read the file
+        monkeypatch.setattr(json, "dump", original_json_dump)
+
+        # Original config should still be intact
+        data = json.loads(server._CONFIG_PATH.read_text(encoding="utf-8"))
+        assert data["tier"] == "base"
+        assert "corrupt" not in data
+
+
+# -----------------------------------------------------------------------
+# M7 (#504) — Config write lock
+# -----------------------------------------------------------------------
+
+
+class TestIssue504WriteLock:
+    """Concurrent _save_config() calls must be serialized with a lock."""
+
+    def test_concurrent_saves_are_serialized(self, server, monkeypatch):
+        """Two threads calling _save_config() simultaneously must not
+        interleave their writes — the final file must contain one complete
+        config, not a mix."""
+        results = []
+        barrier = threading.Barrier(2)
+
+        def writer(tier_name, idx):
+            barrier.wait()
+            server._save_config({"tier": tier_name, "writer": idx})
+            results.append(idx)
+
+        t1 = threading.Thread(target=writer, args=("base", 1))
+        t2 = threading.Thread(target=writer, args=("pro", 2))
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        # File must be valid JSON (no interleaved writes)
+        data = json.loads(server._CONFIG_PATH.read_text(encoding="utf-8"))
+        assert data["tier"] in ("base", "pro"), (
+            f"Config file is corrupt after concurrent writes: {data}"
+        )
+        # Both writers must have completed
+        assert len(results) == 2
+
+    def test_save_config_lock_attribute_exists(self, server):
+        """The module should have a config write lock."""
+        assert hasattr(server, "_config_write_lock"), (
+            "_config_write_lock not found — M7 lock not implemented"
+        )
+
+
+# -----------------------------------------------------------------------
+# M8 (#505) — HyDE status should reflect tier, not just key presence
+# -----------------------------------------------------------------------
+
+
+class TestIssue505HydeTierCheck:
+    """truememory_configure must only report hyde_search=enabled for Pro tier."""
+
+    def test_hyde_disabled_for_edge_with_key(self, server, monkeypatch):
+        """Edge tier should report hyde_search as disabled even when an API key
+        is present, because Edge does not support HyDE."""
+        _no_op_model(server, monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key-12345")
+
+        result = json.loads(server.truememory_configure(tier="edge"))
+        assert result["status"] == "configured"
+        assert "enabled" not in result["hyde_search"], (
+            f"Edge tier should not report hyde_search=enabled: {result['hyde_search']}"
+        )
+
+    def test_hyde_disabled_for_base_with_key(self, server, monkeypatch):
+        """Base tier should report hyde_search as disabled even when an API key
+        is present, because Base does not support HyDE."""
+        _no_op_model(server, monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key-12345")
+
+        result = json.loads(server.truememory_configure(tier="base"))
+        assert result["status"] == "configured"
+        assert "enabled" not in result["hyde_search"], (
+            f"Base tier should not report hyde_search=enabled: {result['hyde_search']}"
+        )
+
+    def test_hyde_enabled_for_pro_with_key(self, server, monkeypatch):
+        """Pro tier with an API key should report hyde_search=enabled."""
+        _no_op_model(server, monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key-12345")
+
+        result = json.loads(server.truememory_configure(tier="pro"))
+        assert result["status"] == "configured"
+        assert result["hyde_search"] == "enabled", (
+            f"Pro tier with API key should report hyde_search=enabled: {result['hyde_search']}"
+        )
+
+    def test_hyde_disabled_for_pro_without_key(self, server, monkeypatch):
+        """Pro tier without an API key should report hyde_search as disabled."""
+        _no_op_model(server, monkeypatch)
+        # Ensure no API keys in env
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        result = json.loads(server.truememory_configure(tier="pro"))
+        assert result["status"] == "configured"
+        assert "enabled" not in result["hyde_search"], (
+            f"Pro tier without API key should not report hyde_search=enabled: {result['hyde_search']}"
+        )

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -49,19 +49,56 @@ log = logging.getLogger(__name__)
 _TRUEMEMORY_DIR = Path.home() / ".truememory"
 _CONFIG_PATH = _TRUEMEMORY_DIR / "config.json"
 
+# M5 (#502) — Config cache: avoid re-reading disk on every _load_config() call.
+# The cache is invalidated after _CONFIG_CACHE_TTL seconds OR when the file's
+# mtime changes (whichever comes first).
+_CONFIG_CACHE_TTL = 5.0  # seconds
+_config_cache: dict | None = None
+_config_cache_mtime: float = 0.0
+_config_cache_time: float = 0.0
+
+# M7 (#504) — Serialize config writes from concurrent MCP handlers / tier-switch.
+_config_write_lock = threading.Lock()
+
 
 def _load_config() -> dict:
     """Load persistent config from ~/.truememory/config.json.
+
+    Uses an in-memory cache with a staleness window (_CONFIG_CACHE_TTL) to
+    avoid redundant disk reads (M5 / #502). The cache is also invalidated
+    when the file's mtime changes.
 
     On JSON corruption, rename the file to ``config.json.corrupt.<unix-ts>``
     so the user can recover any API keys that were in it. On OSError, warn
     to stderr. Returns ``{}`` in both failure modes so callers never see a
     half-loaded config.
     """
+    global _config_cache, _config_cache_mtime, _config_cache_time
+
+    now = time.monotonic()
+    if _config_cache is not None and (now - _config_cache_time) < _CONFIG_CACHE_TTL:
+        # Fast path: cache is fresh — but verify mtime hasn't changed
+        try:
+            current_mtime = _CONFIG_PATH.stat().st_mtime if _CONFIG_PATH.exists() else 0.0
+        except OSError:
+            current_mtime = 0.0
+        if current_mtime == _config_cache_mtime:
+            return _config_cache.copy()
+
     if not _CONFIG_PATH.exists():
+        _config_cache = {}
+        _config_cache_mtime = 0.0
+        _config_cache_time = now
         return {}
     try:
-        return json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        result = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        try:
+            _config_cache_mtime = _CONFIG_PATH.stat().st_mtime
+        except OSError:
+            _config_cache_mtime = 0.0
+        _config_cache = result
+        _config_cache_time = now
+        return result.copy()
     except json.JSONDecodeError as e:
         # .with_suffix would replace ".json"; we want to APPEND to preserve
         # the origin filename in the backup so users can find it easily.
@@ -81,17 +118,29 @@ def _load_config() -> dict:
                 "backed up. Run `truememory-mcp --setup` to recreate.",
                 file=sys.stderr,
             )
+        _config_cache = {}
+        _config_cache_mtime = 0.0
+        _config_cache_time = now
         return {}
     except OSError as e:
         print(
             f"truememory: could not read config.json: {e}",
             file=sys.stderr,
         )
+        _config_cache = {}
+        _config_cache_mtime = 0.0
+        _config_cache_time = now
         return {}
 
 
 def _save_config(config: dict) -> None:
     """Save config to ~/.truememory/config.json.
+
+    Uses atomic write (M6 / #503): writes to a temp file in the same
+    directory, then calls os.replace() to atomically swap. This prevents
+    config corruption if the process crashes mid-write.
+
+    Serializes concurrent writes via _config_write_lock (M7 / #504).
 
     the POSIX `chmod` calls below are silent no-ops on Windows;
     the config file (which stores API keys in plaintext) inherits the
@@ -99,10 +148,39 @@ def _save_config(config: dict) -> None:
     storing a key on Windows we warn to stderr and suggest the env-var
     route, which is the actually-private channel.
     """
-    _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
-    _TRUEMEMORY_DIR.chmod(0o700)
-    _CONFIG_PATH.write_text(json.dumps(config, indent=2), encoding="utf-8")
-    _CONFIG_PATH.chmod(0o600)
+    global _config_cache, _config_cache_mtime, _config_cache_time
+    import tempfile
+
+    with _config_write_lock:
+        _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
+        _TRUEMEMORY_DIR.chmod(0o700)
+
+        # Atomic write: temp file + os.replace() (M6 / #503)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".config.tmp.", suffix=".json",
+            dir=str(_TRUEMEMORY_DIR),
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(config, f, indent=2)
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, str(_CONFIG_PATH))
+        except BaseException:
+            # Clean up the temp file on failure — original config survives
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+        # Invalidate cache so the next _load_config() picks up the new data
+        try:
+            _config_cache_mtime = _CONFIG_PATH.stat().st_mtime
+        except OSError:
+            _config_cache_mtime = 0.0
+        _config_cache = config.copy()
+        _config_cache_time = time.monotonic()
+
     if sys.platform == "win32" and any(k.endswith("_api_key") for k in config):
         print(
             "truememory: warning — on Windows, ~/.truememory/config.json "
@@ -931,7 +1009,8 @@ def truememory_configure(
     if api_key:
         result["api_key_saved"] = f"{api_provider} key stored"
 
-    # Check if HyDE search is available
+    # Check if HyDE search is available — HyDE is Pro-only (M8 / #505).
+    # Non-Pro tiers never use HyDE regardless of API key presence.
     has_key = bool(
         os.environ.get("ANTHROPIC_API_KEY")
         or os.environ.get("OPENROUTER_API_KEY")
@@ -940,7 +1019,12 @@ def truememory_configure(
         or config.get("openrouter_api_key")
         or config.get("openai_api_key")
     )
-    result["hyde_search"] = "enabled" if has_key else "disabled (no API key — search still works, just without query expansion)"
+    if tier != "pro":
+        result["hyde_search"] = "disabled (HyDE is Pro-only)"
+    elif has_key:
+        result["hyde_search"] = "enabled"
+    else:
+        result["hyde_search"] = "disabled (no API key — search still works, just without query expansion)"
 
     # Mark onboarding complete so the SessionStart hook stops showing
     # the setup banner on subsequent sessions.


### PR DESCRIPTION
## Summary

Fixes four config-related issues in `truememory/mcp_server.py`:

- **M5 (#502)**: `_load_config()` now caches in memory with a 5-second staleness window + mtime check, eliminating 2x JSON parse per search query
- **M6 (#503)**: `_save_config()` uses atomic write pattern (tempfile.mkstemp + os.replace) so a crash during write cannot corrupt config.json
- **M7 (#504)**: `_save_config()` serializes concurrent writes via `threading.Lock` (`_config_write_lock`), preventing races between MCP handlers and tier-switch
- **M8 (#505)**: `truememory_configure` only reports `hyde_search: enabled` when tier is Pro AND an API key is present; non-Pro tiers report "disabled (HyDE is Pro-only)"

Closes #502, closes #503, closes #504, closes #505

## Test plan

- [x] 11 new TDD tests in `tests/test_issue_502_config.py` covering all four fixes
- [x] All 22 config-related tests pass (including existing `test_config_corruption.py`, `test_issue_497_edge_persist.py`, `test_issue_463_hyde_tier_gate.py`)
- [x] Full test suite passes (1 pre-existing failure in unrelated `test_issue_496_update_lock.py`)