### PR TITLE
chore: bump version to 0.7.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truememory"
-version = "0.7.2.0"
+version = "0.7.2.1"
 description = "SOTA-level agent memory at zero infrastructure cost."
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
- Version bump to 0.7.2.1 after audit-fix cycle
- 6 PRs merged: #540 (test fixes), #541 (consolidation gaps), #413 (custom tiers), #412 (instrumentation), #542 (auto-consolidation), #411 (Windows TCP transport)

## Changes since 0.7.2.0
- **Critical fix**: `consolidate()` now calls `cluster_messages()` and `extract_preferences()` — closes the production/benchmark parity gap
- **Reliability**: auto-consolidation threshold lowered from 100 to 25, startup consolidation check added
- **Platform**: Windows TCP loopback transport with HMAC authentication
- **Features**: custom tier configs, opt-in SQLite telemetry
- **Tests**: 10 test alignment fixes, 15 new TCP transport tests, 7 consolidation gap tests