### PR TITLE
style: refactor imports to separate lines

### DIFF
--- a/benchmarks/beam/bench_truememory_pro_beam10m.py
+++ b/benchmarks/beam/bench_truememory_pro_beam10m.py
@@ -20,7 +20,14 @@ Usage:
     modal volume get locomo-results / ./results --force
 """
 
-import ast, json, modal, os, re, sys, time, tempfile
+import ast
+import json
+import modal
+import os
+import re
+import sys
+import time
+import tempfile
 from pathlib import Path
 
 app = modal.App("beam-truememory-pro-10m")


### PR DESCRIPTION
### 问题背景
这个 PR 解决了代码风格问题，将多个导入语句写在一行中，这违反了 PEP 8 的 E401 规则（多个导入在一行）。通过将导入拆分成单独的行，提高了代码的可读性和一致性。

### 修改内容
- **修改了什么**：在文件 `benchmarks/beam/bench_truememory_pro_beam10m.py` 中，将 `import ast, json, modal, os, re, sys, time, tempfile` 拆分为每个库单独一行。
- **为什么这样改**：遵循 PEP 8 编码标准，使代码更易读和维护，减少合并冲突的风险，并支持自动化工具更好地分析导入。
- **对代码质量的提升**：增强了代码的可读性和一致性，有助于团队协作和长期维护。

### 验证方式
- **通过现有测试**：由于是纯风格修改，不改变代码功能，所有现有测试应继续通过。建议运行完整的测试套件以确保无回归。
- **手动验证**：可以使用 lint 工具（如 flake8 或 pylint）检查代码风格，确认没有 E401 警告。
- **未添加新测试**：修改不涉及功能逻辑，因此无需新增测试。

### 其他信息
- **Breaking changes**：无。修改仅影响代码格式，不改变外部行为或 API。
- **文档更新**：无需更新文档。
- **已知限制**：无。