### PR TITLE
chore: release v0.7.6.0 — directives discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.7.6.0] — 2026-06-08
+
+Directives discoverability release. Claude now learns about directives from every
+surface it reads — CLAUDE.md template, MCP instructions, and tool schemas — solving
+the chicken-and-egg problem where the first directive could never be created correctly.
+
+### Added
+
+- **Directive guidance in CLAUDE_TEMPLATE.md** — Auto-Store section now teaches Claude
+  to use `directive=True` for standing instructions ("always do X", "never do Y",
+  "from now on..."). Auto-Recall section notes directives are auto-injected. (#563)
+- **Directive management guidance in MCP instructions** — Directives section now
+  explains deletion (truememory_directives → truememory_forget) and contradiction
+  handling. (#565)
+- **Comprehensive discoverability regression tests** — 17 tests covering all 4
+  Claude-facing surfaces (CLAUDE_TEMPLATE.md, MCP instructions, tool schemas,
+  session start hook). (#568)
+
+### Fixed
+
+- **`truememory_forget` now `alwaysLoad`** — was the only core CRUD tool without
+  eager loading, potentially deferred behind ToolSearch. (#566)
+- **MCP "Storing memories" section cross-references directives** — models reading
+  the storing section now discover the `directive=True` flag. (#564)
+- **Expanded directive trigger phrases** — added "from now on", "in every session",
+  "make this a rule", "this should always apply" to MCP instructions. (#565)
+
 ## [0.7.5.0] — 2026-06-08
 
 Deterministic memory triggering release. TrueMemory tools are now guaranteed to be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truememory"
-version = "0.7.5.0"
+version = "0.7.6.0"
 description = "SOTA-level agent memory at zero infrastructure cost."
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
Version bump to 0.7.6.0 and CHANGELOG entry for the directives discoverability release.

## Changes in this release
- #563 — Directive guidance in CLAUDE_TEMPLATE.md
- #564 — MCP storing section cross-references directives
- #565 — Expanded trigger phrases and management guidance
- #566 — truememory_forget alwaysLoad
- #567 — Closed as wontfix (50 directives = 763 tokens, under threshold)
- #568 — 17 discoverability regression tests