### PR TITLE
fix: enable model preloading by default (#452)

### DIFF
--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1228,11 +1228,10 @@ def _touch_search_time() -> None:
 def _preload_models():
     """Pre-load ML models in background threads so the first search is fast.
 
-    Disabled by default (lazy load on first search). Set
-    TRUEMEMORY_PRELOAD_MODELS=1 to enable eager preloading.
+    Enabled by default. Set TRUEMEMORY_PRELOAD_MODELS=0 to disable.
     """
-    if os.environ.get("TRUEMEMORY_PRELOAD_MODELS", "") != "1":
-        log.info("Models will load on first search (set TRUEMEMORY_PRELOAD_MODELS=1 to preload)")
+    if os.environ.get("TRUEMEMORY_PRELOAD_MODELS", "1") == "0":
+        log.info("Model preloading disabled via TRUEMEMORY_PRELOAD_MODELS=0")
         return
 
     def _load_embedding_model_and_db():


### PR DESCRIPTION
## Summary
Closes #452. Eliminates the 10+ second cold start on first search.

The MCP server already had a `_preload_models()` function that loads embedding model and reranker in background threads during startup. It was disabled by default via `TRUEMEMORY_PRELOAD_MODELS=1`. This flips the default to enabled.

**Before:** First search waits 5-10s for model loading
**After:** Models load during MCP server startup; first search is fast

Set `TRUEMEMORY_PRELOAD_MODELS=0` to restore lazy loading if needed.

## Test plan
- [x] `import truememory.mcp_server` succeeds
- [x] Full ingest test suite passes (222/222)