### PR TITLE
fix(tests): align tests with production behavior (10 fixes)

### DIFF
--- a/tests/ingest/test_cli_preflight.py
+++ b/tests/ingest/test_cli_preflight.py
@@ -26,6 +26,13 @@ def _run_cli(args: list[str], env: dict | None = None) -> subprocess.CompletedPr
     base_env.pop("ANTHROPIC_API_KEY", None)
     base_env.pop("OPENROUTER_API_KEY", None)
     if env:
+        # Preserve user site-packages so dependencies (numpy etc.) remain
+        # importable even when HOME is overridden to a temp directory.
+        if "HOME" in env and "PYTHONPATH" not in env:
+            import site
+            user_sp = site.getusersitepackages()
+            existing = base_env.get("PYTHONPATH", "")
+            base_env["PYTHONPATH"] = f"{user_sp}:{existing}" if existing else user_sp
         base_env.update(env)
 
     return subprocess.run(

--- a/tests/ingest/test_stop_hook_safety.py
+++ b/tests/ingest/test_stop_hook_safety.py
@@ -66,6 +66,7 @@ def test_spawn_cap_allows_spawn_under_cap(monkeypatch, tmp_path):
     """Under the cap, Popen must be called and no backlog marker written."""
     from contextlib import contextmanager
     from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import _shared as shared_mod
     from truememory.hooks import core as core_mod
 
     @contextmanager
@@ -74,6 +75,7 @@ def test_spawn_cap_allows_spawn_under_cap(monkeypatch, tmp_path):
 
     monkeypatch.setattr(core_mod, "spawn_gate", _gate_under_cap)
     monkeypatch.setattr(core_mod, "register_spawned_pid", lambda pid: None)
+    monkeypatch.setattr(shared_mod, "check_extraction_budget", lambda: True)
     monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
     monkeypatch.setattr(stop_mod, "TRACE_DIR", tmp_path / "traces")
     monkeypatch.setattr(stop_mod, "LOG_DIR", tmp_path / "logs")
@@ -139,6 +141,7 @@ def test_popen_failure_queues_backlog_not_inline(monkeypatch, tmp_path):
     ingestion — that path blocks Claude Code's shutdown."""
     from contextlib import contextmanager
     from truememory.ingest.hooks import stop as stop_mod
+    from truememory.ingest.hooks import _shared as shared_mod
     from truememory.hooks import core as core_mod
 
     @contextmanager
@@ -146,6 +149,7 @@ def test_popen_failure_queues_backlog_not_inline(monkeypatch, tmp_path):
         yield True
 
     monkeypatch.setattr(core_mod, "spawn_gate", _gate_allows)
+    monkeypatch.setattr(shared_mod, "check_extraction_budget", lambda: True)
     monkeypatch.setattr(stop_mod, "BACKLOG_DIR", tmp_path / "backlog")
     monkeypatch.setattr(stop_mod, "TRACE_DIR", tmp_path / "traces")
     monkeypatch.setattr(stop_mod, "LOG_DIR", tmp_path / "logs")

--- a/tests/test_l0_style_vector.py
+++ b/tests/test_l0_style_vector.py
@@ -161,17 +161,17 @@ class TestBuildEntityStyleVectors:
 
         result = build_entity_style_vectors(conn)
 
-        assert "Alice" in result
-        assert "Bob" in result
-        assert len(result["Alice"]) == DIM
-        assert len(result["Bob"]) == DIM
+        assert "alice" in result
+        assert "bob" in result
+        assert len(result["alice"]) == DIM
+        assert len(result["bob"]) == DIM
 
         # Vectors should be stored in DB
-        stored_alice = get_entity_style_vector(conn, "Alice")
+        stored_alice = get_entity_style_vector(conn, "alice")
         assert stored_alice is not None
         assert len(stored_alice) == DIM
 
-        stored_bob = get_entity_style_vector(conn, "Bob")
+        stored_bob = get_entity_style_vector(conn, "bob")
         assert stored_bob is not None
         conn.close()
 
@@ -195,14 +195,14 @@ class TestIncrementalUpdate:
         for msg in messages:
             _insert_msg(conn, msg, sender="Alice")
         batch_result = build_entity_style_vectors(conn)
-        batch_vec = batch_result["Alice"]
+        batch_vec = batch_result["alice"]
 
         # Incremental build (fresh DB)
         conn2 = _make_test_db()
         for msg in messages:
             _insert_msg(conn2, msg, sender="Alice")
-            update_entity_style_vector_incremental(conn2, "Alice", msg)
-        inc_vec = get_entity_style_vector(conn2, "Alice")
+            update_entity_style_vector_incremental(conn2, "alice", msg)
+        inc_vec = get_entity_style_vector(conn2, "alice")
 
         assert inc_vec is not None
         # Cosine should be reasonably high (incremental weighted average
@@ -226,10 +226,10 @@ class TestGetEntityStyleVector:
         _insert_msg(conn, "Test message two", sender="Charlie")
 
         result = build_entity_style_vectors(conn)
-        stored = get_entity_style_vector(conn, "Charlie")
+        stored = get_entity_style_vector(conn, "charlie")
 
         assert stored is not None
-        for a, b in zip(result["Charlie"], stored):
+        for a, b in zip(result["charlie"], stored):
             assert abs(a - b) < 1e-10
         conn.close()
 
@@ -252,13 +252,13 @@ class TestForgetClearsVector:
         _insert_msg(conn, "Hello from Dave", sender="Dave")
         build_entity_style_vectors(conn)
 
-        assert get_entity_style_vector(conn, "Dave") is not None
+        assert get_entity_style_vector(conn, "dave") is not None
 
         # Simulate forget
-        conn.execute("DELETE FROM entity_style_vectors WHERE entity = ?", ("Dave",))
+        conn.execute("DELETE FROM entity_style_vectors WHERE entity = ?", ("dave",))
         conn.commit()
 
-        assert get_entity_style_vector(conn, "Dave") is None
+        assert get_entity_style_vector(conn, "dave") is None
         conn.close()
 
 

--- a/tests/test_l5_surprise_rerank.py
+++ b/tests/test_l5_surprise_rerank.py
@@ -483,6 +483,9 @@ def test_sparse_surprise_across_chunk_boundary(engine_with_surprise):
     eng._alpha_surprise_override = 0.5
 
     # Re-seed surprise_scores so only ids {1,2,3,1450,1451,1452} get a row.
+    # Temporarily disable FK checks — this test validates boost logic on
+    # synthetic result sets with IDs that don't exist in messages.
+    eng.conn.execute("PRAGMA foreign_keys = OFF")
     eng.conn.execute("DELETE FROM surprise_scores")
     for mid, s in [
         (1, 0.9), (2, 0.9), (3, 0.9),
@@ -493,6 +496,7 @@ def test_sparse_surprise_across_chunk_boundary(engine_with_surprise):
             (mid, s),
         )
     eng.conn.commit()
+    eng.conn.execute("PRAGMA foreign_keys = ON")
 
     # Construct fake results with all 1500 ids at the same base score.
     base = 1.0

--- a/tests/test_spawn_gate.py
+++ b/tests/test_spawn_gate.py
@@ -399,6 +399,7 @@ def _json_load(path):
 def test_drain_backlog_respects_spawn_cap(tmp_path, monkeypatch):
     """_drain_backlog must not spawn processes beyond the spawn cap."""
     from truememory.ingest.hooks import session_start as ss_mod
+    from truememory.ingest.hooks import _shared as shared_mod
     from truememory.hooks import core as core_mod
 
     backlog = tmp_path / "backlog"
@@ -414,6 +415,7 @@ def test_drain_backlog_respects_spawn_cap(tmp_path, monkeypatch):
         }))
 
     monkeypatch.setattr(ss_mod, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "check_extraction_budget", lambda: True)
 
     spawn_count = {"n": 0}
 


### PR DESCRIPTION
## Summary
Fixes 10 test failures across 5 files that were caused by environment issues and test/code misalignment.

## Root Causes
1. **style_vec tests (4)**: Tests asserted original-case entity keys (`"Alice"`) but `build_entity_style_vectors()` normalizes to lowercase (`"alice"`)
2. **surprise rerank (1)**: Test inserted surprise_scores for message_ids 1450+ but fixture only creates 5 messages — FK violation after #537 enabled foreign_keys
3. **CLI preflight (2)**: Subprocess spawned with overridden `HOME` lost access to user site-packages where numpy lives
4. **stop hook / spawn gate (3)**: Tests didn't mock `check_extraction_budget()` — real budget counter was exhausted, blocking spawns before mock Popen was reached

## Fix
- style_vec: Use lowercase keys matching code behavior
- surprise rerank: Temporarily disable FK for synthetic test data
- CLI preflight: Preserve PYTHONPATH with user site-packages when HOME is overridden
- stop hook / spawn gate: Mock `check_extraction_budget` to return True

## Test Plan
- All 10 previously-failing tests now pass
- Full suite: 961 pass, 0 fail, 2 skipped