### PR TITLE
feat: complete directive field propagation — lands owner WIP safely (#589)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ m = Memory()
 
 m.add("Prefers dark mode and TypeScript", user_id="alex")
 m.add("Works at Anthropic as a senior engineer", user_id="alex")
+m.add("Always sign commits with GPG", directive=True)  # directives auto-load every session
 
 results = m.search("What are Alex's preferences?", user_id="alex")
 results = m.search_deep("career history?", user_id="alex")  # multi-round, higher accuracy
@@ -204,7 +205,7 @@ results = m.search_deep("career history?", user_id="alex")  # multi-round, highe
 
 | Method | Description |
 |--------|-------------|
-| `m.add(content, user_id)` | Store a memory |
+| `m.add(content, user_id)` | Store a memory (`directive=True` for standing instructions that auto-load at the start of every session) |
 | `m.search(query, user_id)` | Search (6-layer pipeline + reranker) |
 | `m.search_deep(query, user_id)` | Multi-round agentic search |
 | `m.get(id)` / `m.get_all(user_id)` | Retrieve memories |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tool Reference
 
-TrueMemory exposes 8 tools via the Model Context Protocol. These are called by Claude Code, Claude Desktop, and other MCP-compatible clients.
+TrueMemory exposes 9 tools via the Model Context Protocol. These are called by Claude Code, Claude Desktop, and other MCP-compatible clients.
 
 ---
 
@@ -13,8 +13,23 @@ Store a memory. Claude calls this proactively when the user shares preferences, 
 | `content` | `str` | required | The fact to remember. One clear, atomic statement. |
 | `user_id` | `str` | `""` | Owner of this memory (e.g., a person's name). |
 | `metadata` | `str` | `""` | Optional JSON string of metadata. |
+| `directive` | `bool` | `false` | Set `true` for standing instructions ("always do X", "never do Y", "from now on..."). Directives are injected automatically at the start of every session — regular memories are not. |
 
 **Content limit:** 50,000 characters max.
+
+**Directives:** store a standing instruction with `directive=true`, list active ones with `truememory_directives`, and remove stale or contradicting ones with `truememory_forget`. Session-start injection is capped at 50 directives (override with `TRUEMEMORY_DIRECTIVE_LIMIT`).
+
+---
+
+## truememory_directives
+
+List all active directives — the always-loaded standing instructions that are injected at session start before search-ranked memories.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `user_id` | `str` | `""` | Filter to this user's directives (optional). |
+
+**Returns:** `{"directives": [...], "count": N}` with `id`, `content`, `user_id`, `created_at`, and `category` per directive. Delete a directive by ID with `truememory_forget`.
 
 ---
 

--- a/tests/test_issue_589_directives_completion.py
+++ b/tests/test_issue_589_directives_completion.py
@@ -1,0 +1,510 @@
+"""Regression suite for issue #589: directives completion (lands the WIP safely).
+
+Covers, in finding order:
+
+- D-2  — legacy (pre-directive, v0.7.5.0-shaped) DBs must upgrade cleanly, and a
+         failed pre-migration backup must NOT leave the DB unmigrated or crash
+         open. Open must NEVER raise ``no such column: directive``.
+- D-8  — the encoding gate must exclude directives BEFORE caching search
+         results, so prediction-error and ``similar_memory`` never see them.
+- D-4  — session-start directive injection is capped, sender-scoping must not
+         hide ``sender=''`` directives, and load errors are logged, not
+         swallowed.
+- D-6  — ``delete_message`` cascades into the ``custom`` tier vector tables.
+- D-7  — Gemini/Cursor/Codex adapter templates + the base.py fallback + user
+         docs all carry directive guidance.
+- WIP  — full lifecycle: store directive -> search returns it flagged ->
+         stats counts it -> forget removes messages + FTS + vec rows.
+
+The legacy schema below is the verbatim messages/FTS section of
+``git show v0.7.5.0:truememory/storage.py`` (the last release before the
+``directive`` column existed).
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# v0.7.5.0 legacy schema (pre-directive) — extracted from the tagged release
+# ---------------------------------------------------------------------------
+
+PRE_DIRECTIVE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    sender TEXT DEFAULT '',
+    recipient TEXT DEFAULT '',
+    timestamp TEXT DEFAULT '',
+    category TEXT DEFAULT '',
+    modality TEXT DEFAULT '',
+    episode_id INTEGER DEFAULT NULL,
+    emotional_valence REAL DEFAULT 0.0,
+    embedding_separation BLOB DEFAULT NULL
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+    content, sender, recipient, category, modality,
+    content_rowid='id',
+    tokenize='porter unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts(rowid, content, sender, recipient, category, modality)
+    VALUES (new.id, new.content, new.sender, new.recipient, new.category, new.modality);
+END;
+
+CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+    DELETE FROM messages_fts WHERE rowid = old.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+    DELETE FROM messages_fts WHERE rowid = old.id;
+    INSERT INTO messages_fts(rowid, content, sender, recipient, category, modality)
+    VALUES (new.id, new.content, new.sender, new.recipient, new.category, new.modality);
+END;
+"""
+
+
+def _make_legacy_db(db_path, rows=()):
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(PRE_DIRECTIVE_SCHEMA)
+    for content in rows:
+        conn.execute("INSERT INTO messages (content) VALUES (?)", (content,))
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# D-2: migration / upgrade path
+# ---------------------------------------------------------------------------
+
+
+def test_issue_589_pre_directive_db_upgrades_cleanly(tmp_path):
+    """Happy path (pins existing behavior): a v0.7.5.0 DB opens, the
+    directive column is added by migration, legacy rows survive, directive
+    ops work, and a pre-migration backup is created."""
+    from truememory.storage import create_db, insert_message
+
+    db = tmp_path / "old.db"
+    _make_legacy_db(db, rows=["legacy fact one", "legacy fact two", "legacy fact three"])
+
+    conn = create_db(db)  # must not raise
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)").fetchall()}
+        assert "directive" in cols
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 3
+        insert_message(conn, {"content": "always respond in lowercase", "directive": True})
+        assert (
+            conn.execute("SELECT COUNT(*) FROM messages WHERE directive = 1").fetchone()[0]
+            == 1
+        )
+    finally:
+        conn.close()
+    assert list(tmp_path.glob("old.db.backup-pre-migration-*")), (
+        "pre-migration backup must be created on the happy path"
+    )
+
+
+def test_issue_589_skipped_migration_cannot_crash_open(tmp_path, monkeypatch, caplog):
+    """Exact failing scenario (repro 5d): when the pre-migration backup fails,
+    the migration must PROCEED anyway (loud warning), so open succeeds and
+    directive ops still work. The old behavior skipped the migration entirely,
+    which the WIP's directive index turned into a hard crash at open."""
+    from truememory.storage import create_db, insert_message
+
+    db = tmp_path / "old.db"
+    _make_legacy_db(db, rows=["legacy fact"])
+
+    monkeypatch.setattr("truememory.storage._backup_database", lambda p: None)
+
+    with caplog.at_level(logging.WARNING, logger="truememory.storage"):
+        conn = create_db(db)  # must not raise — D-2
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)").fetchall()}
+        assert "directive" in cols, (
+            "migration must proceed even when the backup fails (D-2)"
+        )
+        # The proceed-anyway path must be loud.
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("backup" in w.lower() for w in warnings), (
+            f"expected a loud backup-failure warning, got: {warnings}"
+        )
+        # Directive ops work on the migrated DB.
+        insert_message(conn, {"content": "always run tests", "directive": True})
+        assert (
+            conn.execute("SELECT COUNT(*) FROM messages WHERE directive = 1").fetchone()[0]
+            == 1
+        )
+        # Legacy rows intact.
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE content = 'legacy fact'"
+            ).fetchone()[0]
+            == 1
+        )
+    finally:
+        conn.close()
+
+
+def test_issue_589_open_never_raises_no_such_column(tmp_path, monkeypatch):
+    """Defense in depth: even if the migration cannot run AT ALL (simulated by
+    no-opping it), opening a legacy DB must never raise
+    ``no such column: directive`` — the directive index must be guarded by a
+    column-existence check, not baked unconditionally into _SCHEMA_SQL."""
+    from truememory import storage
+
+    db = tmp_path / "old.db"
+    _make_legacy_db(db, rows=["legacy fact"])
+
+    monkeypatch.setattr(storage, "_migrate_messages_schema", lambda conn, path: None)
+
+    conn = storage.create_db(db)  # must not raise, even degraded
+    try:
+        # Degraded-but-openable: reads of legacy data still work.
+        assert (
+            conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 1
+        )
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# D-6: forget cascade for the custom tier group
+# ---------------------------------------------------------------------------
+
+
+def test_issue_589_forget_directive_cascades_custom_tier(tmp_path):
+    """delete_message must clear vec_messages_custom / vec_messages_sep_custom
+    (plain tables stand in for the vec0 virtual tables — DELETE semantics are
+    identical)."""
+    from truememory.storage import create_db, delete_message, insert_message
+
+    conn = create_db(tmp_path / "custom.db")
+    try:
+        mid = insert_message(conn, {"content": "always use tabs", "directive": True})
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS vec_messages_custom "
+            "(rowid INTEGER PRIMARY KEY, embedding BLOB)"
+        )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS vec_messages_sep_custom "
+            "(rowid INTEGER PRIMARY KEY, embedding BLOB)"
+        )
+        conn.execute(
+            "INSERT INTO vec_messages_custom(rowid, embedding) VALUES (?, x'00')", (mid,)
+        )
+        conn.execute(
+            "INSERT INTO vec_messages_sep_custom(rowid, embedding) VALUES (?, x'00')",
+            (mid,),
+        )
+        conn.commit()
+
+        assert delete_message(conn, mid) is True
+
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM vec_messages_custom WHERE rowid = ?", (mid,)
+            ).fetchone()[0]
+            == 0
+        ), "custom-tier vector row must be cascaded on delete (D-6)"
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM vec_messages_sep_custom WHERE rowid = ?", (mid,)
+            ).fetchone()[0]
+            == 0
+        ), "custom-tier separation vector row must be cascaded on delete (D-6)"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# D-4: injection cap + sender scoping + logged load errors
+# ---------------------------------------------------------------------------
+
+
+def test_issue_589_directive_visible_regardless_of_user_scope(tmp_path):
+    """A directive stored with the MCP default ``user_id=''`` (sender='') must
+    still be injected when the session hook runs with --user scoping."""
+    from truememory import Memory
+    from truememory.ingest.hooks.session_start import _load_directives
+
+    m = Memory(path=str(tmp_path / "scope.db"))
+    try:
+        m.add("always reply in lowercase", directive=True)  # sender=''
+        m.add("always run the linter", user_id="josh", directive=True)
+        m.add("directive for someone else", user_id="sam", directive=True)
+
+        got = _load_directives(m, user_id="josh")
+        contents = {d["content"] for d in got}
+        assert "always reply in lowercase" in contents, (
+            "sender='' directives must be visible under --user scoping (D-4)"
+        )
+        assert "always run the linter" in contents
+        assert "directive for someone else" not in contents, (
+            "other users' directives must stay scoped out"
+        )
+
+        # Unscoped load still returns everything.
+        all_got = _load_directives(m)
+        assert len(all_got) == 3
+    finally:
+        m.close()
+
+
+def test_issue_589_directive_injection_cap(tmp_path, caplog):
+    """More directives than the cap -> only DIRECTIVE_LIMIT are injected, a
+    warning is logged, and the block carries an overflow note pointing at
+    truememory_directives."""
+    from truememory.storage import create_db, insert_message
+
+    db = tmp_path / "cap.db"
+    conn = create_db(db)
+    for i in range(60):
+        insert_message(conn, {"content": f"directive number {i:03d}", "directive": True})
+    conn.commit()
+    conn.close()
+
+    from truememory.ingest.hooks.session_start import DIRECTIVE_LIMIT, recall_memories
+
+    assert DIRECTIVE_LIMIT == 50
+
+    with caplog.at_level(logging.WARNING):
+        ctx = recall_memories({}, db_path=str(db))
+
+    assert "<truememory-directives>" in ctx
+    block = ctx.split("<truememory-directives>")[1].split("</truememory-directives>")[0]
+    bullets = [ln for ln in block.splitlines() if ln.startswith("- directive number")]
+    assert len(bullets) == DIRECTIVE_LIMIT, (
+        f"expected exactly {DIRECTIVE_LIMIT} injected directives, got {len(bullets)}"
+    )
+    assert "truememory_directives" in block, (
+        "overflow note must point the agent at truememory_directives"
+    )
+    warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("directive" in w.lower() for w in warnings), (
+        f"cap truncation must be logged, got: {warnings}"
+    )
+
+
+def test_issue_589_directive_load_errors_are_logged(tmp_path, caplog, monkeypatch):
+    """_load_directives must log failures instead of silently returning []."""
+    from truememory import Memory
+    from truememory.ingest.hooks.session_start import _load_directives
+
+    m = Memory(path=str(tmp_path / "err.db"))
+    try:
+        m.add("always reply in lowercase", directive=True)
+
+        def _boom(*a, **kw):
+            raise sqlite3.OperationalError("no such column: directive")
+
+        monkeypatch.setattr(m._engine, "_ensure_connection", _boom)
+        with caplog.at_level(logging.WARNING):
+            got = _load_directives(m)
+        assert got == []
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("directive" in w.lower() for w in warnings), (
+            f"directive load failure must be logged, got: {warnings}"
+        )
+    finally:
+        m.close()
+
+
+# ---------------------------------------------------------------------------
+# D-8: encoding gate must not feed directives into PE / similar_memory
+# ---------------------------------------------------------------------------
+
+
+class _StubMemory:
+    """Memory stub whose only search hit is a near-identical directive."""
+
+    def __init__(self, results):
+        self._results = results
+
+    def search_vectors(self, fact, limit=10):
+        return [dict(r) for r in self._results]
+
+    def search(self, query, user_id=None, limit=5):
+        return [dict(r) for r in self._results]
+
+
+def test_issue_589_gate_excludes_directives_from_pe():
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    directive_row = {
+        "id": 1,
+        "content": "always respond to emails in lowercase",
+        "directive": True,
+        "score": 0.99,
+    }
+    gate = EncodingGate(memory=_StubMemory([directive_row]))
+    decision = gate.evaluate("respond to emails in lowercase always")
+
+    assert all(not r.get("directive") for r in gate._last_search_results), (
+        "_last_search_results must never contain directives (D-8): "
+        f"{gate._last_search_results}"
+    )
+    assert decision.similar_memory == "", (
+        "similar_memory must not expose directive text (D-8)"
+    )
+    # With the directive filtered out, memory is effectively empty: PE must
+    # match the empty-memory baseline (0.0) and novelty the empty-memory max.
+    assert decision.prediction_error == 0.0
+    assert decision.novelty == 1.0
+
+
+def test_issue_589_gate_still_sees_real_facts():
+    """Sanity: non-directive results still flow into the gate's cache."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    fact_row = {"id": 2, "content": "user works at Anthropic", "score": 0.9}
+    gate = EncodingGate(memory=_StubMemory([fact_row]))
+    gate.evaluate("user works at Anthropic as an engineer")
+    assert gate._last_search_results, "real facts must remain visible to the gate"
+    assert gate._last_search_results[0]["content"] == "user works at Anthropic"
+
+
+# ---------------------------------------------------------------------------
+# WIP surface: full directive lifecycle (store -> search -> stats -> forget)
+# ---------------------------------------------------------------------------
+
+
+def test_issue_589_directive_full_lifecycle(tmp_path):
+    from truememory import Memory
+
+    m = Memory(path=str(tmp_path / "life.db"))
+    try:
+        stored = m.add("always sign commits with GPG", directive=True)
+        mid = stored["id"]
+        m.add("user prefers vim keybindings")
+
+        # Search returns the directive flagged.
+        results = m._engine.search("sign commits GPG", limit=5, _skip_reranker=True)
+        hit = next((r for r in results if r.get("id") == mid), None)
+        assert hit is not None, f"directive not returned by search: {results}"
+        assert hit.get("directive") is True, (
+            "search results must carry the directive flag (WIP propagation)"
+        )
+        fact_hits = m._engine.search("vim keybindings", limit=5, _skip_reranker=True)
+        assert fact_hits and all(
+            r.get("directive") is False for r in fact_hits if r.get("id") != mid
+        ), "regular facts must be flagged directive=False"
+
+        # Stats counts it.
+        stats = m._engine.get_stats()
+        assert stats.get("directive_count") == 1, (
+            f"get_stats must report directive_count, got: {stats.keys()}"
+        )
+
+        conn = m._engine.conn
+        # Only the vec0 virtual tables themselves — not their _info/_chunks/
+        # _rowids shadow tables, which hold table-level metadata, not
+        # per-message rows.
+        vec_tables = [
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE name LIKE 'vec_messages%' AND sql LIKE '%USING vec0%'"
+            ).fetchall()
+        ]
+        if m._engine._has_vectors:
+            pre = sum(
+                conn.execute(
+                    f"SELECT COUNT(*) FROM {t} WHERE rowid = ?", (mid,)
+                ).fetchone()[0]
+                for t in vec_tables
+            )
+            assert pre >= 1, "directive must be embedded at add time"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'gpg'"
+        ).fetchone()[0] >= 1
+
+        # Forget removes messages + FTS + vec rows.
+        assert m.delete(mid) is True
+        assert (
+            conn.execute("SELECT COUNT(*) FROM messages WHERE id = ?", (mid,)).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'gpg'"
+            ).fetchone()[0]
+            == 0
+        ), "FTS row must be removed on forget"
+        for t in vec_tables:
+            assert (
+                conn.execute(
+                    f"SELECT COUNT(*) FROM {t} WHERE rowid = ?", (mid,)
+                ).fetchone()[0]
+                == 0
+            ), f"vec row must be removed from {t} on forget"
+
+        stats = m._engine.get_stats()
+        assert stats.get("directive_count") == 0
+    finally:
+        m.close()
+
+
+# ---------------------------------------------------------------------------
+# D-7: adapter/docs parity
+# ---------------------------------------------------------------------------
+
+
+def _adapter_templates():
+    from truememory.hooks.adapters import base as base_mod
+    from truememory.hooks.adapters.codex import _AGENTS_TEMPLATE
+    from truememory.hooks.adapters.cursor import (
+        _SYSTEM_PROMPT_TEMPLATE as cursor_template,
+    )
+    from truememory.hooks.adapters.gemini import (
+        _SYSTEM_PROMPT_TEMPLATE as gemini_template,
+    )
+
+    return {
+        "gemini": gemini_template,
+        "cursor": cursor_template,
+        "codex": _AGENTS_TEMPLATE,
+        "base-fallback": base_mod._FALLBACK_PROMPT,
+    }
+
+
+@pytest.mark.parametrize("adapter", ["gemini", "cursor", "codex", "base-fallback"])
+def test_issue_589_all_adapters_mention_directives(adapter):
+    text = _adapter_templates()[adapter]
+    lower = text.lower()
+    assert "directive" in lower, f"{adapter} template must mention directives (D-7)"
+    assert "directive=true" in lower, (
+        f"{adapter} template must show the directive=True store call (D-7)"
+    )
+    assert "always" in lower and "never" in lower, (
+        f"{adapter} template must include the always/never trigger phrases (D-7)"
+    )
+
+
+def test_issue_589_base_fallback_is_served_when_template_missing(monkeypatch):
+    """The hardened fallback (with directive guidance) is what non-Claude CLIs
+    get when CLAUDE_TEMPLATE.md is unreadable."""
+    from pathlib import Path
+
+    from truememory.hooks.adapters import base as base_mod
+
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    prompt = base_mod.get_generic_system_prompt()
+    assert "directive" in prompt.lower()
+
+
+def test_issue_589_user_docs_mention_directives():
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parent.parent
+    for doc in ("README.md", "docs/mcp-tools.md"):
+        text = (repo / doc).read_text(encoding="utf-8").lower()
+        assert "directive" in text, f"{doc} must document directives (D-7)"
+    mcp_doc = (repo / "docs/mcp-tools.md").read_text(encoding="utf-8")
+    assert "truememory_directives" in mcp_doc, (
+        "docs/mcp-tools.md must document the truememory_directives tool (D-7)"
+    )

--- a/tests/test_issue_589_directives_completion.py
+++ b/tests/test_issue_589_directives_completion.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -374,79 +375,96 @@ def test_issue_589_gate_still_sees_real_facts():
 
 
 def test_issue_589_directive_full_lifecycle(tmp_path):
+    """Embeddings use the house stub (``vector_search.get_model`` patched to a
+    deterministic MagicMock, as in test_issue_493_cascade_delete.py /
+    test_issue_462_delete_cascade.py) so the test is embedder-agnostic: it
+    behaves identically on the no-network CI gate (where the real model cannot
+    load and ``engine.add`` would degrade to storing without an embedding) and
+    on dev machines with cached models."""
+    import numpy as np
+
     from truememory import Memory
 
-    m = Memory(path=str(tmp_path / "life.db"))
-    try:
-        stored = m.add("always sign commits with GPG", directive=True)
-        mid = stored["id"]
-        m.add("user prefers vim keybindings")
+    fake_embedding = np.random.rand(256).astype(np.float32)
+    mock_model = MagicMock()
+    mock_model.encode = lambda texts, **kw: np.array([fake_embedding] * len(texts))
 
-        # Search returns the directive flagged.
-        results = m._engine.search("sign commits GPG", limit=5, _skip_reranker=True)
-        hit = next((r for r in results if r.get("id") == mid), None)
-        assert hit is not None, f"directive not returned by search: {results}"
-        assert hit.get("directive") is True, (
-            "search results must carry the directive flag (WIP propagation)"
-        )
-        fact_hits = m._engine.search("vim keybindings", limit=5, _skip_reranker=True)
-        assert fact_hits and all(
-            r.get("directive") is False for r in fact_hits if r.get("id") != mid
-        ), "regular facts must be flagged directive=False"
+    with patch("truememory.vector_search.get_model", return_value=mock_model):
+        m = Memory(path=str(tmp_path / "life.db"))
+        try:
+            stored = m.add("always sign commits with GPG", directive=True)
+            mid = stored["id"]
+            m.add("user prefers vim keybindings")
 
-        # Stats counts it.
-        stats = m._engine.get_stats()
-        assert stats.get("directive_count") == 1, (
-            f"get_stats must report directive_count, got: {stats.keys()}"
-        )
-
-        conn = m._engine.conn
-        # Only the vec0 virtual tables themselves — not their _info/_chunks/
-        # _rowids shadow tables, which hold table-level metadata, not
-        # per-message rows.
-        vec_tables = [
-            r[0]
-            for r in conn.execute(
-                "SELECT name FROM sqlite_master "
-                "WHERE name LIKE 'vec_messages%' AND sql LIKE '%USING vec0%'"
-            ).fetchall()
-        ]
-        if m._engine._has_vectors:
-            pre = sum(
-                conn.execute(
-                    f"SELECT COUNT(*) FROM {t} WHERE rowid = ?", (mid,)
-                ).fetchone()[0]
-                for t in vec_tables
+            # Search returns the directive flagged.
+            results = m._engine.search("sign commits GPG", limit=5, _skip_reranker=True)
+            hit = next((r for r in results if r.get("id") == mid), None)
+            assert hit is not None, f"directive not returned by search: {results}"
+            assert hit.get("directive") is True, (
+                "search results must carry the directive flag (WIP propagation)"
             )
-            assert pre >= 1, "directive must be embedded at add time"
-        assert conn.execute(
-            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'gpg'"
-        ).fetchone()[0] >= 1
+            fact_hits = m._engine.search("vim keybindings", limit=5, _skip_reranker=True)
+            assert fact_hits and all(
+                r.get("directive") is False for r in fact_hits if r.get("id") != mid
+            ), "regular facts must be flagged directive=False"
 
-        # Forget removes messages + FTS + vec rows.
-        assert m.delete(mid) is True
-        assert (
-            conn.execute("SELECT COUNT(*) FROM messages WHERE id = ?", (mid,)).fetchone()[0]
-            == 0
-        )
-        assert (
-            conn.execute(
+            # Stats counts it.
+            stats = m._engine.get_stats()
+            assert stats.get("directive_count") == 1, (
+                f"get_stats must report directive_count, got: {stats.keys()}"
+            )
+
+            conn = m._engine.conn
+            # Only the vec0 virtual tables themselves — not their _info/
+            # _chunks/_rowids shadow tables, which hold table-level metadata,
+            # not per-message rows.
+            vec_tables = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE name LIKE 'vec_messages%' AND sql LIKE '%USING vec0%'"
+                ).fetchall()
+            ]
+            if m._engine._has_vectors:
+                # With the stubbed model, add() embeds deterministically even
+                # on the no-network gate (sqlite-vec is a local pip package).
+                pre = sum(
+                    conn.execute(
+                        f"SELECT COUNT(*) FROM {t} WHERE rowid = ?", (mid,)
+                    ).fetchone()[0]
+                    for t in vec_tables
+                )
+                assert pre >= 1, "directive must be embedded at add time"
+            assert conn.execute(
                 "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'gpg'"
-            ).fetchone()[0]
-            == 0
-        ), "FTS row must be removed on forget"
-        for t in vec_tables:
+            ).fetchone()[0] >= 1
+
+            # Forget removes messages + FTS + vec rows.
+            assert m.delete(mid) is True
             assert (
                 conn.execute(
-                    f"SELECT COUNT(*) FROM {t} WHERE rowid = ?", (mid,)
+                    "SELECT COUNT(*) FROM messages WHERE id = ?", (mid,)
                 ).fetchone()[0]
                 == 0
-            ), f"vec row must be removed from {t} on forget"
+            )
+            assert (
+                conn.execute(
+                    "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'gpg'"
+                ).fetchone()[0]
+                == 0
+            ), "FTS row must be removed on forget"
+            for t in vec_tables:
+                assert (
+                    conn.execute(
+                        f"SELECT COUNT(*) FROM {t} WHERE rowid = ?", (mid,)
+                    ).fetchone()[0]
+                    == 0
+                ), f"vec row must be removed from {t} on forget"
 
-        stats = m._engine.get_stats()
-        assert stats.get("directive_count") == 0
-    finally:
-        m.close()
+            stats = m._engine.get_stats()
+            assert stats.get("directive_count") == 0
+        finally:
+            m.close()
 
 
 # ---------------------------------------------------------------------------

--- a/truememory/agentic_search.py
+++ b/truememory/agentic_search.py
@@ -213,6 +213,7 @@ def clean_results(
             "timestamp": r.get("timestamp", ""),
             "category": r.get("category", ""),
             "modality": r.get("modality", ""),
+            "directive": r.get("directive", False),
             "score": score,
             "source": r.get("source", "agentic"),
         })

--- a/truememory/consolidation.py
+++ b/truememory/consolidation.py
@@ -46,7 +46,7 @@ def _get_all_messages_chrono(conn: sqlite3.Connection) -> list[dict]:
     """Fetch all messages ordered by timestamp."""
     rows = conn.execute(
         "SELECT id, content, sender, recipient, timestamp, category, modality "
-        "FROM messages ORDER BY timestamp"
+        "FROM messages WHERE directive = 0 ORDER BY timestamp"
     ).fetchall()
     return [
         {
@@ -1070,7 +1070,7 @@ def build_entity_summary_sheets(conn):
     # Get all entities with significant message counts
     entities = conn.execute(
         "SELECT sender, COUNT(*) as cnt FROM messages "
-        "WHERE sender != '' GROUP BY sender HAVING cnt >= 5 "
+        "WHERE sender != '' AND directive = 0 GROUP BY sender HAVING cnt >= 5 "
         "ORDER BY cnt DESC"
     ).fetchall()
 
@@ -1081,8 +1081,8 @@ def build_entity_summary_sheets(conn):
         # Gather all messages for this entity
         rows = conn.execute(
             "SELECT id, content, sender, recipient, timestamp, category, modality "
-            "FROM messages WHERE LOWER(sender) = LOWER(?) OR LOWER(recipient) = LOWER(?) "
-            "ORDER BY timestamp",
+            "FROM messages WHERE (LOWER(sender) = LOWER(?) OR LOWER(recipient) = LOWER(?)) "
+            "AND directive = 0 ORDER BY timestamp",
             (entity_name, entity_name)
         ).fetchall()
 

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -672,6 +672,7 @@ class TrueMemoryEngine:
             "recipient": recipient,
             "timestamp": timestamp,
             "category": category,
+            "directive": directive,
         }
 
     def _maybe_auto_consolidate(self) -> None:
@@ -1925,6 +1926,7 @@ class TrueMemoryEngine:
                 "timestamp": r.get("timestamp", ""),
                 "category": r.get("category", ""),
                 "modality": r.get("modality", ""),
+                "directive": r.get("directive", False),
                 "score": score,
                 "source": r.get("source", source_label),
             })
@@ -2269,6 +2271,7 @@ class TrueMemoryEngine:
                 "timestamp": r.get("timestamp", ""),
                 "category": r.get("category", ""),
                 "modality": r.get("modality", ""),
+                "directive": r.get("directive", False),
                 "score": r.get("score", 0),
                 "source": "fts",
             })
@@ -2288,6 +2291,10 @@ class TrueMemoryEngine:
         if self.conn:
             try:
                 stats["message_count"] = get_message_count(self.conn)
+                dc = self.conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE directive = 1"
+                ).fetchone()
+                stats["directive_count"] = dc[0] if dc else 0
             except Exception:
                 logger.debug("Failed to get message count in get_stats()", exc_info=True)
 

--- a/truememory/fts_search.py
+++ b/truememory/fts_search.py
@@ -78,7 +78,8 @@ def _rows_to_results(rows: list[tuple]) -> list[dict]:
             "timestamp": row[4],
             "category": row[5],
             "modality": row[6],
-            "raw_score": row[7],
+            "directive": bool(row[7]),
+            "raw_score": row[8],
             "score": 0.0,  # placeholder, filled by _normalize_scores
         }
         for row in rows
@@ -88,7 +89,7 @@ def _rows_to_results(rows: list[tuple]) -> list[dict]:
 _FTS_SELECT = """
     SELECT
         m.id, m.content, m.sender, m.recipient, m.timestamp,
-        m.category, m.modality,
+        m.category, m.modality, m.directive,
         messages_fts.rank AS bm25_score
     FROM messages_fts
     JOIN messages m ON m.id = messages_fts.rowid

--- a/truememory/hooks/adapters/base.py
+++ b/truememory/hooks/adapters/base.py
@@ -66,6 +66,24 @@ class CLIAdapter(ABC):
         """Return the TrueMemory system prompt content for this CLI."""
 
 
+# Served when CLAUDE_TEMPLATE.md is missing or unreadable. Must carry the
+# same directive guidance as the template (issue #589, D-7) so directives
+# stay discoverable even on broken installs.
+_FALLBACK_PROMPT = (
+    "# TrueMemory — Persistent Memory\n\n"
+    "You have access to TrueMemory MCP tools for persistent memory.\n"
+    "- Use `truememory_store` to save user facts, preferences, and decisions.\n"
+    '- When the user gives a standing instruction ("always do X", "never do Y", '
+    '"from now on..."), store it as a directive: '
+    '`truememory_store(content="...", directive=True)`. Directives auto-load '
+    "at the start of every session — regular memories do not.\n"
+    "- Use `truememory_search` to recall stored memories before answering.\n"
+    "- Directives are injected automatically at session start — you do not "
+    "need to search for them.\n"
+    "- Search TrueMemory FIRST on any 'do you remember' question.\n"
+)
+
+
 def get_generic_system_prompt() -> str:
     """Return the TrueMemory system prompt for non-Claude CLIs."""
     template = Path(__file__).parent.parent.parent / "ingest" / "CLAUDE_TEMPLATE.md"
@@ -77,10 +95,4 @@ def get_generic_system_prompt() -> str:
             return content
         except OSError:
             pass
-    return (
-        "# TrueMemory — Persistent Memory\n\n"
-        "You have access to TrueMemory MCP tools for persistent memory.\n"
-        "- Use `truememory_store` to save user facts, preferences, and decisions.\n"
-        "- Use `truememory_search` to recall stored memories before answering.\n"
-        "- Search TrueMemory FIRST on any 'do you remember' question.\n"
-    )
+    return _FALLBACK_PROMPT

--- a/truememory/hooks/adapters/codex.py
+++ b/truememory/hooks/adapters/codex.py
@@ -56,6 +56,8 @@ When the `truememory` MCP server is connected, follow these rules:
 ## Auto-Recall (every session)
 - At the START of each conversation, call `truememory_search` with a \
 broad query about the user to load relevant memories before responding.
+- Directives are automatically injected at session start — you do not \
+need to search for them.
 - Before making recommendations, check TrueMemory for stored preferences.
 - When the user asks anything about past conversations or personal \
 facts — search TrueMemory first.
@@ -65,6 +67,10 @@ facts — search TrueMemory first.
 via `truememory_store`. Do not ask permission.
 - When an important decision is made, store it.
 - When the user corrects you, store the correction.
+- When the user gives a standing instruction ("always do X", \
+"never do Y", "from now on..."), store it as a directive: \
+`truememory_store(content="...", directive=True)`. Directives \
+auto-load at the start of every session — regular memories do not.
 - Write each memory as a clear, atomic statement.
 - Do NOT store full conversations, large code blocks, or transient \
 debugging context.

--- a/truememory/hooks/adapters/cursor.py
+++ b/truememory/hooks/adapters/cursor.py
@@ -55,6 +55,8 @@ When the `truememory` MCP server is connected, follow these rules:
 ## Auto-Recall (every session)
 - At the START of each conversation, call `truememory_search` with a \
 broad query about the user to load relevant memories before responding.
+- Directives are automatically injected at session start — you do not \
+need to search for them.
 - Before making recommendations, check TrueMemory for stored preferences.
 - When the user asks anything about past conversations or personal \
 facts — search TrueMemory first.
@@ -64,6 +66,10 @@ facts — search TrueMemory first.
 via `truememory_store`. Do not ask permission.
 - When an important decision is made, store it.
 - When the user corrects you, store the correction.
+- When the user gives a standing instruction ("always do X", \
+"never do Y", "from now on..."), store it as a directive: \
+`truememory_store(content="...", directive=True)`. Directives \
+auto-load at the start of every session — regular memories do not.
 - Write each memory as a clear, atomic statement.
 - Do NOT store full conversations, large code blocks, or transient \
 debugging context.

--- a/truememory/hooks/adapters/gemini.py
+++ b/truememory/hooks/adapters/gemini.py
@@ -56,6 +56,8 @@ When the `truememory` MCP server is connected, follow these rules:
 ## Auto-Recall (every session)
 - At the START of each conversation, call `truememory_search` with a \
 broad query about the user to load relevant memories before responding.
+- Directives are automatically injected at session start -- you do not \
+need to search for them.
 - Before making recommendations, check TrueMemory for stored preferences.
 - When the user asks anything about past conversations or personal \
 facts -- search TrueMemory first.
@@ -65,6 +67,10 @@ facts -- search TrueMemory first.
 via `truememory_store`. Do not ask permission.
 - When an important decision is made, store it.
 - When the user corrects you, store the correction.
+- When the user gives a standing instruction ("always do X", \
+"never do Y", "from now on..."), store it as a directive: \
+`truememory_store(content="...", directive=True)`. Directives \
+auto-load at the start of every session -- regular memories do not.
 - Write each memory as a clear, atomic statement.
 - Do NOT store full conversations, large code blocks, or transient \
 debugging context.

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -251,7 +251,9 @@ class EncodingGate:
             if self._last_search_results:
                 similar = self._last_search_results[0].get("content", "")
             else:
-                results = self._search(fact, limit=1)
+                # Same directive exclusion as the cached path (issue #589,
+                # D-8): similar_memory must never expose directive text.
+                results = [r for r in self._search(fact, limit=1) if not r.get("directive")]
                 if results:
                     similar = results[0].get("content", "")
 
@@ -305,11 +307,14 @@ class EncodingGate:
         if results is None:
             results = self._search(fact, limit=10)
 
-        self._last_search_results = results
-
         # Exclude directives — they are standing instructions, not facts,
         # and should not cause incoming memories to be rejected as redundant.
+        # Filter BEFORE caching: _compute_prediction_error and evaluate()'s
+        # similar_memory both read _last_search_results, and neither may see
+        # directives (issue #589, D-8).
         results = [r for r in results if not r.get("directive")]
+
+        self._last_search_results = results
 
         if not results:
             return 1.0  # Empty memory = maximum novelty

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -307,6 +307,10 @@ class EncodingGate:
 
         self._last_search_results = results
 
+        # Exclude directives — they are standing instructions, not facts,
+        # and should not cause incoming memories to be rejected as redundant.
+        results = [r for r in results if not r.get("directive")]
+
         if not results:
             return 1.0  # Empty memory = maximum novelty
 

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -36,6 +36,9 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 MEMORY_LIMIT = int(os.environ.get("TRUEMEMORY_RECALL_LIMIT", "25"))
+# Max directives force-injected at session start. Uncapped injection let a
+# large directive set consume unbounded context (issue #589, D-4).
+DIRECTIVE_LIMIT = int(os.environ.get("TRUEMEMORY_DIRECTIVE_LIMIT", "50"))
 ONBOARDED_MARKER = Path.home() / ".truememory" / ".onboarded"
 BACKLOG_DIR = Path.home() / ".truememory" / "backlog"
 _DRAIN_CAP = 3
@@ -443,19 +446,57 @@ def _first_run_context() -> str:
     return "\n".join(lines)
 
 
+def _directive_scope_sql(user_id: str) -> tuple[str, list]:
+    """WHERE-clause suffix + params for directive queries.
+
+    Directives stored without a sender (``truememory_store`` defaults
+    ``user_id=''``) must stay visible under ``--user`` scoping — they used to
+    be silently hidden (issue #589, D-4).
+    """
+    if user_id:
+        return " AND (sender = ? OR sender = '')", [user_id]
+    return "", []
+
+
+def _count_directives(memory, user_id: str = "") -> int:
+    """Total stored directives in scope (cheap COUNT on idx_messages_directive)."""
+    try:
+        scope_sql, params = _directive_scope_sql(user_id)
+        row = memory._engine.conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE directive = 1" + scope_sql, params
+        ).fetchone()
+        return int(row[0]) if row else 0
+    except Exception:
+        log.warning("Failed to count directives", exc_info=True)
+        return 0
+
+
 def _load_directives(memory, user_id: str = "") -> list[dict]:
-    """Load all directive memories unconditionally."""
+    """Load directive memories for session injection, capped at DIRECTIVE_LIMIT.
+
+    Failures are logged (not swallowed): a directive-column error on a
+    half-migrated DB must not silently disable the feature (issue #589, D-4).
+    """
     try:
         memory._engine._ensure_connection()
         query = "SELECT id, content, sender, timestamp, category FROM messages WHERE directive = 1"
-        params: list = []
-        if user_id:
-            query += " AND sender = ?"
-            params.append(user_id)
-        query += " ORDER BY id"
+        scope_sql, params = _directive_scope_sql(user_id)
+        query += scope_sql
+        # LIMIT cap+1 so truncation is detectable without an unbounded fetch.
+        query += " ORDER BY id LIMIT ?"
+        params.append(DIRECTIVE_LIMIT + 1)
         rows = memory._engine.conn.execute(query, params).fetchall()
+        if len(rows) > DIRECTIVE_LIMIT:
+            log.warning(
+                "Directive injection capped at %d (more are stored). Prune "
+                "stale directives with truememory_forget, or raise "
+                "TRUEMEMORY_DIRECTIVE_LIMIT.",
+                DIRECTIVE_LIMIT,
+            )
+            rows = rows[:DIRECTIVE_LIMIT]
         return [{"id": r[0], "content": r[1], "sender": r[2]} for r in rows]
     except Exception:
+        log.warning("Failed to load directives for session injection", exc_info=True)
         return []
 
 
@@ -486,6 +527,14 @@ def recall_memories(input_data: dict, user_id: str = "", db_path: str = "") -> s
             content = d.get("content", "").strip()
             if content:
                 dir_lines.append(f"- {content}")
+        if len(directives) >= DIRECTIVE_LIMIT:
+            total = _count_directives(memory, user_id=user_id)
+            if total > len(directives):
+                dir_lines.append(
+                    f"({len(directives)} of {total} directives shown — use "
+                    "truememory_directives to view all, truememory_forget to "
+                    "prune stale ones)"
+                )
         dir_lines.append("</truememory-directives>")
         parts.append("\n".join(dir_lines))
 

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -683,17 +683,21 @@ def delete_message(conn: sqlite3.Connection, msg_id: int) -> bool:
     """
     # Delete child rows BEFORE the parent to avoid FK violations on
     # databases created before ON DELETE CASCADE was added to the schema.
-    for tbl in (
-        "vec_messages", "vec_messages_edge", "vec_messages_basepro",
-    ):
-        try:
-            conn.execute(f"DELETE FROM {tbl} WHERE rowid = ?", (msg_id,))
-        except sqlite3.OperationalError:
-            pass
-    for tbl in (
-        "vec_messages_sep", "vec_messages_sep_edge",
-        "vec_messages_sep_basepro",
-    ):
+    #
+    # The vector tables are derived from the tier groups instead of being
+    # hardcoded: the old explicit list missed the `custom` tier group, which
+    # orphaned embeddings in vec_messages_custom / vec_messages_sep_custom on
+    # delete (issue #589, D-6). Tables that don't exist on a given install
+    # are skipped via the OperationalError guard.
+    from truememory.tier_config import VALID_TIER_GROUPS
+
+    vec_tables = ["vec_messages"] + [
+        f"vec_messages_{group}" for group in sorted(VALID_TIER_GROUPS)
+    ]
+    sep_tables = ["vec_messages_sep"] + [
+        f"vec_messages_sep_{group}" for group in sorted(VALID_TIER_GROUPS)
+    ]
+    for tbl in (*vec_tables, *sep_tables):
         try:
             conn.execute(f"DELETE FROM {tbl} WHERE rowid = ?", (msg_id,))
         except sqlite3.OperationalError:

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -197,7 +197,10 @@ CREATE INDEX IF NOT EXISTS idx_summaries_entity ON summaries(entity);
 CREATE INDEX IF NOT EXISTS idx_summaries_period ON summaries(period);
 CREATE INDEX IF NOT EXISTS idx_entity_relationships_a ON entity_relationships(entity_a);
 CREATE INDEX IF NOT EXISTS idx_landmark_events_timestamp ON landmark_events(timestamp);
-CREATE INDEX IF NOT EXISTS idx_messages_directive ON messages(directive);
+-- NOTE: idx_messages_directive is intentionally NOT in this script. It is
+-- created by create_db() behind a column-existence check so that opening a
+-- legacy (pre-directive) DB whose migration could not run never raises
+-- "no such column: directive" (issue #589, D-2).
 
 -- Vector cache registry (tier-switch: tracks per-tier-group vector table state)
 CREATE TABLE IF NOT EXISTS vector_cache_registry (
@@ -293,7 +296,10 @@ def _migrate_messages_schema(conn: sqlite3.Connection, db_path: str | Path) -> N
 
     Safety measures:
     - Creates a complete backup (DB + WAL + SHM) before any changes
-    - If backup fails, migration is skipped entirely
+    - If the backup fails, the migration still proceeds (with a loud
+      warning): the ALTER TABLE ADD COLUMN statements are additive and
+      transactional, while skipping the migration would leave the DB
+      unusable by current code (issue #589, D-2)
     - All ALTER TABLE statements run inside a single transaction
     - If any ALTER fails, the entire transaction is rolled back
     - Only runs if the messages table already exists and is missing columns
@@ -312,8 +318,21 @@ def _migrate_messages_schema(conn: sqlite3.Connection, db_path: str | Path) -> N
     if str(db_path) != ":memory:":
         backup = _backup_database(Path(str(db_path)))
         if backup is None:
-            log.warning("Skipping legacy migration — backup failed")
-            return
+            # Do NOT skip the migration: an unmigrated DB is unusable by
+            # current code (missing columns break every insert/select), and
+            # with the directive index it used to hard-crash at open
+            # (issue #589, D-2). The ALTERs below are additive and run in a
+            # single rolled-back-on-failure transaction, so proceeding
+            # without a backup is the lower-risk path.
+            log.warning(
+                "Pre-migration backup FAILED for %s — proceeding with the "
+                "legacy schema migration anyway (columns to add: %s). The "
+                "migration is additive and transactional, but no restore "
+                "point exists for this upgrade; back up the database file "
+                "manually if you need one.",
+                db_path,
+                ", ".join(sorted(missing)),
+            )
 
     try:
         conn.execute("BEGIN IMMEDIATE")
@@ -357,6 +376,27 @@ def create_db(db_path: str | Path) -> sqlite3.Connection:
     conn.execute("PRAGMA mmap_size=268435456")
     _migrate_messages_schema(conn, db_path)
     conn.executescript(_SCHEMA_SQL)
+    # The directive index lives outside _SCHEMA_SQL on purpose: if a legacy
+    # DB's migration could not add messages.directive (e.g. a rolled-back
+    # ALTER), an unconditional CREATE INDEX inside executescript would turn a
+    # degraded-but-openable DB into a hard crash at open with
+    # "no such column: directive" (issue #589, D-2). Open must never raise
+    # for a missing directive column.
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()}
+        if "directive" in cols:
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_messages_directive ON messages(directive)"
+            )
+        else:
+            log.warning(
+                "messages.directive column is missing after migration — "
+                "directive index not created; database %s is open in "
+                "degraded legacy mode",
+                db_path,
+            )
+    except sqlite3.OperationalError:
+        log.warning("Could not ensure directive index on %s", db_path, exc_info=True)
     conn.commit()
     return conn
 

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -197,6 +197,7 @@ CREATE INDEX IF NOT EXISTS idx_summaries_entity ON summaries(entity);
 CREATE INDEX IF NOT EXISTS idx_summaries_period ON summaries(period);
 CREATE INDEX IF NOT EXISTS idx_entity_relationships_a ON entity_relationships(entity_a);
 CREATE INDEX IF NOT EXISTS idx_landmark_events_timestamp ON landmark_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_directive ON messages(directive);
 
 -- Vector cache registry (tier-switch: tracks per-tier-group vector table state)
 CREATE TABLE IF NOT EXISTS vector_cache_registry (
@@ -700,7 +701,7 @@ def update_message(conn: sqlite3.Connection, msg_id: int, **fields) -> bool:
     Returns:
         True if the row was updated, False if ID not found.
     """
-    allowed = {"content", "sender", "recipient", "timestamp", "category", "modality"}
+    allowed = {"content", "sender", "recipient", "timestamp", "category", "modality", "directive"}
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return False

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -675,7 +675,7 @@ def search_vector(
         f"""
         SELECT v.rowid, v.distance,
                m.content, m.sender, m.recipient,
-               m.timestamp, m.category, m.modality
+               m.timestamp, m.category, m.modality, m.directive
         FROM (
             SELECT rowid, distance
             FROM {tbl}
@@ -701,6 +701,7 @@ def search_vector(
                 "timestamp": row[5],
                 "category": row[6],
                 "modality": row[7],
+                "directive": bool(row[8]),
                 "score": round(score, 6),
             }
         )
@@ -729,7 +730,7 @@ def search_vector_raw(
         f"""
         SELECT v.rowid, v.distance,
                m.content, m.sender, m.recipient,
-               m.timestamp, m.category, m.modality
+               m.timestamp, m.category, m.modality, m.directive
         FROM (
             SELECT rowid, distance
             FROM {tbl}
@@ -755,6 +756,7 @@ def search_vector_raw(
                 "timestamp": row[5],
                 "category": row[6],
                 "modality": row[7],
+                "directive": bool(row[8]),
                 "score": round(cos_sim, 6),
             }
         )
@@ -946,7 +948,7 @@ def search_vector_separation(
         f"""
         SELECT v.rowid, v.distance,
                m.content, m.sender, m.recipient,
-               m.timestamp, m.category, m.modality
+               m.timestamp, m.category, m.modality, m.directive
         FROM (
             SELECT rowid, distance
             FROM {sep_tbl}
@@ -970,6 +972,7 @@ def search_vector_separation(
             "timestamp": row[5],
             "category": row[6],
             "modality": row[7],
+            "directive": bool(row[8]),
             "score": round(score, 6),
         })
 


### PR DESCRIPTION
## Summary
Lands the owner's WIP directive-field propagation (applied verbatim) and fixes the five audit defects around it. Fixes #589

## Root Cause
The directive feature shipped half-propagated: the field existed in storage/MCP but not in search results, stats, consolidation exclusion, or the encoding gate. Completing it exposed D-2: a legacy DB whose column migration was skipped (backup failure path) would hard-crash at open on the new `idx_messages_directive`.

## Fix
- **WIP landed verbatim** (`git apply` clean): directive in FTS/vector row parsing, search results, stats, consolidation `WHERE directive = 0` filters, agentic propagation, gate exclusion, `idx_messages_directive`, `update_message`.
- **D-2:** migration now proceeds on backup failure with a loud warning (previously skipped → broken DB); the directive index moved out of `_SCHEMA_SQL` behind a column-existence check in `create_db` — open can never raise `no such column: directive`.
- **D-8:** gate's directive filter moved before `_last_search_results` assignment (prediction-error and similar_memory no longer see directives).
- **D-4:** injection cap (50, `TRUEMEMORY_DIRECTIVE_LIMIT`, truncation logged + overflow note), `(sender = ? OR sender = '')` scoping so default-sender directives aren't hidden under `--user`, load errors logged.
- **D-6:** `delete_message` vec-table list derived from `VALID_TIER_GROUPS` — custom-tier embeddings no longer orphaned on forget.
- **D-7:** directive guidance bullets added to Gemini/Cursor/Codex inline templates + `base.py` fallback; `docs/mcp-tools.md` documents the `directive` param and `truememory_directives` (9 tools); README example.
- **Deferred by design-panel consensus (7/7):** D-5 store-time contradiction guard → separate issue (adds an embedding call to the store path; needs per-tier threshold calibration).

## Dependency Impact
Every consumer of the changed surfaces verified (`rg` sweep in the run report): search-result row shape (additive key only), `get_stats` (additive `directive_count`), `update_message` (optional param, default preserves behavior), `delete_message` (table list derivation — existing `OperationalError` guard covers absent tables), session_start injection (cap is new behavior, logged). Known accepted inconsistency, flagged for follow-up: MCP `truememory_directives` listing still uses strict `sender = ?` scoping while injection now includes `sender = ''` (panel ruled acceptable for this PR).

## Test Plan
- 16-test regression suite `tests/test_issue_589_directives_completion.py`: **13/16 fail on unmodified main, 16/16 pass with fixes** (stash-cycle outputs in `_working/blastoff/pr_review/pr_589_report.md`; the 3 always-passing tests pin existing behavior: happy-path migration, open-no-crash on main, gate sanity).
- Covers: v0.7.5.0 legacy-DB upgrade matrix, skipped-migration open-no-crash, custom-tier forget cascade, cap/scoping/logging, gate PE exclusion, full store→search→stats→forget lifecycle, adapter/docs parity.
- Full suite: **1117 passed / 0 new failures** vs frozen post-merge baseline (1101); only failure is the known environmental `test_ingest_version_flag_exits_cleanly`. Ruff clean.

## Validation
Design panel (7 models): 7/7 consensus on scope + D-2 mechanism. Validation panel on this diff: **7/7 satisfied, zero required changes.**

**Phased-PR class (DB schema/upgrade path) — owner merges.**