### PR TITLE
fix(tests): eliminate timeout flakes in e2e and retry tests

### DIFF
--- a/tests/ingest/test_integration.py
+++ b/tests/ingest/test_integration.py
@@ -15,10 +15,14 @@ from __future__ import annotations
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from truememory.ingest.encoding_gate import EncodingGate
 from truememory.ingest.pipeline import IngestionPipeline, IngestionResult
 from truememory.ingest.transcript import parse_transcript, format_for_extraction
+
+def _skip_model_load():
+    raise RuntimeError("model loading skipped in integration test")
 
 
 # Load the fixture once
@@ -138,7 +142,8 @@ def test_e2e_heuristic_extraction_and_storage():
     # Force heuristic extraction regardless of environment
     pipeline.llm_config = None
 
-    result = pipeline.ingest_transcript(str(FIXTURE_PATH), session_id="test-e2e")
+    with patch("truememory.vector_search.get_model", side_effect=_skip_model_load):
+        result = pipeline.ingest_transcript(str(FIXTURE_PATH), session_id="test-e2e")
 
     assert isinstance(result, IngestionResult)
     assert result.facts_extracted > 0, "Should extract at least one fact from the fixture"
@@ -171,8 +176,9 @@ def test_e2e_reset_batch_between_runs():
     # Inject stale batch state
     pipeline.gate._batch_scores.append(0.999)
 
-    # Ingest the fixture
-    pipeline.ingest_transcript(str(FIXTURE_PATH), session_id="test-reset-1")
+    # Ingest the fixture (patch get_model to skip slow model loading)
+    with patch("truememory.vector_search.get_model", side_effect=_skip_model_load):
+        pipeline.ingest_transcript(str(FIXTURE_PATH), session_id="test-reset-1")
 
     # After ingestion, the stale score should be gone
     # (batch may contain NEW scores from the actual facts, but not the stale one)

--- a/tests/ingest/test_models_retry.py
+++ b/tests/ingest/test_models_retry.py
@@ -99,30 +99,25 @@ def test_retry_backoff_bounds():
 def test_complete_on_unreachable_host_raises_llmerror():
     """
     Calling an unreachable URL should raise LLMError (not URLError) after retries.
-    Uses a guaranteed-unroutable IP to ensure we get a connection error.
+    Mocks urlopen to raise immediately so we don't wait for real socket timeouts.
     """
+    from unittest.mock import patch
+
     config = LLMConfig(
         provider="test",
         model="test-model",
-        # Reserved TEST-NET-1 range (RFC 5737) — should never respond
         base_url="http://192.0.2.1:1",
         api_key="",
         max_tokens=10,
     )
 
-    # This will hit retry, exhaust attempts, and raise LLMError
-    # We don't actually wait through the real backoff — just verify the error
-    # type. In CI this would take ~7 seconds (1 + 2 + 4 backoffs) so we keep
-    # the test focused and don't assert on timing.
-    import time
-    start = time.time()
-    try:
-        _complete_openai_compat(config, "hi", "")
-        assert False, "Expected LLMError"
-    except LLMError as e:
-        # Success: we got an LLMError, not a raw URLError
-        assert "test" in str(e).lower() or "network" in str(e).lower() or "connection" in str(e).lower()
-    elapsed = time.time() - start
-    # Should have attempted retries (takes some time, even if connection fails fast)
-    # Just verify it didn't fail instantly without any retry attempts
-    assert elapsed >= 0  # sanity check, don't enforce min time to keep CI fast
+    def fake_urlopen(*args, **kwargs):
+        raise urllib.error.URLError("connection refused")
+
+    with patch("truememory.ingest.models.urllib.request.urlopen", side_effect=fake_urlopen), \
+         patch("truememory.ingest.models._retry_backoff", return_value=0.0):
+        try:
+            _complete_openai_compat(config, "hi", "")
+            assert False, "Expected LLMError"
+        except LLMError as e:
+            assert "test" in str(e).lower() or "network" in str(e).lower() or "connection" in str(e).lower()


### PR DESCRIPTION
## Summary
- Patch `get_model` in e2e integration tests to skip slow embedding model loading (~60s) that caused `pytest-timeout` failures
- Mock `urlopen` in unreachable-host retry test instead of waiting for real socket timeout (60s per attempt x 4 retries = 240s on macOS)
- Result: 1012 passed, 0 failed (was 3 timeouts before fix)

## Test plan
- [x] `test_e2e_heuristic_extraction_and_storage` passes within 60s
- [x] `test_e2e_reset_batch_between_runs` passes within 60s
- [x] `test_complete_on_unreachable_host_raises_llmerror` passes within 60s
- [x] Full suite: 1012 passed, 0 failed, 2 skipped