### PR TITLE
fix: address 7 confirmed findings from Rustling the Feathers audit

### DIFF
--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -437,10 +437,12 @@ class TrueMemoryEngine:
                                 if _msg_count > 0:
                                     def _bg_reembed(db_path):
                                         import sqlite3 as _sql
+                                        _conn = None
                                         try:
                                             _conn = _sql.connect(str(db_path), check_same_thread=False)
                                             _conn.execute("PRAGMA journal_mode=WAL")
-                                            _conn.execute("PRAGMA busy_timeout=30000")
+                                            _conn.execute("PRAGMA busy_timeout=%d" % DEFAULT_BUSY_TIMEOUT_MS)
+                                            _conn.execute("PRAGMA synchronous=NORMAL")
                                             _conn.execute("PRAGMA foreign_keys=ON")
                                             # Issue #499: load sqlite-vec on the
                                             # background thread's connection so
@@ -469,7 +471,6 @@ class TrueMemoryEngine:
                                                 ("qwen3_nan_fix_applied", "1"),
                                             )
                                             _conn.commit()
-                                            _conn.close()
                                             logger.warning(
                                                 "Qwen3 NaN fix: re-embedded %d vectors "
                                                 "in background", _msg_count,
@@ -480,6 +481,12 @@ class TrueMemoryEngine:
                                                 "will retry on next startup",
                                                 exc_info=True,
                                             )
+                                        finally:
+                                            if _conn is not None:
+                                                try:
+                                                    _conn.close()
+                                                except Exception:
+                                                    pass
                                     _db = self.db_path
                                     if str(_db) != ":memory:":
                                         self._nan_migration_in_progress = True
@@ -644,7 +651,7 @@ class TrueMemoryEngine:
                         )
                     _write_embedder_metadata(self.conn)
                 except Exception:
-                    logger.debug("Failed to store embedding for message %s during add()", new_id, exc_info=True)
+                    logger.warning("Failed to store embedding for message %s during add()", new_id, exc_info=True)
 
             # Incrementally update entity profile
             if self._has_personality and sender:
@@ -2802,7 +2809,12 @@ Return ONLY the queries, one per line, no numbering or explanation:"""
         return stats
 
     def close(self):
-        """Close database connection."""
+        """Close database connection and join background threads."""
+        if self._consolidation_thread is not None and self._consolidation_thread.is_alive():
+            try:
+                self._consolidation_thread.join(timeout=5)
+            except Exception:
+                pass
         if self.conn:
             try:
                 self.conn.close()

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -111,10 +111,11 @@ def check_extraction_budget() -> bool:
     """Check if the hourly extraction budget allows another extraction.
 
     Returns True if extraction is allowed, False if budget is exhausted.
-    Uses flock for atomicity across concurrent processes.
+    Uses flock for atomicity across concurrent processes (no-op on Windows).
     """
     if _MAX_EXTRACTIONS_PER_HOUR <= 0:
         return True
+    fd = -1
     try:
         _BUDGET_FILE.parent.mkdir(parents=True, exist_ok=True)
         fd = os.open(str(_BUDGET_FILE), os.O_RDWR | os.O_CREAT)
@@ -129,16 +130,22 @@ def check_extraction_budget() -> bool:
         if data.get("hour") != current_hour:
             data = {"hour": current_hour, "count": 0}
         if data["count"] >= _MAX_EXTRACTIONS_PER_HOUR:
-            os.close(fd)
             return False
         data["count"] += 1
+        payload = json.dumps(data).encode("utf-8")
         os.lseek(fd, 0, os.SEEK_SET)
         os.ftruncate(fd, 0)
-        os.write(fd, json.dumps(data).encode("utf-8"))
-        os.close(fd)
+        os.write(fd, payload)
         return True
     except OSError:
+        log.warning("Budget file I/O error — allowing extraction", exc_info=True)
         return True
+    finally:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
 
 
 def record_stale_processing_pid(processing_path: Path, pid: int) -> None:

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -220,7 +220,8 @@ class ModelServer:
         return self._reranker
 
     def handle_request(self, request: dict) -> dict:
-        self._last_activity = time.time()
+        with self._lock:
+            self._last_activity = time.time()
         op = request.get("op")
 
         if op == "ping":
@@ -231,14 +232,18 @@ class ModelServer:
             tier = request.get("tier", "")
 
             now = time.time()
-            self._embed_timestamps.append(now)
-            self._embed_timestamps = [
-                t for t in self._embed_timestamps
-                if now - t < self._SUSTAINED_WINDOW
-            ]
+            with self._lock:
+                self._embed_timestamps.append(now)
+                self._embed_timestamps = [
+                    t for t in self._embed_timestamps
+                    if now - t < self._SUSTAINED_WINDOW
+                ]
+                should_activate = (
+                    len(self._embed_timestamps) >= self._SUSTAINED_THRESHOLD
+                    and not self._throttler_active
+                )
 
-            if (len(self._embed_timestamps) >= self._SUSTAINED_THRESHOLD
-                    and not self._throttler_active):
+            if should_activate:
                 self._activate_throttler()
 
             if self._throttler_active and self._throttler:
@@ -271,7 +276,9 @@ class ModelServer:
                 if self._throttler.should_flush_cache():
                     self._flush_mps_cache()
 
-            if self._throttler_active and len(self._embed_timestamps) < 3:
+            with self._lock:
+                should_deactivate = self._throttler_active and len(self._embed_timestamps) < 3
+            if should_deactivate:
                 self._deactivate_throttler()
 
             return {"ok": True, "vectors": np.asarray(vectors, dtype=np.float32)}
@@ -399,7 +406,9 @@ class ModelServer:
             time.sleep(60)
             if not self._running:
                 break
-            elapsed = time.time() - self._last_activity
+            with self._lock:
+                last = self._last_activity
+            elapsed = time.time() - last
             if elapsed >= IDLE_TIMEOUT:
                 log.info(
                     "Idle timeout (%.0fs), shutting down model server", elapsed
@@ -443,8 +452,10 @@ class ModelServer:
             os.replace(str(tmp), str(path))
         except OSError:
             # os.replace can fail on Windows if another process holds the
-            # file open.  Fall back to direct write.
-            path.write_text(text)
+            # file open.  Fall back to direct write with restricted perms.
+            fd2 = os.open(str(path), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, mode)
+            with os.fdopen(fd2, "w") as f2:
+                f2.write(text)
             tmp.unlink(missing_ok=True)
 
     def run(self):


### PR DESCRIPTION
## Summary
Fixes 7 of the 9 confirmed findings from a 10-persona adversarial audit (26 agents, 94 raw findings, 9 confirmed after verification).

**engine.py (4 fixes):**
- SQLite connection leak in `_bg_reembed()` — moved `_conn.close()` to `finally` block
- Missing `PRAGMA synchronous=NORMAL` in background re-embed connection
- Asymmetric `busy_timeout` (was hardcoded 30000 vs `DEFAULT_BUSY_TIMEOUT_MS=10000`)
- Silent embedding failures upgraded from DEBUG to WARNING level
- Background consolidation thread now joined in `close()` (5s timeout)

**model_server.py (2 fixes):**
- HMAC token file permission bypass on Windows fallback path — now uses `os.open()` with `mode` instead of `path.write_text()`
- Race conditions on `_last_activity` and `_embed_timestamps` — protected with `_lock`

**ingest/hooks/_shared.py (1 fix):**
- File descriptor leak in `check_extraction_budget()` — added `finally` block
- Budget I/O errors now logged at WARNING instead of silently swallowed

**Not addressed (by design):**
- L5 consolidation transaction atomicity — requires architectural change, tracked separately
- Vector table name allowlist at read time — low practical risk (requires DB tampering)

## Test plan
- [x] 51 targeted tests pass (hardening, consolidation, model server, TCP transport)
- [x] Full suite: 1033 passed, 0 failed