### PR TITLE
fix(hooks): debounce redundant first-message recall (closes #561)

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -47,6 +47,7 @@ All TrueMemory environment variables and their defaults.
 | `TRUEMEMORY_INCREMENTAL_INTERVAL` | `14400` | Seconds between incremental extractions (default: 4 hours) |
 | `TRUEMEMORY_BUFFER_RETENTION_DAYS` | `7` | Days to keep diagnostic buffer files |
 | `TRUEMEMORY_BUFFER_MAX_BYTES` | `10485760` | Max buffer file size before rotation (10 MB) |
+| `TRUEMEMORY_RECALL_DEBOUNCE_SECONDS` | `60` | Window after SessionStart recall during which the first prompt's auto-recall is skipped (`0` or negative disables) |
 
 ## Directories
 

--- a/tests/ingest/test_recall_debounce.py
+++ b/tests/ingest/test_recall_debounce.py
@@ -11,11 +11,16 @@ Covers:
 """
 from __future__ import annotations
 
+import importlib
+import io
+import json
+import os
 import time
 
 import pytest
 
 from truememory.ingest.hooks import _shared
+from truememory.ingest.hooks import session_start as ss
 from truememory.ingest.hooks import user_prompt_submit as ups
 
 
@@ -93,3 +98,105 @@ class TestAutoRecallGate:
         )
         assert result is None
         assert called["prompt"] == "what's my favorite editor"
+
+
+def _run_session_start(monkeypatch, session_id: str, recall_context: str,
+                       update_notice: str = "") -> str:
+    """Run session_start.main() hermetically and return its stdout."""
+    monkeypatch.setattr(ss, "_drain_backlog", lambda: None)
+    monkeypatch.setattr(ss, "_scan_stale_sessions", lambda: None)
+    monkeypatch.setattr(ss, "_is_first_run", lambda: False)
+    monkeypatch.setattr(ss, "recall_memories", lambda *a, **k: recall_context)
+    monkeypatch.setattr(ss, "_check_for_update", lambda: update_notice)
+    monkeypatch.setattr(ss, "_check_email_needed", lambda: "")
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"session_id": session_id})))
+    captured = io.StringIO()
+    monkeypatch.setattr("sys.stdout", captured)
+    ss.main()
+    return captured.getvalue().strip()
+
+
+class TestSessionStartMarker:
+    """The session_start.py half of the debounce (issue #561)."""
+
+    def test_issue_561_marker_not_written_when_recall_empty(self, marker_dir, monkeypatch):
+        """An empty/failed recall injects nothing, so the marker must NOT be
+        written — otherwise the first prompt's targeted recall is suppressed
+        too and the session's first turn gets zero recall, silently."""
+        out = _run_session_start(monkeypatch, "sess-empty", "")
+        assert out == ""
+        assert not (marker_dir / "sess-empty").exists()
+
+    def test_issue_561_marker_written_when_context_nonempty(self, marker_dir, monkeypatch):
+        """Happy path: recall produced context, it was emitted, marker written."""
+        out = _run_session_start(monkeypatch, "sess-full", "<truememory-recall>x</truememory-recall>")
+        data = json.loads(out)
+        assert "additionalContext" in data
+        assert (marker_dir / "sess-full").exists()
+        assert _shared.consume_recall_injected("sess-full") is True
+
+    def test_issue_561_notices_alone_do_not_mark(self, marker_dir, monkeypatch):
+        """Update/email notices can make the emitted context truthy even when
+        recall returned nothing; that must not debounce the first prompt."""
+        out = _run_session_start(monkeypatch, "sess-notice", "", update_notice="update available")
+        data = json.loads(out)
+        assert "update available" in data["additionalContext"]
+        assert not (marker_dir / "sess-notice").exists()
+
+
+class TestRecallMarkerEdges:
+    def test_issue_561_per_session_isolation(self, marker_dir):
+        """Marking one session must never debounce another."""
+        _shared.mark_recall_injected("session-a")
+        assert _shared.consume_recall_injected("session-b") is False
+        assert _shared.consume_recall_injected("session-a") is True
+
+    def test_issue_561_stale_markers_pruned_on_write(self, marker_dir):
+        """Sessions that never send a prompt never consume their marker; the
+        next write opportunistically sweeps anything well past the window."""
+        _shared.mark_recall_injected("session-abandoned")
+        stale = marker_dir / "session-abandoned"
+        two_hours_ago = time.time() - 7200
+        os.utime(stale, (two_hours_ago, two_hours_ago))
+        _shared.mark_recall_injected("session-new")
+        assert not stale.exists()
+        assert (marker_dir / "session-new").exists()
+
+    def test_issue_561_fresh_markers_survive_the_sweep(self, marker_dir):
+        _shared.mark_recall_injected("session-a")
+        _shared.mark_recall_injected("session-b")
+        assert (marker_dir / "session-a").exists()
+        assert (marker_dir / "session-b").exists()
+
+    def test_issue_561_short_first_prompt_does_not_strand_marker(self, marker_dir, monkeypatch):
+        """A first prompt under the min-length gate must still consume the
+        marker, so the second (real) prompt is not debounced."""
+        _shared.mark_recall_injected("sess-short")
+        monkeypatch.delenv("TRUEMEMORY_EXTRACTION", raising=False)
+        monkeypatch.setattr(
+            "sys.stdin", io.StringIO(json.dumps({"prompt": "hi", "session_id": "sess-short"}))
+        )
+        ups.main()
+        assert not (marker_dir / "sess-short").exists()
+        assert _shared.consume_recall_injected("sess-short") is False
+
+    def test_issue_561_invalid_env_var_falls_back_to_default(self, tmp_path):
+        """TRUEMEMORY_RECALL_DEBOUNCE_SECONDS=abc must not crash the hooks.
+
+        The knob is parsed at import of _shared, which both SessionStart and
+        UserPromptSubmit import — an unguarded float() kills every hook."""
+        old = os.environ.get("TRUEMEMORY_RECALL_DEBOUNCE_SECONDS")
+        os.environ["TRUEMEMORY_RECALL_DEBOUNCE_SECONDS"] = "abc"
+        try:
+            importlib.reload(_shared)  # must not raise
+            assert _shared._RECALL_DEBOUNCE_SECONDS == 60.0
+            # And the marker round-trip still works on the reloaded module.
+            _shared.RECALL_MARKER_DIR = tmp_path / "recall_markers"
+            _shared.mark_recall_injected("sess-env")
+            assert _shared.consume_recall_injected("sess-env") is True
+        finally:
+            if old is None:
+                os.environ.pop("TRUEMEMORY_RECALL_DEBOUNCE_SECONDS", None)
+            else:
+                os.environ["TRUEMEMORY_RECALL_DEBOUNCE_SECONDS"] = old
+            importlib.reload(_shared)

--- a/tests/ingest/test_recall_debounce.py
+++ b/tests/ingest/test_recall_debounce.py
@@ -1,0 +1,95 @@
+"""Tests for the first-message recall debounce (issue #561).
+
+SessionStart already searches TrueMemory and injects up to 25 memories. The
+UserPromptSubmit hook's per-message auto-recall is therefore redundant on the
+first prompt of a session. These tests cover the one-shot, time-windowed
+debounce marker that lets UserPromptSubmit skip that redundant recall.
+
+Covers:
+  - mark_recall_injected / consume_recall_injected round-trip and semantics
+  - _try_auto_recall short-circuits (no recall work) when the marker is fresh
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from truememory.ingest.hooks import _shared
+from truememory.ingest.hooks import user_prompt_submit as ups
+
+
+@pytest.fixture
+def marker_dir(monkeypatch, tmp_path):
+    """Point the recall-marker store at an isolated temp dir."""
+    d = tmp_path / "recall_markers"
+    monkeypatch.setattr(_shared, "RECALL_MARKER_DIR", d)
+    return d
+
+
+class TestRecallMarker:
+    def test_mark_then_consume_is_true(self, marker_dir):
+        _shared.mark_recall_injected("session-abc")
+        assert _shared.consume_recall_injected("session-abc") is True
+
+    def test_consume_is_one_shot(self, marker_dir):
+        """Only the first prompt is debounced; the marker is consumed."""
+        _shared.mark_recall_injected("session-abc")
+        assert _shared.consume_recall_injected("session-abc") is True
+        assert _shared.consume_recall_injected("session-abc") is False
+
+    def test_consume_without_marker_is_false(self, marker_dir):
+        assert _shared.consume_recall_injected("never-marked") is False
+
+    def test_stale_marker_is_not_fresh_and_is_cleaned(self, marker_dir):
+        _shared.mark_recall_injected("session-old")
+        marker = marker_dir / "session-old"
+        marker.write_text(str(time.time() - 10_000), encoding="utf-8")
+        assert _shared.consume_recall_injected("session-old", within_seconds=60) is False
+        # Stale markers are still removed so the dir self-cleans.
+        assert not marker.exists()
+
+    def test_within_seconds_zero_disables_debounce(self, marker_dir):
+        _shared.mark_recall_injected("session-abc")
+        assert _shared.consume_recall_injected("session-abc", within_seconds=0) is False
+
+    def test_empty_session_id_is_safe(self, marker_dir):
+        assert _shared.consume_recall_injected("") is False
+        # Must not raise even when there is nothing to mark.
+        _shared.mark_recall_injected("")
+
+    def test_corrupt_marker_is_false(self, marker_dir):
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        (marker_dir / "session-bad").write_text("not-a-timestamp", encoding="utf-8")
+        assert _shared.consume_recall_injected("session-bad") is False
+
+
+class TestAutoRecallGate:
+    def test_fresh_marker_short_circuits_recall(self, marker_dir, monkeypatch):
+        """A fresh marker makes _try_auto_recall return None before doing any
+        recall work (no detection, no Memory load)."""
+        def _boom(*_a, **_k):
+            raise AssertionError("recall work must not run when marker is fresh")
+
+        monkeypatch.setattr(ups, "_detect_recall", _boom)
+        _shared.mark_recall_injected("session-first")
+
+        result = ups._try_auto_recall(
+            "what's my favorite editor", "", "", session_id="session-first"
+        )
+        assert result is None
+
+    def test_no_marker_allows_recall_detection(self, marker_dir, monkeypatch):
+        """Without a marker, the gate falls through to normal recall detection."""
+        called = {}
+
+        def _detect(prompt):
+            called["prompt"] = prompt
+            return False  # short-circuit before Memory load
+
+        monkeypatch.setattr(ups, "_detect_recall", _detect)
+        result = ups._try_auto_recall(
+            "what's my favorite editor", "", "", session_id="session-fresh"
+        )
+        assert result is None
+        assert called["prompt"] == "what's my favorite editor"

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -27,7 +27,12 @@ _STALE_PROCESSING_THRESHOLD = 1800  # 30 minutes
 # How long after SessionStart injects recall the first user prompt is treated
 # as redundant. SessionStart writes the marker just before the first prompt
 # arrives, so a short window is enough to cover that first message (issue #561).
-_RECALL_DEBOUNCE_SECONDS = float(os.environ.get("TRUEMEMORY_RECALL_DEBOUNCE_SECONDS", "60"))
+# Defensive parse: a typo in this user-facing knob must not crash every hook
+# at import time — fall back to the default instead.
+try:
+    _RECALL_DEBOUNCE_SECONDS = float(os.environ.get("TRUEMEMORY_RECALL_DEBOUNCE_SECONDS", "60"))
+except ValueError:
+    _RECALL_DEBOUNCE_SECONDS = 60.0
 
 
 def _safe_session_id(session_id: str) -> str:
@@ -267,6 +272,18 @@ def mark_recall_injected(session_id: str) -> None:
         return
     try:
         RECALL_MARKER_DIR.mkdir(parents=True, exist_ok=True)
+        # Opportunistic sweep: markers from sessions that never sent a prompt
+        # are never consumed; remove anything well past the debounce window so
+        # the dir cannot grow unboundedly (mirrors _prune_old_buffers).
+        cutoff = time.time() - max(_RECALL_DEBOUNCE_SECONDS * 10, 3600.0)
+        for stale in RECALL_MARKER_DIR.iterdir():
+            try:
+                if stale.stat().st_mtime < cutoff:
+                    stale.unlink()
+            except OSError:
+                continue
+        # Wall clock (not monotonic) on purpose: the timestamp is compared
+        # across the SessionStart and UserPromptSubmit processes.
         (RECALL_MARKER_DIR / safe_id).write_text(str(time.time()), encoding="utf-8")
     except OSError:
         pass

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -17,11 +17,17 @@ log = logging.getLogger(__name__)
 
 EXTRACTED_DIR = Path.home() / ".truememory" / "extracted"
 BACKLOG_DIR = Path.home() / ".truememory" / "backlog"
+RECALL_MARKER_DIR = Path.home() / ".truememory" / "recall_markers"
 
 _BUDGET_FILE = Path.home() / ".truememory" / ".extraction_budget"
 _MAX_EXTRACTIONS_PER_HOUR = int(os.environ.get("TRUEMEMORY_MAX_EXTRACTIONS_PER_HOUR", "20"))
 
 _STALE_PROCESSING_THRESHOLD = 1800  # 30 minutes
+
+# How long after SessionStart injects recall the first user prompt is treated
+# as redundant. SessionStart writes the marker just before the first prompt
+# arrives, so a short window is enough to cover that first message (issue #561).
+_RECALL_DEBOUNCE_SECONDS = float(os.environ.get("TRUEMEMORY_RECALL_DEBOUNCE_SECONDS", "60"))
 
 
 def _safe_session_id(session_id: str) -> str:
@@ -248,3 +254,48 @@ def mark_session_extracted(session_id: str, transcript_path: str, spawned_pid: i
         }), encoding="utf-8")
     except OSError:
         pass
+
+
+def mark_recall_injected(session_id: str) -> None:
+    """Record that SessionStart injected recall for this session.
+
+    Lets UserPromptSubmit skip its redundant per-message auto-recall on the
+    first prompt of the session (issue #561). Best-effort: never raises.
+    """
+    safe_id = _safe_session_id(session_id)
+    if not safe_id:
+        return
+    try:
+        RECALL_MARKER_DIR.mkdir(parents=True, exist_ok=True)
+        (RECALL_MARKER_DIR / safe_id).write_text(str(time.time()), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def consume_recall_injected(session_id: str, within_seconds: float = _RECALL_DEBOUNCE_SECONDS) -> bool:
+    """Return True if SessionStart recall ran for this session recently.
+
+    One-shot: the marker is removed on read (whether fresh or stale), so only
+    the first user prompt after SessionStart is debounced and the marker dir
+    self-cleans for any session that sends at least one prompt. Returns True
+    only when a marker existed and is younger than ``within_seconds``.
+    """
+    safe_id = _safe_session_id(session_id)
+    if not safe_id:
+        return False
+    marker = RECALL_MARKER_DIR / safe_id
+    try:
+        raw = marker.read_text(encoding="utf-8").strip()
+    except OSError:
+        return False
+    try:
+        marker.unlink()
+    except OSError:
+        pass
+    if within_seconds <= 0:
+        return False
+    try:
+        ts = float(raw)
+    except ValueError:
+        return False
+    return (time.time() - ts) < within_seconds

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -400,14 +400,10 @@ def main():
     try:
         if _is_first_run():
             context = _first_run_context()
+            recall_injected = False
         else:
             context = recall_memories(input_data, user_id=args.user, db_path=args.db)
-            '''Mark recall as injected so the first UserPromptSubmit can skip
-            its redundant per-message auto-recall (issue #561).'''
-            session_id = input_data.get("session_id", "")
-            if session_id:
-                from truememory.ingest.hooks._shared import mark_recall_injected
-                mark_recall_injected(session_id)
+            recall_injected = bool(context)
 
         # Check for available updates
         update_notice = _check_for_update()
@@ -422,6 +418,16 @@ def main():
         if context:
             output = {"additionalContext": context}
             print(json.dumps(output))
+            # Mark recall as injected so the first UserPromptSubmit can skip
+            # its redundant per-message auto-recall (issue #561). Written only
+            # after the context has actually been emitted, and only when the
+            # recall portion was non-empty — an empty/failed recall must not
+            # suppress the first prompt's targeted recall.
+            if recall_injected:
+                session_id = input_data.get("session_id", "")
+                if session_id:
+                    from truememory.ingest.hooks._shared import mark_recall_injected
+                    mark_recall_injected(session_id)
     except Exception as e:
         log.error("SessionStart hook failed: %s", e)
 

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -402,6 +402,12 @@ def main():
             context = _first_run_context()
         else:
             context = recall_memories(input_data, user_id=args.user, db_path=args.db)
+            '''Mark recall as injected so the first UserPromptSubmit can skip
+            its redundant per-message auto-recall (issue #561).'''
+            session_id = input_data.get("session_id", "")
+            if session_id:
+                from truememory.ingest.hooks._shared import mark_recall_injected
+                mark_recall_injected(session_id)
 
         # Check for available updates
         update_notice = _check_for_update()

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -225,6 +225,14 @@ def main():
     session_id = input_data.get("session_id", "unknown")
 
     if not prompt or len(prompt) < 3:
+        # A too-short first prompt is still the session's first prompt:
+        # consume any recall marker now so it cannot strand and debounce the
+        # next, real prompt (issue #561).
+        try:
+            from truememory.ingest.hooks._shared import consume_recall_injected
+            consume_recall_injected(session_id)
+        except Exception:
+            pass
         return
 
     try:

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -132,8 +132,16 @@ def _detect_recall(prompt: str) -> bool:
     return bool(_RECALL_RE.search(prompt))
 
 
-def _try_auto_recall(prompt: str, user_id: str, db_path: str) -> str | None:
-    """Search TrueMemory if prompt looks like a recall question."""
+def _try_auto_recall(prompt: str, user_id: str, db_path: str, session_id: str = "") -> str | None:
+    """Search TrueMemory if prompt looks like a recall question.
+
+    Skips the search entirely on the first prompt right after SessionStart,
+    which already injected recall (issue #561). The gate runs before detection
+    and the Memory load so the redundant first-message recall costs nothing.
+    """
+    from truememory.ingest.hooks._shared import consume_recall_injected
+    if session_id and consume_recall_injected(session_id):
+        return None
     if not _detect_recall(prompt):
         return None
     try:
@@ -250,7 +258,7 @@ def main():
         except Exception:
             pass
 
-    recall_context = _try_auto_recall(prompt, args.user, args.db)
+    recall_context = _try_auto_recall(prompt, args.user, args.db, session_id)
     if recall_context:
         print(json.dumps({"additionalContext": recall_context}))
 


### PR DESCRIPTION
## Summary
The UserPromptSubmit hook ran a full auto-recall (Memory load + embedding search) on the first message of every session, duplicating the recall SessionStart had just injected. This adds a one-shot, time-windowed debounce so the first prompt skips that redundant work.

  ## Changes
  | File | Change |
  |------|--------|
  | `_shared.py` | Add `mark_recall_injected()` / `consume_recall_injected()`, `RECALL_MARKER_DIR`, and
  `TRUEMEMORY_RECALL_DEBOUNCE_SECONDS` (default 60s) |
  | `session_start.py` | Write the per-session marker after normal-run recall |
  | `user_prompt_submit.py` | `_try_auto_recall` takes `session_id`; a fresh marker short-circuits before detection and the Memory
  load |
  | `tests/ingest/test_recall_debounce.py` | New: marker semantics + gate short-circuit (9 tests) |

The debounce is one-shot (marker consumed on read) and self-cleaning, so only the first prompt after SessionStart is skipped; later prompts recall normally.

  ## Test plan
  - [x] All tests pass (`pytest tests/ -q -m "not network"` — 1062 passed, 14 skipped)
  - [x] Lint clean on changed files (`ruff check`)

  ## Notes
  - A pre-warmed daemon/Unix socket to remove the ~90ms interpreter cold start is intentionally out of scope here; worth a separate issue.
  - For reviewers: CI's repo-wide `ruff check` may flag a pre-existing `F401` (unused `import pytest`) in
  `tests/test_issue_566_forget_always_load.py`. That already exists on `main` and is unrelated to this PR — happy to fix it in a separate change if preferred.