### PR TITLE
fix(tests): update M19 test for pid_is_alive refactor

### DIFF
--- a/tests/test_issue_514_model_server.py
+++ b/tests/test_issue_514_model_server.py
@@ -53,13 +53,19 @@ class TestM18OutboundSizeCheck(unittest.TestCase):
 
 
 class TestM19PermissionError(unittest.TestCase):
-    """M19: PID check should catch PermissionError."""
+    """M19: PID check should handle PermissionError (via pid_is_alive)."""
 
-    def test_pid_check_catches_permission_error(self):
+    def test_pid_check_handles_permission_error(self):
+        from truememory._platform import pid_is_alive
+        source = inspect.getsource(pid_is_alive)
+        self.assertIn("PermissionError", source,
+                       "pid_is_alive() should catch PermissionError")
+
+    def test_main_uses_pid_is_alive(self):
         from truememory.model_server import main
         source = inspect.getsource(main)
-        self.assertIn("PermissionError", source,
-                       "main() PID check should catch PermissionError")
+        self.assertIn("pid_is_alive", source,
+                       "main() should use pid_is_alive for cross-platform PID check")
 
 
 class TestM20RebuildLock(unittest.TestCase):


### PR DESCRIPTION
## Summary
- PR #411 refactored PID checking from `os.kill(pid, 0)` to `pid_is_alive()` (cross-platform)
- The M19 test looked for `PermissionError` in `main()` source but it moved to `_platform.py`
- Updated test to verify `pid_is_alive` handles PermissionError and that `main()` uses it

## Test plan
- [x] All 8 tests in `test_issue_514_model_server.py` pass