### PR TITLE
fix: add directive guidance to CLAUDE_TEMPLATE.md

### DIFF
--- a/tests/test_issue_563_template_directives.py
+++ b/tests/test_issue_563_template_directives.py
@@ -1,0 +1,27 @@
+"""Regression tests for issue #563: CLAUDE_TEMPLATE.md must mention directives."""
+
+from pathlib import Path
+
+TEMPLATE = Path(__file__).parent.parent / "truememory" / "ingest" / "CLAUDE_TEMPLATE.md"
+
+
+def test_issue_563_template_mentions_directives():
+    text = TEMPLATE.read_text()
+    assert "directive" in text.lower(), "CLAUDE_TEMPLATE.md must mention directives"
+
+
+def test_issue_563_template_auto_store_has_directive_true():
+    text = TEMPLATE.read_text()
+    auto_store_start = text.index("Auto-Store")
+    next_section = text.index("##", auto_store_start + 1)
+    auto_store = text[auto_store_start:next_section]
+    assert "directive=True" in auto_store or "directive=true" in auto_store, (
+        "Auto-Store section must mention directive=True"
+    )
+
+
+def test_issue_563_template_has_trigger_phrases():
+    text = TEMPLATE.read_text()
+    lower = text.lower()
+    assert "always" in lower, "Template must include 'always' trigger phrase"
+    assert "never" in lower, "Template must include 'never' trigger phrase"

--- a/truememory/ingest/CLAUDE_TEMPLATE.md
+++ b/truememory/ingest/CLAUDE_TEMPLATE.md
@@ -19,6 +19,7 @@ MEMORY.md may contain personal facts that were cached from earlier sessions. **D
 
 ## Auto-Recall (every session)
 - At the START of each conversation, call `truememory_search` with a broad query about the user (e.g. "user preferences and context") to load relevant memories before responding.
+- Directives are automatically injected at session start — you do not need to search for them.
 - Before making recommendations, check TrueMemory for stored preferences.
 - When the user asks anything about past conversations, "do you remember", or any personal fact question — search TrueMemory. Do NOT answer "I don't know" without searching first.
 
@@ -26,6 +27,7 @@ MEMORY.md may contain personal facts that were cached from earlier sessions. **D
 - When the user shares a personal preference, store it immediately via `truememory_store`. Do not ask permission.
 - When an important decision is made, store it.
 - When the user corrects you, store the correction.
+- When the user gives a standing instruction ("always do X", "never do Y", "from now on...", "in every session..."), store it as a directive: `truememory_store(content="...", directive=True)`. Directives auto-load at the start of every session — regular memories do not.
 - When the user shares a fact about themselves (location, job, projects, relationships, etc.), store it.
 - Write each memory as a clear, atomic statement: "Prefers bun over npm" not "The user mentioned they like bun."
 - Do NOT store to the built-in auto-memory (`MEMORY.md`) for user facts — those go to TrueMemory only.


### PR DESCRIPTION
## Summary
Add directive guidance to CLAUDE_TEMPLATE.md so Claude knows to use `directive=True` for standing instructions from the first session, before any directives exist.

Fixes #563

## Root Cause
The CLAUDE_TEMPLATE.md (installed as ~/.claude/CLAUDE.md) is the first thing Claude reads every session. Its Auto-Store section teaches storing preferences, facts, and corrections — but never mentions `directive=True`. This creates a chicken-and-egg problem: if no directives exist yet, the `<truememory-directives>` block is never injected, so Claude has no way to learn about directives from the template alone.

## Fix
Two additions:
1. **Auto-Store section**: New bullet teaching Claude to use `directive=True` for standing instructions ("always do X", "never do Y", "from now on...", "in every session...")
2. **Auto-Recall section**: New bullet noting that directives are automatically injected at session start

## Dependency Impact
- `truememory/ingest/CLAUDE_TEMPLATE.md` is read by:
  - `truememory/hooks/adapters/base.py:71` (template path reference)
  - `truememory/hooks/adapters/claude.py:328` (installs as ~/.claude/CLAUDE.md)
  - `tests/ingest/test_production_fixes.py:78` (existence + length check)
- No function signatures changed — only template text content
- Existing test_production_fixes checks still pass (template > 100 chars, exists in package)

## Test Plan
- `test_issue_563_template_mentions_directives` — fails pre-fix (no "directive" in template), passes post-fix
- `test_issue_563_template_auto_store_has_directive_true` — fails pre-fix, passes post-fix
- `test_issue_563_template_has_trigger_phrases` — fails pre-fix, passes post-fix
- Full suite: 1039 passed, 6 skipped, 0 new failures

## Validation
Panel advisory: 3/5 responses (GPT-4.1, DeepSeek v3, Qwen3) — all consensus on the fix approach
Deterministic gates: all pass (regression tests verified, suite green, callers checked)