### PR TITLE
fix(engine): lower auto-consolidation threshold to 25 + startup check

### DIFF
--- a/tests/test_consolidation_gaps.py
+++ b/tests/test_consolidation_gaps.py
@@ -87,3 +87,40 @@ def test_consolidate_handles_cluster_error_gracefully():
     assert "cluster_messages" in result
     assert "ERROR" in result["cluster_messages"]
     eng.close()
+
+
+def test_auto_consolidation_threshold_lowered():
+    """Default auto-consolidation threshold is 25 (was 100)."""
+    eng, td = _make_engine_with_messages()
+    assert eng._auto_consolidate_threshold == 25
+    eng.close()
+
+
+def test_startup_consolidation_triggers_when_clusters_empty():
+    """On startup, if messages exist but clusters are empty, consolidate fires."""
+    eng, td = _make_engine_with_messages(n=30)
+
+    with patch.object(eng, "_bg_consolidate") as mock_bg:
+        eng._has_consolidation = True
+        eng._maybe_startup_consolidate()
+
+    assert mock_bg.called or eng._consolidation_thread is not None
+    eng.close()
+
+
+def test_startup_consolidation_skips_when_few_messages():
+    """Don't consolidate on startup if fewer messages than threshold."""
+    eng, td = _make_engine_with_messages(n=5)
+
+    consolidate_called = False
+    orig = eng._bg_consolidate
+    def spy():
+        nonlocal consolidate_called
+        consolidate_called = True
+        return orig()
+
+    eng._bg_consolidate = spy
+    eng._has_consolidation = True
+    eng._maybe_startup_consolidate()
+    assert not consolidate_called
+    eng.close()

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -365,7 +365,7 @@ class TrueMemoryEngine:
         # Auto-consolidation: run L5 consolidation every N adds (#498)
         self._adds_since_consolidation = 0
         self._auto_consolidate_threshold = int(
-            os.environ.get("TRUEMEMORY_AUTO_CONSOLIDATE_EVERY", "100")
+            os.environ.get("TRUEMEMORY_AUTO_CONSOLIDATE_EVERY", "25")
         )
         self._consolidation_thread: threading.Thread | None = None
 
@@ -535,6 +535,28 @@ class TrueMemoryEngine:
                     )
 
             self.ready = True
+            self._maybe_startup_consolidate()
+
+    def _maybe_startup_consolidate(self) -> None:
+        """Trigger background consolidation on startup if data looks stale."""
+        if not self._has_consolidation or self.conn is None:
+            return
+        try:
+            msg_count = self.conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+            if msg_count < self._auto_consolidate_threshold:
+                return
+            cluster_count = self.conn.execute(
+                "SELECT COUNT(*) FROM message_clusters"
+            ).fetchone()[0]
+            if cluster_count == 0:
+                self._consolidation_thread = threading.Thread(
+                    target=self._bg_consolidate,
+                    daemon=True,
+                    name="startup-consolidate",
+                )
+                self._consolidation_thread.start()
+        except Exception:
+            pass
 
     # ──────────────────────────────────────────────────────────────────────
     # Production CRUD API


### PR DESCRIPTION
## Summary
- Lowers `_auto_consolidate_threshold` from 100 to 25 — MCP sessions restart frequently, so the old threshold was rarely reached in production
- Adds `_maybe_startup_consolidate()` that detects when messages exist but clusters are empty (stale DB from pre-fix versions) and kicks off background consolidation
- Closes the production/benchmark parity gap where production DBs never got clusters or preferences populated

## Test plan
- [x] `test_auto_consolidation_threshold_lowered` — verifies default is 25
- [x] `test_startup_consolidation_triggers_when_clusters_empty` — verifies background thread spawns
- [x] `test_startup_consolidation_skips_when_few_messages` — no false triggers
- [x] All 7 tests in `test_consolidation_gaps.py` pass