### PR TITLE
fix: add cluster_messages and extract_preferences to consolidate()

### DIFF
--- a/tests/test_consolidation_gaps.py
+++ b/tests/test_consolidation_gaps.py
@@ -1,0 +1,89 @@
+"""Regression tests for consolidation gaps (clustering + preferences).
+
+Verifies that consolidate() calls cluster_messages and extract_preferences —
+features that were previously only available via ingest().
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from truememory.engine import TrueMemoryEngine
+from truememory.storage import create_db
+
+
+def _make_engine_with_messages(n=20):
+    """Create an engine with messages in a temp DB (no vectors needed)."""
+    td = tempfile.mkdtemp()
+    db = os.path.join(td, "test.db")
+    conn = create_db(db)
+    for i in range(n):
+        conn.execute(
+            "INSERT INTO messages (content, sender, recipient, timestamp, category, modality) "
+            "VALUES (?, ?, '', '', '', '')",
+            (f"Message {i} about topic {i % 5}", "alice" if i % 2 == 0 else "bob"),
+        )
+    conn.commit()
+    conn.close()
+
+    eng = TrueMemoryEngine(db_path=db)
+    eng._ensure_connection()
+    return eng, td
+
+
+def test_consolidate_calls_cluster_messages():
+    """consolidate() must call cluster_messages when clustering is available."""
+    eng, td = _make_engine_with_messages()
+    eng._has_vectors = True
+
+    with patch("truememory.engine._HAS_CLUSTERING", True), \
+         patch("truememory.clustering.cluster_messages", return_value=3) as mock_cm:
+        result = eng.consolidate()
+
+    assert "cluster_messages" in result
+    assert "ERROR" not in result["cluster_messages"]
+    assert "3 clusters" in result["cluster_messages"]
+    mock_cm.assert_called_once_with(eng.conn)
+    eng.close()
+
+
+def test_consolidate_calls_extract_preferences():
+    """consolidate() must call extract_preferences when personality is available."""
+    eng, td = _make_engine_with_messages()
+
+    with patch("truememory.engine._HAS_PERSONALITY", True), \
+         patch("truememory.personality.extract_preferences", return_value={}) as mock_ep:
+        result = eng.consolidate()
+
+    assert "extract_preferences" in result
+    assert "ERROR" not in result["extract_preferences"]
+    mock_ep.assert_called_once_with(eng.conn)
+    eng.close()
+
+
+def test_consolidate_skips_clustering_without_vectors():
+    """consolidate() must skip clustering when vectors are unavailable."""
+    eng, td = _make_engine_with_messages()
+    eng._has_vectors = False
+
+    result = eng.consolidate()
+    assert "cluster_messages" not in result
+    eng.close()
+
+
+def test_consolidate_handles_cluster_error_gracefully():
+    """consolidate() must catch and report clustering errors."""
+    eng, td = _make_engine_with_messages()
+    eng._has_vectors = True
+
+    with patch("truememory.engine._HAS_CLUSTERING", True), \
+         patch("truememory.clustering.cluster_messages", side_effect=RuntimeError("boom")):
+        result = eng.consolidate()
+
+    assert "cluster_messages" in result
+    assert "ERROR" in result["cluster_messages"]
+    eng.close()

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -854,7 +854,7 @@ class TrueMemoryEngine:
             return deleted
 
     def consolidate(self) -> dict[str, str]:
-        """Run all consolidation layers (L2-L5) under the write lock.
+        """Run all consolidation layers (L0-L5) under the write lock.
 
         Returns timing stats for each step.
         """
@@ -889,7 +889,40 @@ class TrueMemoryEngine:
         except (ImportError, ModuleNotFoundError):
             build_dunbar_hierarchy = None
 
+        _cluster_messages = None
+        if _HAS_CLUSTERING and self._has_vectors:
+            try:
+                from truememory.clustering import cluster_messages as _cm
+                _cluster_messages = _cm
+            except (ImportError, ModuleNotFoundError):
+                pass
+
+        _extract_preferences = None
+        if _HAS_PERSONALITY:
+            try:
+                from truememory.personality import extract_preferences as _ep
+                _extract_preferences = _ep
+            except (ImportError, ModuleNotFoundError):
+                pass
+
         with self._write_lock:
+            if _cluster_messages:
+                try:
+                    t0 = _time.time()
+                    n = _cluster_messages(self.conn)
+                    stats["cluster_messages"] = f"{n} clusters in {_time.time() - t0:.3f}s"
+                    self._has_clustering = True
+                except Exception as exc:
+                    stats["cluster_messages"] = f"ERROR: {exc}"
+
+            if _extract_preferences:
+                try:
+                    t0 = _time.time()
+                    _extract_preferences(self.conn)
+                    stats["extract_preferences"] = f"{_time.time() - t0:.3f}s"
+                except Exception as exc:
+                    stats["extract_preferences"] = f"ERROR: {exc}"
+
             try:
                 t0 = _time.time()
                 build_summaries(self.conn)


### PR DESCRIPTION
## Summary
Closes the critical benchmark-production gap where `consolidate()` was missing `cluster_messages()` and `extract_preferences()`.

## Root Cause
`consolidate()` only ran L2-L5 steps (summaries, contradictions, facts, surprise, episodes, landmarks, dunbar). It was missing L0/L1 steps that `ingest()` performed:
- `cluster_messages()` — builds scene clusters used by `search_clustered()` in `search_agentic()`
- `extract_preferences()` — extracts personality preferences used by `search_personality()`

Since production users go through `add()` → `_maybe_auto_consolidate()` → `consolidate()`, clusters and preferences were never built.

## Fix
Added both function calls to `consolidate()`, ordered before existing steps, with proper try/except error isolation matching the existing pattern.

## Evidence
- Production DB: `message_clusters=0`, `cluster_centroids=0` (confirmed via DB health check)
- `search_agentic()` calls `search_clustered()` at engine.py:1971, which requires populated clusters
- Benchmark path (`ingest()`) calls both at engine.py:1354 and engine.py:1396

## Test Plan
- `test_consolidate_calls_cluster_messages` — verifies mock cluster_messages called
- `test_consolidate_calls_extract_preferences` — verifies mock extract_preferences called
- `test_consolidate_skips_clustering_without_vectors` — verifies skip when no vectors
- `test_consolidate_handles_cluster_error_gracefully` — verifies error isolation
- Full suite: 961 pass, 0 fail