### PR TITLE
perf: model server — TRUEMEMORY_DEVICE override, sticky-CPU OOM degradation, hook deadlines (#577)

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -54,6 +54,7 @@ All TrueMemory environment variables and their defaults.
 | `TRUEMEMORY_BUFFER_RETENTION_DAYS` | `7` | Days to keep diagnostic buffer files |
 | `TRUEMEMORY_BUFFER_MAX_BYTES` | `10485760` | Max buffer file size before rotation (10 MB) |
 | `TRUEMEMORY_RECALL_DEBOUNCE_SECONDS` | `60` | Window after SessionStart recall during which the first prompt's auto-recall is skipped (`0` or negative disables) |
+| `TRUEMEMORY_HOOK_RECALL_TIMEOUT` | `5` | Per-request model-server deadline (seconds) for hook recall searches. On expiry the search falls back to FTS-only retrieval instead of blocking the hook. `0` or negative disables (legacy 120s behavior) |
 
 ## Directories
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -11,6 +11,12 @@ All TrueMemory environment variables and their defaults.
 | `TRUEMEMORY_EMBED_MODEL` | `edge` | Embedding model tier (`edge`, `base`, `pro`) |
 | `TRUEMEMORY_USER_ID` | `""` | Default user ID for hook-based ingestion |
 
+## Model Server
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRUEMEMORY_DEVICE` | `auto` | Inference device for embedding and reranker models: `cpu`, `mps`, `cuda`, or `auto`. Honored by the shared model server (embed + rerank), the local-fallback reranker, and the adaptive throttler. `cpu` is the escape hatch for MPS out-of-memory retry storms on memory-constrained Macs. If the requested accelerator is unavailable (or the value is invalid), a warning is logged and auto-detection (`cuda` → `mps` → `cpu`) is used. Note: the model server reads this at startup — after changing the value, restart the server (it exits on its own after the idle timeout, 300s by default). After an MPS OOM the affected model is degraded to CPU for the server's lifetime regardless of this setting. |
+
 ## Encoding Gate
 
 | Variable | Default | Description |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,3 +92,26 @@ def _isolate_vector_search_globals():
         yield
     finally:
         _vs.EMBEDDING_MODEL, _vs._embedding_dim, _vs._model = saved
+
+
+@pytest.fixture(autouse=True)
+def _isolate_model_client_timeout():
+    """Snapshot/restore ``truememory.model_client._default_request_timeout``.
+
+    Hook recall paths arm a process-wide model-server deadline via
+    ``set_request_timeout`` (issue #577). In production the hooks are
+    short-lived standalone processes, but in the test suite any test that
+    exercises a recall path would otherwise leak the 5s deadline into later
+    tests that assert the legacy 120s autostart-retry behavior.
+    """
+    try:
+        from truememory import model_client
+    except Exception:
+        yield
+        return
+
+    saved = model_client._default_request_timeout
+    try:
+        yield
+    finally:
+        model_client._default_request_timeout = saved

--- a/tests/test_issue_459_mps_oom.py
+++ b/tests/test_issue_459_mps_oom.py
@@ -130,8 +130,10 @@ class TestIssue459MPSOOMFallback:
         mock_model = MagicMock()
         mock_model.encode = mock_encode
 
-        server._embed_model = mock_model
-        server._embed_tier = ""
+        # Issue #577 (panel round 2): the server now stores the loaded model
+        # as one immutable _EmbedState snapshot; inject via the snapshot.
+        from truememory.model_server import _EmbedState
+        server._embed_state = _EmbedState(model=mock_model, tier="", model_id="model2vec")
 
         request = {"op": "embed", "texts": ["hello", "world", "test"], "tier": ""}
         response = server.handle_request(request)
@@ -153,8 +155,10 @@ class TestIssue459MPSOOMFallback:
         mock_model = MagicMock()
         mock_model.encode = mock_encode
 
-        server._embed_model = mock_model
-        server._embed_tier = ""
+        # Issue #577 (panel round 2): the server now stores the loaded model
+        # as one immutable _EmbedState snapshot; inject via the snapshot.
+        from truememory.model_server import _EmbedState
+        server._embed_state = _EmbedState(model=mock_model, tier="", model_id="model2vec")
 
         request = {"op": "embed", "texts": ["hello"], "tier": ""}
         with pytest.raises(RuntimeError, match="CUDA"):

--- a/tests/test_issue_489_mps_safety.py
+++ b/tests/test_issue_489_mps_safety.py
@@ -126,18 +126,28 @@ class TestModelServerMpsRestore(unittest.TestCase):
         import inspect
         from truememory import model_server
         handler_source = inspect.getsource(model_server.ModelServer.handle_request)
-        cpu_idx = handler_source.find('model.to("cpu")')
-        mps_idx = handler_source.find('model.to("mps")')
-        self.assertGreater(cpu_idx, -1, "Should have model.to('cpu')")
-        self.assertEqual(
-            mps_idx, -1,
-            "model.to('mps') re-promotion must NOT exist — sticky-CPU "
-            "degradation (issue #577) replaces the H4 restore behavior",
+        recovery_source = inspect.getsource(
+            model_server.ModelServer._recover_embed_oom_locked
         )
-        self.assertIn(
-            "_mark_sticky_cpu", handler_source,
-            "OOM recovery must mark the model sticky-CPU (issue #577)",
-        )
+        fast_source = inspect.getsource(model_server.ModelServer._handle_fast_embed)
+        # All embed OOM recovery is routed through the single helper
+        # (issue #577 panel round 2) — both the batch path and the fast lane.
+        self.assertIn("_recover_embed_oom_locked", handler_source)
+        self.assertIn("_recover_embed_oom_locked", fast_source)
+        self.assertIn('model.to("cpu")', recovery_source,
+                      "recovery must move the model to CPU")
+        self.assertIn("_mark_sticky_cpu", recovery_source,
+                      "OOM recovery must mark the model sticky-CPU (issue #577)")
+        for src_name, src in (
+            ("handle_request", handler_source),
+            ("_recover_embed_oom_locked", recovery_source),
+            ("_handle_fast_embed", fast_source),
+        ):
+            self.assertNotIn(
+                'model.to("mps")', src,
+                f"model.to('mps') re-promotion must NOT exist in {src_name} — "
+                "sticky-CPU degradation (issue #577) replaces the H4 restore",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_489_mps_safety.py
+++ b/tests/test_issue_489_mps_safety.py
@@ -113,18 +113,31 @@ class TestModelServerMpsRestore(unittest.TestCase):
         source = inspect.getsource(model_server)
         self.assertIn("from truememory.mps_utils import is_mps_oom", source)
 
-    def test_model_server_restores_to_mps(self):
-        """H4: After CPU fallback, model should be moved back to MPS."""
+    def test_model_server_sticky_cpu_no_mps_restore(self):
+        """H4 (superseded by #577): after CPU fallback the model must STAY
+        on CPU for the server's lifetime.
+
+        The original H4 fix restored the model to MPS after recovery, but
+        the MPS pool never drops below the watermark cap after an OOM, so
+        re-promotion guaranteed the next OOM (measured retry storms stalling
+        every client 23-112s — issue #577). The policy is now sticky-CPU
+        degradation: model.to("cpu") with NO model.to("mps") re-promotion.
+        """
         import inspect
         from truememory import model_server
-        inspect.getsource(model_server)
         handler_source = inspect.getsource(model_server.ModelServer.handle_request)
-        # After model.to("cpu") there should be model.to("mps")
         cpu_idx = handler_source.find('model.to("cpu")')
         mps_idx = handler_source.find('model.to("mps")')
         self.assertGreater(cpu_idx, -1, "Should have model.to('cpu')")
-        self.assertGreater(mps_idx, -1, "Should have model.to('mps') restore")
-        self.assertGreater(mps_idx, cpu_idx, "MPS restore must come after CPU fallback")
+        self.assertEqual(
+            mps_idx, -1,
+            "model.to('mps') re-promotion must NOT exist — sticky-CPU "
+            "degradation (issue #577) replaces the H4 restore behavior",
+        )
+        self.assertIn(
+            "_mark_sticky_cpu", handler_source,
+            "OOM recovery must mark the model sticky-CPU (issue #577)",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_577_model_server_oom.py
+++ b/tests/test_issue_577_model_server_oom.py
@@ -221,8 +221,8 @@ class TestIssue577StickyCpuOom:
         model = MagicMock()
         model.encode = encode
         model.to = lambda device: to_calls.append(device)
-        server._embed_model = model
-        server._embed_tier = ""
+        from truememory.model_server import _EmbedState
+        server._embed_state = _EmbedState(model=model, tier="", model_id="model2vec")
 
         req = {"op": "embed", "texts": ["a", "b"], "tier": ""}
         with caplog.at_level("ERROR", logger="truememory.model_server"):
@@ -264,8 +264,8 @@ class TestIssue577StickyCpuOom:
 
         model = MagicMock()
         model.encode = encode
-        server._embed_model = model
-        server._embed_tier = ""
+        from truememory.model_server import _EmbedState
+        server._embed_state = _EmbedState(model=model, tier="", model_id="model2vec")
 
         results: list[dict] = []
         t = threading.Thread(
@@ -300,8 +300,8 @@ class TestIssue577StickyCpuOom:
         model.encode = MagicMock(
             side_effect=RuntimeError("CUDA error: device-side assert triggered")
         )
-        server._embed_model = model
-        server._embed_tier = ""
+        from truememory.model_server import _EmbedState
+        server._embed_state = _EmbedState(model=model, tier="", model_id="model2vec")
 
         with pytest.raises(RuntimeError, match="CUDA"):
             server.handle_request({"op": "embed", "texts": ["a", "b"], "tier": ""})
@@ -392,8 +392,8 @@ class TestIssue577FastLane:
                 "fast lane must not use the locked main model while a batch runs"
             )
         )
-        server._embed_model = main_model
-        server._embed_tier = ""
+        from truememory.model_server import _EmbedState
+        server._embed_state = _EmbedState(model=main_model, tier="", model_id="model2vec")
 
         fast_calls: list[list[str]] = []
 
@@ -434,13 +434,14 @@ class TestIssue577FastLane:
             server._lock.release()
 
     def test_issue_577_fast_lane_model_dim_parity(self, monkeypatch):
-        """Panel round 1, item 3/4: the fast-lane encoder's (model_id, dim)
-        must equal the main path's — including under sticky-CPU degradation
-        and global tier drift — and must DECLINE (fall through) for custom
-        models where parity cannot be guaranteed. Stubs at the loader level
-        (_build_embed_model) so the real parity/resolution logic runs."""
+        """Panel rounds 1-2, items 3/4: the fast-lane encoder's
+        (model_id, dim) must equal the main path's — including under
+        sticky-CPU degradation and global tier drift — and must DECLINE
+        (fall through) when no snapshot exists for the tier or the model is
+        custom. Stubs at the loader level (_build_embed_model) so the real
+        parity logic runs."""
         import truememory.vector_search as vs
-        from truememory.model_server import ModelServer
+        from truememory.model_server import ModelServer, _EmbedState
 
         built: list[tuple] = []
 
@@ -467,16 +468,26 @@ class TestIssue577FastLane:
         server._sticky_cpu.add("embed")  # simulate sticky-CPU degradation
         monkeypatch.setattr(vs, "EMBEDDING_MODEL", "base")
 
+        # No snapshot yet: the fast lane must DECLINE (round 2 semantics —
+        # the one-time load happens exactly once, on the main path).
+        assert server._lock.acquire(timeout=1)
+        try:
+            assert server._handle_fast_embed(["q"], "") is None, (
+                "fast lane must decline when no main model is loaded yet"
+            )
+        finally:
+            server._lock.release()
+
         # Main path loads for tier="" -> resolves via the global ("base"
-        # -> qwen3_256) and records the actual loaded identity.
+        # -> qwen3_256) and records the loaded identity in the snapshot.
         resp = server.handle_request({"op": "embed", "texts": ["a", "b"], "tier": ""})
         assert resp["ok"] is True
-        assert server._embed_model_id == "qwen3_256"
+        assert server._embed_state.model_id == "qwen3_256"
         assert built[-1] == ("qwen3_256", "cpu"), "sticky degradation must load on CPU"
 
         # Global drift AFTER the main load: a fresh tier="" resolution would
         # now pick model2vec — a DIFFERENT vector space. The fast lane must
-        # follow the main path's actual loaded identity instead.
+        # follow the snapshot's actual loaded identity instead.
         monkeypatch.setattr(vs, "EMBEDDING_MODEL", "edge")
 
         assert server._lock.acquire(timeout=1)  # force the contended branch
@@ -485,21 +496,24 @@ class TestIssue577FastLane:
         finally:
             server._lock.release()
         assert result is not None and result["ok"] is True
-        assert server._fast_model_id == server._embed_model_id == "qwen3_256", (
+        assert server._fast_model_id == server._embed_state.model_id == "qwen3_256", (
             "fast-lane encoder drifted from the main path's loaded model — "
             "single-text embeddings would silently mismatch the vec table"
         )
         assert built[-1] == ("qwen3_256", "cpu")
 
-        main_dim = server._embed_model.encode(["x"]).shape[1]
+        main_dim = server._embed_state.model.encode(["x"]).shape[1]
         fast_dim = server._fast_encoder.encode(["x"]).shape[1]
         assert main_dim == fast_dim, "fast-lane embeddings in a different space"
 
         # Custom model: dim is re-read from config.json at build time, so
         # parity cannot be guaranteed -> the fast lane must decline and the
         # request must fall through to the main (locked) path.
-        server._embed_model_id = "acme/custom-encoder"
-        server._embed_tier = "custom"
+        server._embed_state = _EmbedState(
+            model=FakeModel("acme/custom-encoder", "cpu"),
+            tier="custom",
+            model_id="acme/custom-encoder",
+        )
         assert server._lock.acquire(timeout=1)
         try:
             assert server._handle_fast_embed(["q"], "custom") is None, (
@@ -509,10 +523,24 @@ class TestIssue577FastLane:
         finally:
             server._lock.release()
 
+        # Allowlist honesty (round 2 item 5): ids without an explicit
+        # _build_embed_model branch (minilm/bge-small legacy fall-through)
+        # must also decline.
+        server._embed_state = _EmbedState(
+            model=FakeModel("minilm", "cpu"), tier="", model_id="minilm",
+        )
+        assert server._lock.acquire(timeout=1)
+        try:
+            assert server._handle_fast_embed(["q"], "") is None, (
+                "minilm has no explicit builder branch — fast lane must decline"
+            )
+        finally:
+            server._lock.release()
+
     def test_issue_577_fast_lane_no_global_mutation(self, monkeypatch):
-        """Panel round 1, item 2: the fast lane resolves the model id as a
-        PURE READ — it must never call set_embedding_model, which
-        force-unloads vector_search's model singleton and rewrites
+        """Panel rounds 1-2, item 2: the fast lane never resolves tiers at
+        all — it must never call set_embedding_model, which force-unloads
+        vector_search's model singleton and rewrites
         EMBEDDING_MODEL/_embedding_dim while the main path may be
         mid-encode."""
         import truememory.vector_search as vs
@@ -534,7 +562,15 @@ class TestIssue577FastLane:
         monkeypatch.setattr(vs, "EMBEDDING_MODEL", "edge")
 
         server = ModelServer()
-        assert server._lock.acquire(timeout=1)  # force the contended branch
+        # Arm the snapshot via a main-path load (the historical mutating
+        # sync happens exactly here, under the lock).
+        resp = server.handle_request({"op": "embed", "texts": ["a", "b"], "tier": "base"})
+        assert resp["ok"] is True
+        assert calls == ["base"]
+        calls.clear()
+
+        # Contended fast lane: serves from the snapshot, zero mutation.
+        assert server._lock.acquire(timeout=1)
         try:
             result = server._handle_fast_embed(["q"], "base")
         finally:
@@ -546,12 +582,108 @@ class TestIssue577FastLane:
         )
         assert vs.EMBEDDING_MODEL == "edge"
 
-        # The main (locked) path keeps its historical set_embedding_model
-        # sync — only the fast lane is mutation-free.
-        server2 = ModelServer()
-        resp = server2.handle_request({"op": "embed", "texts": ["a", "b"], "tier": "base"})
-        assert resp["ok"] is True
-        assert calls == ["base"]
+    def test_issue_577_fast_lane_concurrent_tier_load_parity(self, monkeypatch):
+        """Panel round 2, item 6: interleave a main-path tier load (blocked
+        mid-build, holding the global lock) with a fast-lane single-text in
+        another thread, plus a mid-load global drift. The single-text result
+        must be parity (same model id as the main load) or an explicit
+        decline that falls through to the main path — never a fresh
+        resolution into a different vector space. Loader-level stub;
+        3 threads total."""
+        import truememory.vector_search as vs
+        from truememory.model_server import ModelServer
+
+        built: list[tuple] = []
+        build_started = threading.Event()
+        release_build = threading.Event()
+
+        class FakeModel:
+            def __init__(self, model_id):
+                self.model_id = model_id
+                self.marker = float(abs(hash(model_id)) % 997)
+
+            def encode(self, texts, **kwargs):
+                return np.full((len(texts), 8), self.marker, dtype=np.float32)
+
+        def fake_build(model_id, device):
+            built.append((model_id, device, threading.current_thread().name))
+            if threading.current_thread().name == "main-loader":
+                build_started.set()
+                assert release_build.wait(10), "test deadlock: build never released"
+            return FakeModel(model_id)
+
+        monkeypatch.setattr(
+            ModelServer, "_build_embed_model", staticmethod(fake_build)
+        )
+        monkeypatch.setattr(vs, "EMBEDDING_MODEL", "base")
+
+        server = ModelServer()
+        results_a: list[dict] = []
+        results_b: list[dict] = []
+
+        ta = threading.Thread(
+            name="main-loader",
+            target=lambda: results_a.append(
+                server.handle_request({"op": "embed", "texts": ["a", "b"], "tier": ""})
+            ),
+            daemon=True,
+        )
+        ta.start()
+        assert build_started.wait(10)  # A is mid-load, holding the lock
+
+        # Global drift WHILE the load is in flight: a fresh tier=""
+        # resolution would now pick model2vec instead of qwen3_256.
+        monkeypatch.setattr(vs, "EMBEDDING_MODEL", "edge")
+
+        tb = threading.Thread(
+            name="fast-lane",
+            target=lambda: results_b.append(
+                server.handle_request({"op": "embed", "texts": ["hook q"], "tier": ""})
+            ),
+            daemon=True,
+        )
+        tb.start()
+        tb.join(2)
+        # Correct behavior: B declined (no snapshot yet) and is blocked
+        # behind the main load — it must NOT have answered from a freshly
+        # resolved (drifted) model.
+        release_build.set()
+        ta.join(10)
+        tb.join(10)
+        assert not ta.is_alive() and not tb.is_alive()
+        assert results_a and results_a[0]["ok"] is True
+        assert results_b and results_b[0]["ok"] is True
+
+        # Every encoder built during the interleaving resolved to the SAME
+        # model id — no vector-space fork.
+        ids = {m for (m, _d, _t) in built}
+        assert ids == {"qwen3_256"}, (
+            f"vector-space fork during concurrent tier load: built {ids}"
+        )
+        assert results_a[0]["vectors"][0, 0] == results_b[0]["vectors"][0, 0], (
+            "single-text vectors in a different space than the batch vectors"
+        )
+
+        # Phase 2: with the snapshot armed and the lock held by a batch,
+        # the contended fast lane serves from the snapshot identity.
+        results_c: list[dict] = []
+        assert server._lock.acquire(timeout=1)
+        try:
+            tc = threading.Thread(
+                name="fast-lane-2",
+                target=lambda: results_c.append(
+                    server.handle_request({"op": "embed", "texts": ["q2"], "tier": ""})
+                ),
+                daemon=True,
+            )
+            tc.start()
+            tc.join(5)
+            assert not tc.is_alive(), "fast lane blocked despite armed snapshot"
+        finally:
+            server._lock.release()
+        assert results_c and results_c[0]["ok"] is True
+        assert results_c[0]["vectors"][0, 0] == results_a[0]["vectors"][0, 0]
+        assert server._fast_model_id == "qwen3_256"
 
     def test_issue_577_single_text_uses_main_path_when_idle(self, monkeypatch):
         """With no contention the fast lane uses the main model (no extra
@@ -563,8 +695,8 @@ class TestIssue577FastLane:
         main_model.encode = MagicMock(
             return_value=np.ones((1, 4), dtype=np.float32)
         )
-        server._embed_model = main_model
-        server._embed_tier = ""
+        from truememory.model_server import _EmbedState
+        server._embed_state = _EmbedState(model=main_model, tier="", model_id="model2vec")
 
         resp = server.handle_request({"op": "embed", "texts": ["q"], "tier": ""})
         assert resp["ok"] is True

--- a/tests/test_issue_577_model_server_oom.py
+++ b/tests/test_issue_577_model_server_oom.py
@@ -433,6 +433,126 @@ class TestIssue577FastLane:
         finally:
             server._lock.release()
 
+    def test_issue_577_fast_lane_model_dim_parity(self, monkeypatch):
+        """Panel round 1, item 3/4: the fast-lane encoder's (model_id, dim)
+        must equal the main path's — including under sticky-CPU degradation
+        and global tier drift — and must DECLINE (fall through) for custom
+        models where parity cannot be guaranteed. Stubs at the loader level
+        (_build_embed_model) so the real parity/resolution logic runs."""
+        import truememory.vector_search as vs
+        from truememory.model_server import ModelServer
+
+        built: list[tuple] = []
+
+        class FakeModel:
+            _DIMS = {"model2vec": 256, "qwen3_256": 256}
+
+            def __init__(self, model_id, device):
+                self.model_id = model_id
+                self.device = device
+                self.dim = self._DIMS.get(model_id, 999)
+
+            def encode(self, texts, **kwargs):
+                return np.zeros((len(texts), self.dim), dtype=np.float32)
+
+        def fake_build(model_id, device):
+            built.append((model_id, device))
+            return FakeModel(model_id, device)
+
+        monkeypatch.setattr(
+            ModelServer, "_build_embed_model", staticmethod(fake_build)
+        )
+
+        server = ModelServer()
+        server._sticky_cpu.add("embed")  # simulate sticky-CPU degradation
+        monkeypatch.setattr(vs, "EMBEDDING_MODEL", "base")
+
+        # Main path loads for tier="" -> resolves via the global ("base"
+        # -> qwen3_256) and records the actual loaded identity.
+        resp = server.handle_request({"op": "embed", "texts": ["a", "b"], "tier": ""})
+        assert resp["ok"] is True
+        assert server._embed_model_id == "qwen3_256"
+        assert built[-1] == ("qwen3_256", "cpu"), "sticky degradation must load on CPU"
+
+        # Global drift AFTER the main load: a fresh tier="" resolution would
+        # now pick model2vec — a DIFFERENT vector space. The fast lane must
+        # follow the main path's actual loaded identity instead.
+        monkeypatch.setattr(vs, "EMBEDDING_MODEL", "edge")
+
+        assert server._lock.acquire(timeout=1)  # force the contended branch
+        try:
+            result = server._handle_fast_embed(["hook query"], "")
+        finally:
+            server._lock.release()
+        assert result is not None and result["ok"] is True
+        assert server._fast_model_id == server._embed_model_id == "qwen3_256", (
+            "fast-lane encoder drifted from the main path's loaded model — "
+            "single-text embeddings would silently mismatch the vec table"
+        )
+        assert built[-1] == ("qwen3_256", "cpu")
+
+        main_dim = server._embed_model.encode(["x"]).shape[1]
+        fast_dim = server._fast_encoder.encode(["x"]).shape[1]
+        assert main_dim == fast_dim, "fast-lane embeddings in a different space"
+
+        # Custom model: dim is re-read from config.json at build time, so
+        # parity cannot be guaranteed -> the fast lane must decline and the
+        # request must fall through to the main (locked) path.
+        server._embed_model_id = "acme/custom-encoder"
+        server._embed_tier = "custom"
+        assert server._lock.acquire(timeout=1)
+        try:
+            assert server._handle_fast_embed(["q"], "custom") is None, (
+                "fast lane must decline custom models instead of risking a "
+                "vector-space mismatch"
+            )
+        finally:
+            server._lock.release()
+
+    def test_issue_577_fast_lane_no_global_mutation(self, monkeypatch):
+        """Panel round 1, item 2: the fast lane resolves the model id as a
+        PURE READ — it must never call set_embedding_model, which
+        force-unloads vector_search's model singleton and rewrites
+        EMBEDDING_MODEL/_embedding_dim while the main path may be
+        mid-encode."""
+        import truememory.vector_search as vs
+        from truememory.model_server import ModelServer
+
+        def fake_build(model_id, device):
+            model = MagicMock()
+            model.encode = lambda texts, **kw: np.zeros(
+                (len(texts), 4), dtype=np.float32
+            )
+            return model
+
+        monkeypatch.setattr(
+            ModelServer, "_build_embed_model", staticmethod(fake_build)
+        )
+
+        calls: list[str] = []
+        monkeypatch.setattr(vs, "set_embedding_model", lambda name: calls.append(name))
+        monkeypatch.setattr(vs, "EMBEDDING_MODEL", "edge")
+
+        server = ModelServer()
+        assert server._lock.acquire(timeout=1)  # force the contended branch
+        try:
+            result = server._handle_fast_embed(["q"], "base")
+        finally:
+            server._lock.release()
+        assert result is not None and result["ok"] is True
+        assert calls == [], (
+            "fast lane mutated vector_search globals (set_embedding_model) "
+            "outside the request lock"
+        )
+        assert vs.EMBEDDING_MODEL == "edge"
+
+        # The main (locked) path keeps its historical set_embedding_model
+        # sync — only the fast lane is mutation-free.
+        server2 = ModelServer()
+        resp = server2.handle_request({"op": "embed", "texts": ["a", "b"], "tier": "base"})
+        assert resp["ok"] is True
+        assert calls == ["base"]
+
     def test_issue_577_single_text_uses_main_path_when_idle(self, monkeypatch):
         """With no contention the fast lane uses the main model (no extra
         CPU encoder is loaded)."""

--- a/tests/test_issue_577_model_server_oom.py
+++ b/tests/test_issue_577_model_server_oom.py
@@ -1,0 +1,556 @@
+"""Regression tests for issue #577: model server device override, sticky-CPU
+OOM degradation outside the global lock, rerank OOM handling, single-text
+fast lane, and client deadline differentiation.
+
+Design consensus (7-model panel):
+1. Shared ``resolve_device`` helper honoring ``TRUEMEMORY_DEVICE`` at all
+   load sites (server embed, server reranker, local reranker, throttler).
+2. MPS OOM marks the affected model sticky-CPU for the server's lifetime;
+   the expensive re-encode runs OUTSIDE the global request lock; the model
+   is never re-promoted to MPS.
+3. The rerank path gets the same OOM handler (previously none — raw
+   RuntimeError reached the client, 3/3 rerank deaths in baseline probe).
+4. Single-text encode requests (hook recall) never queue behind batch work.
+5. ``EmbeddingProxy.encode`` / ``RerankerProxy.predict`` accept a per-call
+   ``timeout``; expiry fast-fails with TimeoutError (no autostart retry);
+   hook recall paths set a short process-wide deadline (~5s).
+
+All tests are device-mockable: CI has no MPS/CUDA. MPS OOM is faked with a
+string-matched RuntimeError that satisfies ``mps_utils.is_mps_oom`` (same
+pattern as tests/test_issue_459_mps_oom.py). Thread governor: each test
+spawns at most 2 extra threads.
+"""
+from __future__ import annotations
+
+import socket
+import threading
+import types
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+
+def _make_mps_oom_error():
+    """Create a RuntimeError that looks like an MPS OOM (house pattern)."""
+    return RuntimeError(
+        "MPS backend out of memory (MPS allocated: 2.16 GiB, "
+        "other allocations: 5.69 MiB, max allowed: 1.95 GiB). "
+        "Tried to allocate 3.00 KiB on private pool."
+    )
+
+
+def _fake_sentence_transformers(captured: dict):
+    """Build a fake ``sentence_transformers`` module that records the
+    ``device`` argument passed to CrossEncoder / SentenceTransformer."""
+    mod = types.ModuleType("sentence_transformers")
+
+    class FakeCrossEncoder:
+        def __init__(self, name, device=None, **kwargs):
+            captured["cross_encoder_device"] = device
+            captured["cross_encoder_name"] = name
+
+        def predict(self, pairs, **kwargs):
+            return np.zeros(len(pairs), dtype=np.float32)
+
+    class FakeSentenceTransformer:
+        def __init__(self, name, device=None, **kwargs):
+            captured["st_device"] = device
+            captured["st_name"] = name
+
+        def encode(self, texts, **kwargs):
+            return np.zeros((len(texts), 4), dtype=np.float32)
+
+    mod.CrossEncoder = FakeCrossEncoder
+    mod.SentenceTransformer = FakeSentenceTransformer
+    return mod
+
+
+@pytest.fixture()
+def no_flush(monkeypatch):
+    """Stub out the MPS cache flush so OOM tests never import torch."""
+    from truememory import mps_utils
+    monkeypatch.setattr(mps_utils, "flush_mps_cache", lambda: None)
+
+
+# ---------------------------------------------------------------------------
+# 1. TRUEMEMORY_DEVICE override
+# ---------------------------------------------------------------------------
+
+class TestIssue577DeviceEnvOverride:
+    def test_issue_577_device_env_override_cpu_resolve_helper(self, monkeypatch):
+        """resolve_device honors TRUEMEMORY_DEVICE=cpu regardless of torch."""
+        from truememory.mps_utils import resolve_device
+        monkeypatch.setenv("TRUEMEMORY_DEVICE", "cpu")
+        assert resolve_device("mps") == "cpu"
+        assert resolve_device(None) == "cpu"
+
+    def test_issue_577_device_env_override_unset_uses_default_auto(self, monkeypatch):
+        """Unset / 'auto' returns the caller's default_auto unchanged."""
+        from truememory.mps_utils import resolve_device
+        monkeypatch.delenv("TRUEMEMORY_DEVICE", raising=False)
+        assert resolve_device("mps") == "mps"
+        assert resolve_device(None) is None
+        monkeypatch.setenv("TRUEMEMORY_DEVICE", "auto")
+        assert resolve_device("cuda:0") == "cuda:0"
+
+    def test_issue_577_device_env_override_invalid(self, monkeypatch, caplog):
+        """Invalid TRUEMEMORY_DEVICE warns and falls back to default_auto."""
+        from truememory.mps_utils import resolve_device
+        monkeypatch.setenv("TRUEMEMORY_DEVICE", "tpu")
+        with caplog.at_level("WARNING", logger="truememory.mps_utils"):
+            assert resolve_device("mps") == "mps"
+        assert any("TRUEMEMORY_DEVICE" in r.message for r in caplog.records), (
+            "invalid TRUEMEMORY_DEVICE value must log a warning"
+        )
+
+    def test_issue_577_device_env_override_cpu_server_reranker(self, monkeypatch):
+        """The server reranker load site honors TRUEMEMORY_DEVICE=cpu."""
+        import sys
+        from truememory.model_server import ModelServer
+
+        captured: dict = {}
+        monkeypatch.setitem(
+            sys.modules, "sentence_transformers", _fake_sentence_transformers(captured)
+        )
+        monkeypatch.setenv("TRUEMEMORY_DEVICE", "cpu")
+
+        server = ModelServer()
+        server._get_reranker("test-model")
+        assert captured["cross_encoder_device"] == "cpu"
+
+    def test_issue_577_device_env_override_cpu_server_embed(self, monkeypatch):
+        """The server embed load site passes the resolved device through."""
+        import sys
+        from truememory.model_server import ModelServer
+
+        captured: dict = {}
+        monkeypatch.setitem(
+            sys.modules, "sentence_transformers", _fake_sentence_transformers(captured)
+        )
+        server = ModelServer()
+
+        # No override and no sticky degradation: framework picks (device=None).
+        monkeypatch.delenv("TRUEMEMORY_DEVICE", raising=False)
+        assert server._embed_device() is None
+        server._build_embed_model("qwen3_256", server._embed_device())
+        assert captured["st_device"] is None
+
+        # Env override is honored at load time.
+        monkeypatch.setenv("TRUEMEMORY_DEVICE", "cpu")
+        assert server._embed_device() == "cpu"
+        server._build_embed_model("qwen3_256", server._embed_device())
+        assert captured["st_device"] == "cpu"
+
+        # Sticky-CPU degradation wins even over the env var.
+        monkeypatch.setenv("TRUEMEMORY_DEVICE", "mps")
+        server._sticky_cpu.add("embed")
+        assert server._embed_device() == "cpu"
+
+    def test_issue_577_device_env_override_cpu_local_reranker(self, monkeypatch):
+        """reranker.get_reranker local fallback honors TRUEMEMORY_DEVICE=cpu."""
+        import sys
+        from truememory import reranker
+
+        captured: dict = {}
+        monkeypatch.setitem(
+            sys.modules, "sentence_transformers", _fake_sentence_transformers(captured)
+        )
+        monkeypatch.setenv("TRUEMEMORY_DEVICE", "cpu")
+        monkeypatch.setenv("TRUEMEMORY_NO_MODEL_SERVER", "1")
+        monkeypatch.setattr(reranker, "_model", None)
+        monkeypatch.setattr(reranker, "_model_name", "")
+
+        model = reranker.get_reranker(model_name="test-model")
+        assert captured["cross_encoder_device"] == "cpu"
+        assert model is not None
+
+        # Explicit device= parameter takes precedence over the env var.
+        monkeypatch.setattr(reranker, "_model", None)
+        monkeypatch.setattr(reranker, "_model_name", "")
+        monkeypatch.setenv("TRUEMEMORY_DEVICE", "cpu")
+        reranker.get_reranker(model_name="other-model", device="mps")
+        assert captured["cross_encoder_device"] == "mps"
+
+    def test_issue_577_device_env_override_cpu_throttler(self, monkeypatch):
+        """The throttler's device pick honors TRUEMEMORY_DEVICE=cpu."""
+        from truememory.model_server import ModelServer
+        from truememory.tier_switch import throttler as throttler_mod
+
+        class FakeThrottler:
+            def __init__(self, device="cpu"):
+                self.device = device
+
+        monkeypatch.setattr(throttler_mod, "DynamicThrottler", FakeThrottler)
+        monkeypatch.setenv("TRUEMEMORY_DEVICE", "cpu")
+
+        server = ModelServer()
+        server._activate_throttler()
+        assert server._throttler is not None
+        assert server._throttler.device == "cpu"
+
+        # Sticky-CPU embed degradation also forces the throttler to CPU.
+        server2 = ModelServer()
+        monkeypatch.delenv("TRUEMEMORY_DEVICE", raising=False)
+        server2._sticky_cpu.add("embed")
+        server2._activate_throttler()
+        assert server2._throttler.device == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# 2. Sticky-CPU OOM degradation (embed path)
+# ---------------------------------------------------------------------------
+
+class TestIssue577StickyCpuOom:
+    def test_issue_577_oom_marks_sticky_cpu(self, no_flush, caplog):
+        """MPS OOM moves the model to CPU permanently: no MPS re-promotion,
+        loud log exactly once."""
+        from truememory.model_server import ModelServer
+
+        server = ModelServer()
+        to_calls: list[str] = []
+        encode_calls: list[int] = []
+
+        def encode(texts, **kwargs):
+            encode_calls.append(len(texts))
+            # OOM on the 1st and 3rd encode attempts (3rd = 2nd request).
+            if len(encode_calls) in (1, 3):
+                raise _make_mps_oom_error()
+            return np.zeros((len(texts), 4), dtype=np.float32)
+
+        model = MagicMock()
+        model.encode = encode
+        model.to = lambda device: to_calls.append(device)
+        server._embed_model = model
+        server._embed_tier = ""
+
+        req = {"op": "embed", "texts": ["a", "b"], "tier": ""}
+        with caplog.at_level("ERROR", logger="truememory.model_server"):
+            resp = server.handle_request(req)
+        assert resp["ok"] is True
+        assert "embed" in server._sticky_cpu
+        assert to_calls == ["cpu"], "model must move to CPU and NEVER back to MPS"
+        sticky_logs = [r for r in caplog.records if "CPU" in r.message]
+        assert len(sticky_logs) == 1, "sticky degradation must log loudly once"
+
+        # Second OOM: still recovers, never re-promotes, no second loud log.
+        caplog.clear()
+        with caplog.at_level("ERROR", logger="truememory.model_server"):
+            resp2 = server.handle_request(req)
+        assert resp2["ok"] is True
+        assert "mps" not in to_calls, "no re-promotion to MPS after recovery"
+        assert all(d == "cpu" for d in to_calls)
+        assert not [r for r in caplog.records if r.levelname == "ERROR"], (
+            "sticky degradation must only be logged on the first OOM"
+        )
+
+    def test_issue_577_oom_retry_not_under_lock(self, no_flush):
+        """The CPU re-encode after an MPS OOM must not hold the global lock:
+        another thread can acquire it while recovery is in progress."""
+        from truememory.model_server import ModelServer
+
+        server = ModelServer()
+        retry_started = threading.Event()
+        release_retry = threading.Event()
+        calls: list[int] = []
+
+        def encode(texts, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                raise _make_mps_oom_error()
+            retry_started.set()
+            assert release_retry.wait(10), "test deadlock: retry never released"
+            return np.zeros((len(texts), 4), dtype=np.float32)
+
+        model = MagicMock()
+        model.encode = encode
+        server._embed_model = model
+        server._embed_tier = ""
+
+        results: list[dict] = []
+        t = threading.Thread(
+            target=lambda: results.append(
+                server.handle_request({"op": "embed", "texts": ["a", "b"], "tier": ""})
+            ),
+            daemon=True,
+        )
+        t.start()
+        assert retry_started.wait(10), "OOM retry never started"
+
+        acquired = server._lock.acquire(timeout=2)
+        try:
+            assert acquired, (
+                "global request lock held during OOM recovery — every other "
+                "client (hook recall, rerank) starves behind the re-encode"
+            )
+        finally:
+            if acquired:
+                server._lock.release()
+
+        release_retry.set()
+        t.join(10)
+        assert results and results[0]["ok"] is True
+
+    def test_issue_577_non_oom_error_still_propagates(self, no_flush):
+        """Non-MPS RuntimeErrors must not be swallowed by the sticky handler."""
+        from truememory.model_server import ModelServer
+
+        server = ModelServer()
+        model = MagicMock()
+        model.encode = MagicMock(
+            side_effect=RuntimeError("CUDA error: device-side assert triggered")
+        )
+        server._embed_model = model
+        server._embed_tier = ""
+
+        with pytest.raises(RuntimeError, match="CUDA"):
+            server.handle_request({"op": "embed", "texts": ["a", "b"], "tier": ""})
+        assert "embed" not in server._sticky_cpu
+
+
+# ---------------------------------------------------------------------------
+# 3. Rerank path OOM handling
+# ---------------------------------------------------------------------------
+
+class TestIssue577RerankOom:
+    def test_issue_577_rerank_oom_handled(self, no_flush, monkeypatch):
+        """MPS OOM in rerank must not reach the client: sticky-CPU reload
+        produces a real score response (baseline: 3/3 rerank deaths)."""
+        from truememory.model_server import ModelServer
+
+        class FakeReranker:
+            def __init__(self, fail):
+                self.fail = fail
+
+            def predict(self, pairs, **kwargs):
+                if self.fail:
+                    raise _make_mps_oom_error()
+                return np.full(len(pairs), 0.5, dtype=np.float32)
+
+        def fake_get_reranker(self, model_name=None):
+            # Before sticky degradation the loaded model is on MPS and OOMs;
+            # after, the reload is CPU-resident and succeeds.
+            return FakeReranker(fail="rerank" not in self._sticky_cpu)
+
+        monkeypatch.setattr(ModelServer, "_get_reranker", fake_get_reranker)
+        server = ModelServer()
+
+        resp = server.handle_request(
+            {"op": "rerank", "pairs": [["q", "d1"], ["q", "d2"]], "model_name": "m"}
+        )
+        assert resp["ok"] is True, "rerank OOM must be recovered, not surfaced"
+        assert len(resp["scores"]) == 2
+        assert "rerank" in server._sticky_cpu
+
+    def test_issue_577_rerank_sticky_reloads_on_cpu(self, monkeypatch):
+        """After sticky degradation, _get_reranker loads with device=cpu even
+        if TRUEMEMORY_DEVICE requests an accelerator."""
+        import sys
+        from truememory.model_server import ModelServer
+
+        captured: dict = {}
+        monkeypatch.setitem(
+            sys.modules, "sentence_transformers", _fake_sentence_transformers(captured)
+        )
+        monkeypatch.setenv("TRUEMEMORY_DEVICE", "cpu")
+
+        server = ModelServer()
+        server._sticky_cpu.add("rerank")
+        server._get_reranker("test-model")
+        assert captured["cross_encoder_device"] == "cpu"
+
+    def test_issue_577_rerank_non_oom_error_propagates(self, no_flush, monkeypatch):
+        """Non-OOM rerank errors keep the existing propagate-to-client path."""
+        from truememory.model_server import ModelServer
+
+        broken = MagicMock()
+        broken.predict = MagicMock(side_effect=RuntimeError("tokenizer exploded"))
+        monkeypatch.setattr(
+            ModelServer, "_get_reranker", lambda self, model_name=None: broken
+        )
+        server = ModelServer()
+        with pytest.raises(RuntimeError, match="tokenizer"):
+            server.handle_request({"op": "rerank", "pairs": [["q", "d"]], "model_name": "m"})
+        assert "rerank" not in server._sticky_cpu
+
+
+# ---------------------------------------------------------------------------
+# 4. Single-text fast lane
+# ---------------------------------------------------------------------------
+
+class TestIssue577FastLane:
+    def test_issue_577_single_text_fast_lane(self, monkeypatch):
+        """A single-text encode (hook recall) completes while a batch holds
+        the global lock, and never trips the sustained-workload throttler."""
+        from truememory.model_server import ModelServer
+
+        server = ModelServer()
+
+        main_model = MagicMock()
+        main_model.encode = MagicMock(
+            side_effect=AssertionError(
+                "fast lane must not use the locked main model while a batch runs"
+            )
+        )
+        server._embed_model = main_model
+        server._embed_tier = ""
+
+        fast_calls: list[list[str]] = []
+
+        class FakeFastEncoder:
+            def encode(self, texts, **kwargs):
+                fast_calls.append(list(texts))
+                return np.zeros((len(texts), 4), dtype=np.float32)
+
+        monkeypatch.setattr(
+            ModelServer, "_get_fast_encoder", lambda self, tier: FakeFastEncoder()
+        )
+
+        # Simulate an in-flight ingestion batch occupying the heavy path.
+        assert server._lock.acquire(timeout=1)
+        try:
+            result: dict = {}
+            t = threading.Thread(
+                target=lambda: result.update(
+                    server.handle_request(
+                        {"op": "embed", "texts": ["hook recall query"], "tier": ""}
+                    )
+                ),
+                daemon=True,
+            )
+            t.start()
+            t.join(5)
+            assert not t.is_alive(), (
+                "single-text request queued behind the batch lock — hook "
+                "recall starves behind ingestion (issue #577)"
+            )
+            assert result.get("ok") is True
+            assert fast_calls == [["hook recall query"]]
+            assert server._embed_timestamps == [], (
+                "fast-lane requests must not feed the sustained-workload "
+                "throttler (C-7: hook bursts tripped batch=1 ramp)"
+            )
+        finally:
+            server._lock.release()
+
+    def test_issue_577_single_text_uses_main_path_when_idle(self, monkeypatch):
+        """With no contention the fast lane uses the main model (no extra
+        CPU encoder is loaded)."""
+        from truememory.model_server import ModelServer
+
+        server = ModelServer()
+        main_model = MagicMock()
+        main_model.encode = MagicMock(
+            return_value=np.ones((1, 4), dtype=np.float32)
+        )
+        server._embed_model = main_model
+        server._embed_tier = ""
+
+        resp = server.handle_request({"op": "embed", "texts": ["q"], "tier": ""})
+        assert resp["ok"] is True
+        assert main_model.encode.called
+        assert server._fast_encoder is None, (
+            "idle single-text requests must not pay for a duplicate CPU encoder"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Client deadline kwarg + hook wiring
+# ---------------------------------------------------------------------------
+
+class TestIssue577ClientDeadline:
+    def test_issue_577_client_deadline_kwarg(self, monkeypatch):
+        """encode/predict accept timeout=; expiry fast-fails with TimeoutError
+        and never falls into the autostart + full-timeout retry cycle."""
+        from truememory import model_client
+
+        send_calls: list[float | None] = []
+
+        def fake_send(request, timeout=None):
+            send_calls.append(timeout)
+            raise socket.timeout("timed out")
+
+        def forbidden_start(wait_timeout=None):
+            raise AssertionError("autostart must not run after deadline expiry")
+
+        monkeypatch.setattr(model_client, "_send_request", fake_send)
+        monkeypatch.setattr(model_client, "_start_server", forbidden_start)
+
+        with pytest.raises(TimeoutError, match="deadline"):
+            model_client.EmbeddingProxy().encode(["q"], timeout=0.05)
+        assert send_calls == [0.05], "per-call timeout must reach the socket layer"
+
+        with pytest.raises(TimeoutError, match="deadline"):
+            model_client.RerankerProxy().predict([("q", "d")], timeout=0.05)
+
+    def test_issue_577_client_default_timeout_unchanged(self, monkeypatch):
+        """timeout=None keeps the legacy 120s default + autostart retry."""
+        from truememory import model_client
+
+        assert model_client._REQUEST_TIMEOUT == 120.0
+
+        attempts: list[int] = []
+
+        def flaky_send(request, timeout=None):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise socket.timeout("timed out")
+            return {"ok": True, "vectors": np.zeros((1, 4), dtype=np.float32)}
+
+        monkeypatch.setattr(model_client, "_send_request", flaky_send)
+        monkeypatch.setattr(model_client, "_start_server", lambda wait_timeout=None: True)
+
+        out = model_client.EmbeddingProxy().encode(["q"])
+        assert out.shape == (1, 4)
+        assert len(attempts) == 2, "legacy path must still autostart + retry"
+
+    def test_issue_577_process_default_deadline(self, monkeypatch):
+        """set_request_timeout() gives hook processes a short deadline for
+        every embed/rerank without threading kwargs through engine.search."""
+        from truememory import model_client
+
+        def fake_send(request, timeout=None):
+            raise socket.timeout("timed out")
+
+        monkeypatch.setattr(model_client, "_send_request", fake_send)
+        monkeypatch.setattr(
+            model_client,
+            "_start_server",
+            lambda wait_timeout=None: pytest.fail("autostart after deadline expiry"),
+        )
+
+        model_client.set_request_timeout(0.05)
+        try:
+            with pytest.raises(TimeoutError, match="deadline"):
+                model_client.EmbeddingProxy().encode(["q"])
+        finally:
+            model_client.set_request_timeout(None)
+
+    def test_issue_577_hooks_pass_short_deadline(self, monkeypatch):
+        """Hook recall paths arm the ~5s deadline so FTS-only fallback can
+        actually trigger (C-1: worst case was 5 x 120s)."""
+        import inspect
+
+        from truememory.ingest.hooks import _shared, session_start, user_prompt_submit
+
+        assert _shared.get_recall_deadline() == 5.0
+        monkeypatch.setenv("TRUEMEMORY_HOOK_RECALL_TIMEOUT", "2.5")
+        assert _shared.get_recall_deadline() == 2.5
+        monkeypatch.setenv("TRUEMEMORY_HOOK_RECALL_TIMEOUT", "0")
+        assert _shared.get_recall_deadline() is None  # 0/negative disables
+        monkeypatch.setenv("TRUEMEMORY_HOOK_RECALL_TIMEOUT", "banana")
+        assert _shared.get_recall_deadline() == 5.0
+
+        recall_src = inspect.getsource(session_start.recall_memories)
+        assert "set_request_timeout" in recall_src, (
+            "session_start recall must arm the short model-server deadline"
+        )
+        ups_src = inspect.getsource(user_prompt_submit._try_auto_recall)
+        assert "set_request_timeout" in ups_src, (
+            "user_prompt_submit auto-recall must arm the short deadline"
+        )
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -35,6 +35,28 @@ except ValueError:
     _RECALL_DEBOUNCE_SECONDS = 60.0
 
 
+def get_recall_deadline() -> float | None:
+    """Per-request model-server deadline for hook recall searches (#577).
+
+    Hooks block on the shared model server; under contention (batch
+    ingestion, MPS OOM recovery) a single embed could previously stall for
+    the full 120s client timeout. Recall paths arm this short deadline via
+    ``model_client.set_request_timeout`` so embeds fast-fail and the
+    engine's FTS-only fallback actually triggers.
+
+    Configured by ``TRUEMEMORY_HOOK_RECALL_TIMEOUT`` (seconds, default 5).
+    ``0`` or negative disables the deadline (legacy 120s behavior); a
+    malformed value falls back to the default instead of crashing the hook.
+    """
+    try:
+        deadline = float(os.environ.get("TRUEMEMORY_HOOK_RECALL_TIMEOUT", "5"))
+    except ValueError:
+        return 5.0
+    if deadline <= 0:
+        return None
+    return deadline
+
+
 def _safe_session_id(session_id: str) -> str:
     """Sanitize session_id to prevent path traversal."""
     return "".join(c for c in session_id if c.isalnum() or c in "-_")[:64]

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -466,6 +466,18 @@ def recall_memories(input_data: dict, user_id: str = "", db_path: str = "") -> s
     except ImportError:
         return ""
 
+    # Issue #577: arm a short per-request deadline for every model-server
+    # call this hook makes. Under server contention (batch ingestion / MPS
+    # OOM recovery) embeds previously stalled up to 120s each (5 serial
+    # searches = 10 min worst case); with the deadline they fast-fail and
+    # engine.search falls back to FTS-only retrieval.
+    try:
+        from truememory.ingest.hooks._shared import get_recall_deadline
+        from truememory.model_client import set_request_timeout
+        set_request_timeout(get_recall_deadline())
+    except Exception:
+        pass
+
     db = db_path or None
     memory = Memory(path=db) if db else Memory()
 

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -145,6 +145,15 @@ def _try_auto_recall(prompt: str, user_id: str, db_path: str, session_id: str = 
     if not _detect_recall(prompt):
         return None
     try:
+        # Issue #577: short model-server deadline so a contended server
+        # fast-fails and the search falls back to FTS-only instead of
+        # stalling this hook for up to 120s.
+        try:
+            from truememory.ingest.hooks._shared import get_recall_deadline
+            from truememory.model_client import set_request_timeout
+            set_request_timeout(get_recall_deadline())
+        except Exception:
+            pass
         from truememory.client import Memory
         m = Memory(path=db_path or None)
         results = m.search(prompt, user_id=user_id or None, limit=5)

--- a/truememory/model_client.py
+++ b/truememory/model_client.py
@@ -48,6 +48,24 @@ _MAX_MESSAGE_SIZE = 10 * 1024 * 1024  # 10 MB
 _SERVER_START_TIMEOUT = 30.0
 _REQUEST_TIMEOUT = 120.0
 
+# Issue #577: process-wide deadline override for model-server requests.
+# None keeps the legacy 120s default. Latency-sensitive processes (Claude
+# Code hooks) set a short deadline via set_request_timeout() so a contended
+# server fast-fails and the caller's FTS-only fallback can trigger.
+_default_request_timeout: float | None = None
+
+
+def set_request_timeout(timeout: float | None) -> None:
+    """Set a process-wide deadline (seconds) for model-server requests.
+
+    When set, every request issued by this process without an explicit
+    per-call ``timeout=`` fast-fails with :class:`TimeoutError` once the
+    deadline expires, instead of absorbing the full autostart + retry
+    cycle. Pass ``None`` to restore the legacy 120s behavior.
+    """
+    global _default_request_timeout
+    _default_request_timeout = timeout
+
 
 def _json_object_hook(obj):
     """Decode base64-encoded numpy arrays from JSON."""
@@ -182,8 +200,15 @@ def _server_ready() -> bool:
     return PORT_PATH.exists() and TOKEN_PATH.exists()
 
 
-def _start_server() -> bool:
-    """Start the model server as a detached subprocess."""
+def _start_server(wait_timeout: float | None = None) -> bool:
+    """Start the model server as a detached subprocess.
+
+    *wait_timeout* caps how long to wait for the spawned server to become
+    ready (defaults to ``_SERVER_START_TIMEOUT``). Deadline-bound callers
+    (issue #577) pass their remaining budget: the spawn still happens, so
+    the server warms up for subsequent requests even when this call
+    returns False.
+    """
     if os.environ.get("TRUEMEMORY_NO_MODEL_SERVER", "") == "1":
         return False
     _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
@@ -242,22 +267,26 @@ def _start_server() -> bool:
         else:
             return False
 
-    deadline = time.time() + _SERVER_START_TIMEOUT
+    wait = _SERVER_START_TIMEOUT
+    if wait_timeout is not None:
+        wait = min(wait, max(wait_timeout, 0.0))
+    deadline = time.time() + wait
     while time.time() < deadline:
         if _server_ready():
             time.sleep(0.2)
             return True
         time.sleep(0.1)
 
-    log.warning("Model server did not start within %.0fs", _SERVER_START_TIMEOUT)
+    log.warning("Model server did not start within %.0fs", wait)
     return False
 
 
-def _connect() -> socket.socket:
+def _connect(timeout: float | None = None) -> socket.socket:
     """Open a connection to the model server (Unix or TCP)."""
+    request_timeout = _REQUEST_TIMEOUT if timeout is None else timeout
     if _USE_UNIX:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(_REQUEST_TIMEOUT)
+        sock.settimeout(request_timeout)
         try:
             sock.connect(str(SOCK_PATH))
         except OSError:
@@ -274,7 +303,7 @@ def _connect() -> socket.socket:
         raise ConnectionError("Model server token file not found")
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.settimeout(_REQUEST_TIMEOUT)
+    sock.settimeout(request_timeout)
     try:
         sock.connect((_LOOPBACK_HOST, port))
         sock.sendall(token)
@@ -284,9 +313,9 @@ def _connect() -> socket.socket:
     return sock
 
 
-def _send_request(request: dict) -> dict:
+def _send_request(request: dict, timeout: float | None = None) -> dict:
     """Send a request to the model server and return the response."""
-    sock = _connect()
+    sock = _connect(timeout)
     try:
         data = json.dumps(request).encode("utf-8")
         header = struct.pack(_HEADER_FMT, len(data))
@@ -316,15 +345,54 @@ def _recv_exact(sock: socket.socket, n: int) -> bytes | None:
     return bytes(buf)
 
 
-def _request_with_autostart(request: dict) -> dict:
-    """Send request, auto-starting server if needed."""
+def _deadline_error(timeout: float) -> TimeoutError:
+    return TimeoutError(
+        f"Model server request exceeded {timeout:.1f}s deadline"
+    )
+
+
+def _request_with_autostart(request: dict, timeout: float | None = None) -> dict:
+    """Send request, auto-starting server if needed.
+
+    *timeout* is a per-request deadline in seconds; ``None`` uses the
+    process default (see :func:`set_request_timeout`, issue #577) which in
+    turn defaults to the legacy ``_REQUEST_TIMEOUT``. When a deadline is in
+    effect, expiry raises :class:`TimeoutError` immediately (fast-fail)
+    instead of silently absorbing the autostart + full-timeout retry cycle —
+    deadline-bound callers (hook recall) have their own FTS-only fallback.
+    """
+    if timeout is None:
+        timeout = _default_request_timeout
+    has_deadline = timeout is not None
+    started = time.monotonic()
+
     try:
-        return _send_request(request)
-    except (ConnectionRefusedError, FileNotFoundError, socket.timeout, OSError):
+        return _send_request(request, timeout=timeout)
+    except TimeoutError:
+        # socket.timeout is TimeoutError on Python >= 3.10.
+        if has_deadline:
+            raise _deadline_error(timeout) from None
+        # Legacy path (no deadline): fall through to autostart + retry.
+    except (ConnectionRefusedError, FileNotFoundError, OSError):
         pass
 
-    if not _start_server():
+    remaining: float | None = None
+    if has_deadline:
+        remaining = timeout - (time.monotonic() - started)
+        if remaining <= 0:
+            raise _deadline_error(timeout)
+
+    if not _start_server(wait_timeout=remaining):
         raise ConnectionError("Cannot start model server")
+
+    if has_deadline:
+        remaining = timeout - (time.monotonic() - started)
+        if remaining <= 0:
+            raise _deadline_error(timeout)
+        try:
+            return _send_request(request, timeout=remaining)
+        except TimeoutError:
+            raise _deadline_error(timeout) from None
 
     return _send_request(request)
 
@@ -335,14 +403,20 @@ class EmbeddingProxy:
     def __init__(self, tier: str = ""):
         self._tier = tier
 
-    def encode(self, texts, **kwargs) -> np.ndarray:
+    def encode(self, texts, timeout: float | None = None, **kwargs) -> np.ndarray:
+        """Embed *texts* via the model server.
+
+        *timeout* is an optional per-call deadline in seconds (issue #577);
+        on expiry a :class:`TimeoutError` is raised (fast-fail, no autostart
+        retry). ``None`` uses the process default / legacy 120s.
+        """
         if isinstance(texts, str):
             texts = [texts]
         resp = _request_with_autostart({
             "op": "embed",
             "texts": list(texts),
             "tier": self._tier,
-        })
+        }, timeout=timeout)
         if not resp.get("ok"):
             raise RuntimeError(f"Model server error: {resp.get('error', 'unknown')}")
         return resp["vectors"]
@@ -354,12 +428,17 @@ class RerankerProxy:
     def __init__(self, model_name: str | None = None):
         self._model_name = model_name
 
-    def predict(self, pairs, **kwargs) -> np.ndarray:
+    def predict(self, pairs, timeout: float | None = None, **kwargs) -> np.ndarray:
+        """Rerank *pairs* via the model server.
+
+        *timeout* is an optional per-call deadline in seconds (issue #577);
+        see :meth:`EmbeddingProxy.encode`.
+        """
         resp = _request_with_autostart({
             "op": "rerank",
             "pairs": list(pairs),
             "model_name": self._model_name,
-        })
+        }, timeout=timeout)
         if not resp.get("ok"):
             raise RuntimeError(f"Model server error: {resp.get('error', 'unknown')}")
         return resp["scores"]

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -118,6 +118,9 @@ class ModelServer:
     def __init__(self):
         self._embed_model = None
         self._embed_tier: str | None = None
+        # Actual loaded model identity (e.g. "qwen3_256") — the fast lane
+        # derives its encoder from this, not from tier defaults (issue #577).
+        self._embed_model_id: str | None = None
         self._reranker = None
         self._reranker_name: str | None = None
         self._lock = threading.Lock()
@@ -138,8 +141,10 @@ class ModelServer:
         self._sticky_cpu: set[str] = set()
         # Issue #577: dedicated CPU encoder for the single-text fast lane,
         # loaded lazily on the first *contended* single-text request.
+        # Cached by MODEL ID (not tier string) so it always tracks the main
+        # path's actual loaded identity.
         self._fast_encoder = None
-        self._fast_tier: str | None = None
+        self._fast_model_id: str | None = None
         self._fast_lock = threading.Lock()
 
     def _mark_sticky_cpu(self, kind: str) -> bool:
@@ -172,17 +177,17 @@ class ModelServer:
         return resolve_device(None)
 
     @staticmethod
-    def _resolve_embed_model_id(tier: str) -> str:
-        """Resolve a tier name to the internal embedding model ID."""
-        from truememory.vector_search import EMBEDDING_MODEL, set_embedding_model
-
-        if tier and tier != EMBEDDING_MODEL:
-            set_embedding_model(tier)
+    def _peek_embed_model_id(tier: str) -> str:
+        """Resolve a tier name to the internal embedding model ID as a PURE
+        READ — no mutation of vector_search globals (issue #577 panel: the
+        fast lane must never call ``set_embedding_model``, which force-unloads
+        the process-local model singleton and rewrites ``EMBEDDING_MODEL`` /
+        ``_embedding_dim`` while the main path may be mid-encode)."""
+        from truememory.vector_search import EMBEDDING_MODEL, _TIER_ALIASES
 
         resolved = EMBEDDING_MODEL if not tier else tier
         # Resolve tier -> internal model ID via centralized tier_config.
         # _TIER_ALIASES is still exported by vector_search for compat.
-        from truememory.vector_search import _TIER_ALIASES
         model_id = _TIER_ALIASES.get(resolved, resolved)
 
         # Custom tier: resolve via tier_config
@@ -194,6 +199,17 @@ class ModelServer:
                 log.warning("Custom tier resolution failed (%s); falling back to model2vec.", e)
                 model_id = "model2vec"
         return model_id
+
+    @staticmethod
+    def _resolve_embed_model_id(tier: str) -> str:
+        """Resolve a tier name to the internal embedding model ID, keeping
+        vector_search's globals in sync (main-path behavior, pre-#577)."""
+        from truememory.vector_search import EMBEDDING_MODEL, set_embedding_model
+
+        if tier and tier != EMBEDDING_MODEL:
+            set_embedding_model(tier)
+
+        return ModelServer._peek_embed_model_id(tier)
 
     @staticmethod
     def _build_embed_model(model_id: str, device: str | None):
@@ -242,12 +258,27 @@ class ModelServer:
             "minishlab/potion-base-8M", force_download=False
         )
 
+    # Model IDs the fast lane can rebuild with guaranteed vector-space
+    # parity: _build_embed_model constructs them deterministically with a
+    # fixed dim and no config reads. Custom models re-read config.json at
+    # build time, so a config change between the main load and the fast
+    # load could silently change the embedding dim/space — the fast lane
+    # declines those and falls through to the main path.
+    _FAST_LANE_SAFE_MODEL_IDS = frozenset(
+        {"model2vec", "minilm", "bge-small", "qwen3_256"}
+    )
+
     def _get_embed_model(self, tier: str):
         if self._embed_model is not None and self._embed_tier == tier:
             return self._embed_model
 
         model_id = self._resolve_embed_model_id(tier)
-        self._embed_model = self._build_embed_model(model_id, self._embed_device())
+        model = self._build_embed_model(model_id, self._embed_device())
+        # Write order matters for the fast lane's lock-free reads:
+        # _embed_tier is written LAST, so a matching tier implies the model
+        # and its identity are already in place.
+        self._embed_model = model
+        self._embed_model_id = model_id
         self._embed_tier = tier
         log.info("Loaded embedding model for tier=%s", tier)
         return self._embed_model
@@ -258,16 +289,36 @@ class ModelServer:
         Loaded lazily on the first single-text request that finds the global
         lock busy, then kept for the server's lifetime. Caller must hold
         ``self._fast_lock``.
+
+        Vector-space parity (issue #577 panel round 1): when the main path
+        already has a model loaded for this tier, the fast encoder is built
+        from the main path's ACTUAL loaded model identity — not from a fresh
+        tier resolution, which could drift for tier="" requests if the
+        global ``EMBEDDING_MODEL`` changed after the main load (the main
+        cache is keyed by tier string, not model ID). Returns ``None`` when
+        parity cannot be guaranteed (custom models); the caller falls
+        through to the main (locked) path.
         """
-        if self._fast_encoder is not None and self._fast_tier == tier:
+        if (
+            self._embed_model is not None
+            and self._embed_tier == tier
+            and self._embed_model_id
+        ):
+            model_id = self._embed_model_id
+        else:
+            model_id = self._peek_embed_model_id(tier)
+
+        if model_id not in self._FAST_LANE_SAFE_MODEL_IDS:
+            return None
+
+        if self._fast_encoder is not None and self._fast_model_id == model_id:
             return self._fast_encoder
 
-        model_id = self._resolve_embed_model_id(tier)
         self._fast_encoder = self._build_embed_model(model_id, "cpu")
-        self._fast_tier = tier
+        self._fast_model_id = model_id
         log.info(
-            "Fast-lane CPU encoder loaded (tier=%s) — single-text requests "
-            "no longer queue behind batch work", tier,
+            "Fast-lane CPU encoder loaded (tier=%s, model=%s) — single-text "
+            "requests no longer queue behind batch work", tier, model_id,
         )
         return self._fast_encoder
 
@@ -325,6 +376,10 @@ class ModelServer:
         try:
             with self._fast_lock:
                 model = self._get_fast_encoder(tier)
+                if model is None:
+                    # Vector-space parity with the main path cannot be
+                    # guaranteed (custom model) — decline the fast lane.
+                    return None
                 vectors = model.encode(texts, show_progress_bar=False)
             return {"ok": True, "vectors": np.asarray(vectors, dtype=np.float32)}
         except Exception:
@@ -431,14 +486,16 @@ class ModelServer:
                     # handler — a raw MPS OOM reached the client (3/3 rerank
                     # deaths in the baseline probe). Same sticky-CPU policy
                     # as embed: drop the MPS-loaded model and reload on CPU.
+                    # Mark + reload happen ATOMICALLY under this same lock
+                    # hold so the retry below always runs on the locally
+                    # reloaded CPU instance (panel round 1, item 1).
                     self._mark_sticky_cpu("rerank")
                     flush_mps_cache()
                     self._reranker = None
                     self._reranker_name = None
+                    reranker = self._get_reranker(model_name)  # sticky → CPU
                     oom = True
             if oom:
-                with self._lock:
-                    reranker = self._get_reranker(model_name)  # sticky → CPU
                 # Retry outside the lock — rerank batches are the expensive
                 # part; other clients must not starve behind the recovery.
                 scores = reranker.predict(

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -117,6 +117,10 @@ class ModelServer:
         self._reranker = None
         self._reranker_name: str | None = None
         self._lock = threading.Lock()
+        # Issue #577: idle-tracking gets its own lock so the single-text
+        # fast lane (and the idle checker) never block on the global
+        # request lock while a batch encode is in flight.
+        self._activity_lock = threading.Lock()
         self._last_activity = time.time()
         self._running = True
         self._embed_timestamps: list[float] = []
@@ -124,11 +128,43 @@ class ModelServer:
         self._throttler_active = False
         self._token: bytes | None = None  # HMAC token for TCP transport
         self._bound_port: int | None = None  # TCP port (Windows only)
+        # Issue #577: models that hit an MPS OOM are degraded to CPU for the
+        # lifetime of this server process ("embed" / "rerank"). Mutated only
+        # while holding self._lock; read lock-free (string membership).
+        self._sticky_cpu: set[str] = set()
 
-    def _get_embed_model(self, tier: str):
-        if self._embed_model is not None and self._embed_tier == tier:
-            return self._embed_model
+    def _mark_sticky_cpu(self, kind: str) -> bool:
+        """Permanently degrade *kind* ("embed"/"rerank") to CPU after an
+        MPS OOM (issue #577). Re-promoting to MPS after recovery guaranteed
+        the next OOM (the pool never drops below the watermark cap), so the
+        degradation is sticky for the server's lifetime.
 
+        Caller must hold ``self._lock``. Returns True on the first marking
+        (which is logged loudly, once).
+        """
+        if kind in self._sticky_cpu:
+            return False
+        self._sticky_cpu.add(kind)
+        log.error(
+            "MPS OOM in the %s path — degrading the %s model to CPU for the "
+            "lifetime of this model server (no MPS re-promotion). Restart "
+            "the server to try MPS again, or set TRUEMEMORY_DEVICE=cpu to "
+            "make CPU permanent.",
+            kind, kind,
+        )
+        return True
+
+    def _embed_device(self) -> str | None:
+        """Device for embed model loads: sticky-CPU > TRUEMEMORY_DEVICE >
+        framework auto-selection (None)."""
+        if "embed" in self._sticky_cpu:
+            return "cpu"
+        from truememory.mps_utils import resolve_device
+        return resolve_device(None)
+
+    @staticmethod
+    def _resolve_embed_model_id(tier: str) -> str:
+        """Resolve a tier name to the internal embedding model ID."""
         from truememory.vector_search import EMBEDDING_MODEL, set_embedding_model
 
         if tier and tier != EMBEDDING_MODEL:
@@ -148,23 +184,29 @@ class ModelServer:
             except (ValueError, ImportError) as e:
                 log.warning("Custom tier resolution failed (%s); falling back to model2vec.", e)
                 model_id = "model2vec"
+        return model_id
 
+    @staticmethod
+    def _build_embed_model(model_id: str, device: str | None):
+        """Construct an embedding model. ``device=None`` lets the framework
+        pick (SentenceTransformer auto-selects; model2vec is CPU-only)."""
         if model_id == "model2vec":
             from model2vec import StaticModel
-            self._embed_model = StaticModel.from_pretrained(
+            return StaticModel.from_pretrained(
                 "minishlab/potion-base-8M", force_download=False
             )
-        elif model_id == "qwen3_256":
+        if model_id == "qwen3_256":
             from sentence_transformers import SentenceTransformer
             mkwargs = {}
             if sys.platform == "darwin":
                 mkwargs["attn_implementation"] = "eager"
-            self._embed_model = SentenceTransformer(
+            return SentenceTransformer(
                 "Qwen/Qwen3-Embedding-0.6B",
                 truncate_dim=256,
                 model_kwargs=mkwargs or None,
+                device=device,
             )
-        elif model_id not in ("model2vec", "minilm", "bge-small", "qwen3_256"):
+        if model_id not in ("model2vec", "minilm", "bge-small", "qwen3_256"):
             # Custom model: require explicit opt-in for arbitrary downloads
             if os.environ.get("TRUEMEMORY_CUSTOM_ALLOW_DOWNLOAD", "").strip() != "1":
                 log.warning(
@@ -174,24 +216,29 @@ class ModelServer:
                     model_id,
                 )
                 from model2vec import StaticModel
-                self._embed_model = StaticModel.from_pretrained(
+                return StaticModel.from_pretrained(
                     "minishlab/potion-base-8M", force_download=False
                 )
-            else:
-                from sentence_transformers import SentenceTransformer
-                from truememory.tier_config import resolve_custom_tier
-                cfg = resolve_custom_tier()
-                custom_dim = cfg["embed_dim"]
-                self._embed_model = SentenceTransformer(
-                    model_id, truncate_dim=custom_dim,
-                    trust_remote_code=False,
-                )
-        else:
-            from model2vec import StaticModel
-            self._embed_model = StaticModel.from_pretrained(
-                "minishlab/potion-base-8M", force_download=False
+            from sentence_transformers import SentenceTransformer
+            from truememory.tier_config import resolve_custom_tier
+            cfg = resolve_custom_tier()
+            custom_dim = cfg["embed_dim"]
+            return SentenceTransformer(
+                model_id, truncate_dim=custom_dim,
+                trust_remote_code=False,
+                device=device,
             )
+        from model2vec import StaticModel
+        return StaticModel.from_pretrained(
+            "minishlab/potion-base-8M", force_download=False
+        )
 
+    def _get_embed_model(self, tier: str):
+        if self._embed_model is not None and self._embed_tier == tier:
+            return self._embed_model
+
+        model_id = self._resolve_embed_model_id(tier)
+        self._embed_model = self._build_embed_model(model_id, self._embed_device())
         self._embed_tier = tier
         log.info("Loaded embedding model for tier=%s", tier)
         return self._embed_model
@@ -204,15 +251,11 @@ class ModelServer:
             return self._reranker
 
         from sentence_transformers import CrossEncoder
-        device = "cpu"
-        try:
-            import torch
-            if torch.cuda.is_available():
-                device = "cuda:0"
-            elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                device = "mps"
-        except ImportError:
-            pass
+        from truememory.mps_utils import auto_detect_device, resolve_device
+        if "rerank" in self._sticky_cpu:
+            device = "cpu"
+        else:
+            device = resolve_device(auto_detect_device())
 
         self._reranker = CrossEncoder(name, device=device)
         self._reranker_name = name
@@ -220,7 +263,7 @@ class ModelServer:
         return self._reranker
 
     def handle_request(self, request: dict) -> dict:
-        with self._lock:
+        with self._activity_lock:
             self._last_activity = time.time()
         op = request.get("op")
 
@@ -250,6 +293,7 @@ class ModelServer:
                 self._throttler.before_batch()
 
             encode_start = time.time()
+            oom = False
             with self._lock:
                 model = self._get_embed_model(tier)
                 try:
@@ -258,17 +302,24 @@ class ModelServer:
                     from truememory.mps_utils import is_mps_oom, flush_mps_cache
                     if not is_mps_oom(exc):
                         raise
-                    log.warning("MPS OOM during encoding — flushing cache and retrying on CPU")
+                    # Issue #577: sticky-CPU degradation. The device move
+                    # happens under the lock (transitions must not race other
+                    # encodes) but the expensive full re-encode runs OUTSIDE
+                    # the lock so other clients are not starved for 23-112s.
+                    # The model is never re-promoted to MPS: the old
+                    # re-promotion left the MPS pool above its watermark cap
+                    # and guaranteed the next OOM (retry storms).
+                    self._mark_sticky_cpu("embed")
                     flush_mps_cache()
                     if hasattr(model, "to"):
                         model.to("cpu")
-                    vectors = model.encode(texts, show_progress_bar=False)
-                    try:
-                        import torch
-                        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                            model.to("mps")
-                    except Exception:
-                        pass
+                    oom = True
+            if oom:
+                log.warning(
+                    "MPS OOM during encoding — retrying on CPU outside the "
+                    "request lock"
+                )
+                vectors = model.encode(texts, show_progress_bar=False)
             encode_time = time.time() - encode_start
 
             if self._throttler_active and self._throttler:
@@ -286,8 +337,31 @@ class ModelServer:
         if op == "rerank":
             pairs = request["pairs"]
             model_name = request.get("model_name")
+            oom = False
             with self._lock:
                 reranker = self._get_reranker(model_name)
+                try:
+                    scores = reranker.predict(
+                        pairs, batch_size=64, show_progress_bar=False
+                    )
+                except RuntimeError as exc:
+                    from truememory.mps_utils import is_mps_oom, flush_mps_cache
+                    if not is_mps_oom(exc):
+                        raise
+                    # Issue #577: the rerank path previously had NO OOM
+                    # handler — a raw MPS OOM reached the client (3/3 rerank
+                    # deaths in the baseline probe). Same sticky-CPU policy
+                    # as embed: drop the MPS-loaded model and reload on CPU.
+                    self._mark_sticky_cpu("rerank")
+                    flush_mps_cache()
+                    self._reranker = None
+                    self._reranker_name = None
+                    oom = True
+            if oom:
+                with self._lock:
+                    reranker = self._get_reranker(model_name)  # sticky → CPU
+                # Retry outside the lock — rerank batches are the expensive
+                # part; other clients must not starve behind the recovery.
                 scores = reranker.predict(
                     pairs, batch_size=64, show_progress_bar=False
                 )
@@ -302,13 +376,21 @@ class ModelServer:
         except ImportError:
             log.warning("Cannot import DynamicThrottler — running without throttling")
             return
-        device = "cpu"
-        try:
-            import torch
-            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                device = "mps"
-        except ImportError:
-            pass
+        # Issue #577: honor sticky-CPU degradation and TRUEMEMORY_DEVICE in
+        # the throttler's device pick (it tunes MPS-specific behavior).
+        if "embed" in self._sticky_cpu:
+            device = "cpu"
+        else:
+            from truememory.mps_utils import resolve_device
+            device = resolve_device(None)
+            if device is None:
+                device = "cpu"
+                try:
+                    import torch
+                    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                        device = "mps"
+                except ImportError:
+                    pass
         self._throttler = DynamicThrottler(device=device)
         self._throttler_active = True
         log.info(
@@ -406,7 +488,7 @@ class ModelServer:
             time.sleep(60)
             if not self._running:
                 break
-            with self._lock:
+            with self._activity_lock:
                 last = self._last_activity
             elapsed = time.time() - last
             if elapsed >= IDLE_TIMEOUT:

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -55,6 +55,7 @@ import struct  # noqa: E402
 import sys  # noqa: E402
 import threading  # noqa: E402
 import time  # noqa: E402
+from dataclasses import dataclass  # noqa: E402
 from pathlib import Path  # noqa: E402
 
 import numpy as np  # noqa: E402
@@ -104,6 +105,22 @@ def _json_object_hook(obj):
 _HMAC_TOKEN_BYTES = 32
 
 
+@dataclass(frozen=True)
+class _EmbedState:
+    """Immutable snapshot of the loaded embedding model and its identity.
+
+    Issue #577 (panel round 2): the server stores this in a SINGLE attribute
+    (``ModelServer._embed_state``) assigned only while holding the global
+    request lock. Lock-free readers (the single-text fast lane) read one
+    reference — Python reference assignment is atomic, so a reader can never
+    observe a torn ``(model, tier, model_id)`` triple.
+    """
+
+    model: object
+    tier: str
+    model_id: str
+
+
 class ModelServer:
     """Serves embedding and reranking over a Unix domain socket (POSIX)
     or HMAC-authenticated TCP loopback (Windows)."""
@@ -116,11 +133,10 @@ class ModelServer:
     _FAST_LANE_MAX_TEXTS = 1
 
     def __init__(self):
-        self._embed_model = None
-        self._embed_tier: str | None = None
-        # Actual loaded model identity (e.g. "qwen3_256") — the fast lane
-        # derives its encoder from this, not from tier defaults (issue #577).
-        self._embed_model_id: str | None = None
+        # Loaded embedding model + identity as ONE immutable snapshot,
+        # assigned only under self._lock; the fast lane reads the single
+        # reference lock-free (issue #577, panel round 2).
+        self._embed_state: _EmbedState | None = None
         self._reranker = None
         self._reranker_name: str | None = None
         self._lock = threading.Lock()
@@ -175,6 +191,21 @@ class ModelServer:
             return "cpu"
         from truememory.mps_utils import resolve_device
         return resolve_device(None)
+
+    def _recover_embed_oom_locked(self, model) -> None:
+        """The single recovery path for an embed MPS OOM (issue #577).
+
+        Caller MUST hold ``self._lock``. Marks the embed path sticky-CPU
+        (loud log once), flushes the MPS cache, and moves the model to CPU —
+        all atomically in the caller's lock hold. Retry placement belongs to
+        the caller: single texts re-encode inside the lock (ms-scale);
+        batches re-encode after releasing it so other clients don't starve.
+        """
+        from truememory.mps_utils import flush_mps_cache
+        self._mark_sticky_cpu("embed")
+        flush_mps_cache()
+        if hasattr(model, "to"):
+            model.to("cpu")
 
     @staticmethod
     def _peek_embed_model_id(tier: str) -> str:
@@ -258,30 +289,26 @@ class ModelServer:
             "minishlab/potion-base-8M", force_download=False
         )
 
-    # Model IDs the fast lane can rebuild with guaranteed vector-space
-    # parity: _build_embed_model constructs them deterministically with a
-    # fixed dim and no config reads. Custom models re-read config.json at
-    # build time, so a config change between the main load and the fast
-    # load could silently change the embedding dim/space — the fast lane
-    # declines those and falls through to the main path.
-    _FAST_LANE_SAFE_MODEL_IDS = frozenset(
-        {"model2vec", "minilm", "bge-small", "qwen3_256"}
-    )
+    # Model IDs the fast lane may rebuild with guaranteed vector-space
+    # parity: ONLY ids with an explicit, deterministic branch in
+    # _build_embed_model (fixed dim, no config reads). "minilm"/"bge-small"
+    # have NO explicit server branch (legacy fall-through to model2vec), and
+    # custom models re-read config.json at build time — the fast lane
+    # declines all of those and falls through to the main path.
+    _FAST_LANE_SAFE_MODEL_IDS = frozenset({"model2vec", "qwen3_256"})
 
     def _get_embed_model(self, tier: str):
-        if self._embed_model is not None and self._embed_tier == tier:
-            return self._embed_model
+        state = self._embed_state
+        if state is not None and state.tier == tier:
+            return state.model
 
         model_id = self._resolve_embed_model_id(tier)
         model = self._build_embed_model(model_id, self._embed_device())
-        # Write order matters for the fast lane's lock-free reads:
-        # _embed_tier is written LAST, so a matching tier implies the model
-        # and its identity are already in place.
-        self._embed_model = model
-        self._embed_model_id = model_id
-        self._embed_tier = tier
-        log.info("Loaded embedding model for tier=%s", tier)
-        return self._embed_model
+        # ONE atomic reference assignment of an immutable snapshot — the
+        # fast lane can never observe a torn (model, tier, model_id) triple.
+        self._embed_state = _EmbedState(model=model, tier=tier, model_id=model_id)
+        log.info("Loaded embedding model for tier=%s (model=%s)", tier, model_id)
+        return model
 
     def _get_fast_encoder(self, tier: str):
         """CPU-resident encoder for the single-text fast lane (issue #577).
@@ -290,35 +317,32 @@ class ModelServer:
         lock busy, then kept for the server's lifetime. Caller must hold
         ``self._fast_lock``.
 
-        Vector-space parity (issue #577 panel round 1): when the main path
-        already has a model loaded for this tier, the fast encoder is built
-        from the main path's ACTUAL loaded model identity — not from a fresh
-        tier resolution, which could drift for tier="" requests if the
-        global ``EMBEDDING_MODEL`` changed after the main load (the main
-        cache is keyed by tier string, not model ID). Returns ``None`` when
-        parity cannot be guaranteed (custom models); the caller falls
-        through to the main (locked) path.
+        Vector-space parity (panel rounds 1-2): the fast encoder is ONLY
+        ever built from the main path's actual loaded identity, taken from
+        one atomic read of the ``_embed_state`` snapshot. The fast lane
+        never resolves tiers itself — no global reads, no config reads, no
+        drift. Returns ``None`` (decline → caller falls through to the main
+        locked path) when there is no snapshot for this tier yet, or the
+        loaded model has no explicit deterministic builder branch.
         """
-        if (
-            self._embed_model is not None
-            and self._embed_tier == tier
-            and self._embed_model_id
-        ):
-            model_id = self._embed_model_id
-        else:
-            model_id = self._peek_embed_model_id(tier)
-
-        if model_id not in self._FAST_LANE_SAFE_MODEL_IDS:
+        state = self._embed_state  # single atomic reference read
+        if state is None or state.tier != tier:
+            # No main model loaded for this tier yet — declining means the
+            # one-time load happens exactly once, on the main path, with
+            # its usual global sync.
             return None
 
-        if self._fast_encoder is not None and self._fast_model_id == model_id:
+        if state.model_id not in self._FAST_LANE_SAFE_MODEL_IDS:
+            return None
+
+        if self._fast_encoder is not None and self._fast_model_id == state.model_id:
             return self._fast_encoder
 
-        self._fast_encoder = self._build_embed_model(model_id, "cpu")
-        self._fast_model_id = model_id
+        self._fast_encoder = self._build_embed_model(state.model_id, "cpu")
+        self._fast_model_id = state.model_id
         log.info(
             "Fast-lane CPU encoder loaded (tier=%s, model=%s) — single-text "
-            "requests no longer queue behind batch work", tier, model_id,
+            "requests no longer queue behind batch work", tier, state.model_id,
         )
         return self._fast_encoder
 
@@ -360,14 +384,13 @@ class ModelServer:
                 try:
                     vectors = model.encode(texts, show_progress_bar=False)
                 except RuntimeError as exc:
-                    from truememory.mps_utils import is_mps_oom, flush_mps_cache
+                    from truememory.mps_utils import is_mps_oom
                     if not is_mps_oom(exc):
                         raise
-                    self._mark_sticky_cpu("embed")
-                    flush_mps_cache()
-                    if hasattr(model, "to"):
-                        model.to("cpu")
-                    # Single text on CPU is ms-scale; retry under the lock.
+                    # Same recovery path as the batch handler, atomic in
+                    # this lock hold; a single text on CPU is ms-scale, so
+                    # the retry stays under the lock too.
+                    self._recover_embed_oom_locked(model)
                     vectors = model.encode(texts, show_progress_bar=False)
                 return {"ok": True, "vectors": np.asarray(vectors, dtype=np.float32)}
             finally:
@@ -427,28 +450,29 @@ class ModelServer:
                 self._throttler.before_batch()
 
             encode_start = time.time()
-            oom = False
+            # `vectors` is assigned on exactly one of two paths: inside the
+            # locked try (retry_on_cpu stays False), or by the post-lock
+            # retry (retry_on_cpu True). Any other outcome raises.
+            vectors = None
+            retry_on_cpu = False
             with self._lock:
                 model = self._get_embed_model(tier)
                 try:
                     vectors = model.encode(texts, show_progress_bar=False)
                 except RuntimeError as exc:
-                    from truememory.mps_utils import is_mps_oom, flush_mps_cache
+                    from truememory.mps_utils import is_mps_oom
                     if not is_mps_oom(exc):
                         raise
-                    # Issue #577: sticky-CPU degradation. The device move
-                    # happens under the lock (transitions must not race other
-                    # encodes) but the expensive full re-encode runs OUTSIDE
-                    # the lock so other clients are not starved for 23-112s.
-                    # The model is never re-promoted to MPS: the old
-                    # re-promotion left the MPS pool above its watermark cap
-                    # and guaranteed the next OOM (retry storms).
-                    self._mark_sticky_cpu("embed")
-                    flush_mps_cache()
-                    if hasattr(model, "to"):
-                        model.to("cpu")
-                    oom = True
-            if oom:
+                    # Issue #577: sticky-CPU degradation via the single
+                    # shared recovery path, atomic in this lock hold. The
+                    # model is never re-promoted to MPS (the old re-promotion
+                    # left the MPS pool above its watermark cap and
+                    # guaranteed the next OOM — retry storms). Only the
+                    # expensive full re-encode runs OUTSIDE the lock, so
+                    # other clients are not starved for 23-112s.
+                    self._recover_embed_oom_locked(model)
+                    retry_on_cpu = True
+            if retry_on_cpu:
                 log.warning(
                     "MPS OOM during encoding — retrying on CPU outside the "
                     "request lock"
@@ -735,9 +759,13 @@ class ModelServer:
                 p.unlink(missing_ok=True)
             except OSError:
                 pass
-        self._embed_model = None
+        # Reset the embed snapshot and fast-lane identity so no stale model
+        # identity survives a stop (issue #577, panel round 2).
+        self._embed_state = None
         self._reranker = None
+        self._reranker_name = None
         self._fast_encoder = None
+        self._fast_model_id = None
         self._token = None
         gc.collect()
         log.info("Model server stopped")

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -110,6 +110,10 @@ class ModelServer:
 
     _SUSTAINED_THRESHOLD = 10
     _SUSTAINED_WINDOW = 30
+    # Requests with at most this many texts take the single-text fast lane
+    # (issue #577): hook recall queries must never queue behind ingestion
+    # batches or OOM recovery.
+    _FAST_LANE_MAX_TEXTS = 1
 
     def __init__(self):
         self._embed_model = None
@@ -132,6 +136,11 @@ class ModelServer:
         # lifetime of this server process ("embed" / "rerank"). Mutated only
         # while holding self._lock; read lock-free (string membership).
         self._sticky_cpu: set[str] = set()
+        # Issue #577: dedicated CPU encoder for the single-text fast lane,
+        # loaded lazily on the first *contended* single-text request.
+        self._fast_encoder = None
+        self._fast_tier: str | None = None
+        self._fast_lock = threading.Lock()
 
     def _mark_sticky_cpu(self, kind: str) -> bool:
         """Permanently degrade *kind* ("embed"/"rerank") to CPU after an
@@ -243,6 +252,25 @@ class ModelServer:
         log.info("Loaded embedding model for tier=%s", tier)
         return self._embed_model
 
+    def _get_fast_encoder(self, tier: str):
+        """CPU-resident encoder for the single-text fast lane (issue #577).
+
+        Loaded lazily on the first single-text request that finds the global
+        lock busy, then kept for the server's lifetime. Caller must hold
+        ``self._fast_lock``.
+        """
+        if self._fast_encoder is not None and self._fast_tier == tier:
+            return self._fast_encoder
+
+        model_id = self._resolve_embed_model_id(tier)
+        self._fast_encoder = self._build_embed_model(model_id, "cpu")
+        self._fast_tier = tier
+        log.info(
+            "Fast-lane CPU encoder loaded (tier=%s) — single-text requests "
+            "no longer queue behind batch work", tier,
+        )
+        return self._fast_encoder
+
     def _get_reranker(self, model_name: str | None = None):
         from truememory.reranker import get_current_reranker_name
         name = model_name or get_current_reranker_name()
@@ -262,6 +290,50 @@ class ModelServer:
         log.info("Loaded reranker model=%s device=%s", name, device)
         return self._reranker
 
+    def _handle_fast_embed(self, texts: list, tier: str) -> dict | None:
+        """Single-text fast lane (issue #577).
+
+        Tries the main path without blocking; when the global lock is busy
+        (a batch encode or OOM recovery is in progress) the text is encoded
+        on a dedicated CPU encoder OUTSIDE the global lock, so hook recall
+        queries never wait on ingestion work. Fast-lane requests skip the
+        sustained-workload bookkeeping entirely — a burst of small hook
+        queries must not trip the throttler's batch=1 ramp (finding C-7).
+
+        Returns a response dict, or None to fall through to the normal
+        (locked) path.
+        """
+        if self._lock.acquire(blocking=False):
+            try:
+                model = self._get_embed_model(tier)
+                try:
+                    vectors = model.encode(texts, show_progress_bar=False)
+                except RuntimeError as exc:
+                    from truememory.mps_utils import is_mps_oom, flush_mps_cache
+                    if not is_mps_oom(exc):
+                        raise
+                    self._mark_sticky_cpu("embed")
+                    flush_mps_cache()
+                    if hasattr(model, "to"):
+                        model.to("cpu")
+                    # Single text on CPU is ms-scale; retry under the lock.
+                    vectors = model.encode(texts, show_progress_bar=False)
+                return {"ok": True, "vectors": np.asarray(vectors, dtype=np.float32)}
+            finally:
+                self._lock.release()
+
+        try:
+            with self._fast_lock:
+                model = self._get_fast_encoder(tier)
+                vectors = model.encode(texts, show_progress_bar=False)
+            return {"ok": True, "vectors": np.asarray(vectors, dtype=np.float32)}
+        except Exception:
+            log.warning(
+                "Fast-lane CPU encode failed — falling back to the main "
+                "embed path", exc_info=True,
+            )
+            return None
+
     def handle_request(self, request: dict) -> dict:
         with self._activity_lock:
             self._last_activity = time.time()
@@ -273,6 +345,13 @@ class ModelServer:
         if op == "embed":
             texts = request["texts"]
             tier = request.get("tier", "")
+
+            # Single-text fast lane (issue #577): hook recall queries must
+            # never queue behind batch ingestion work or OOM recovery.
+            if len(texts) <= self._FAST_LANE_MAX_TEXTS:
+                fast = self._handle_fast_embed(texts, tier)
+                if fast is not None:
+                    return fast
 
             now = time.time()
             with self._lock:
@@ -601,6 +680,7 @@ class ModelServer:
                 pass
         self._embed_model = None
         self._reranker = None
+        self._fast_encoder = None
         self._token = None
         gc.collect()
         log.info("Model server stopped")

--- a/truememory/mps_utils.py
+++ b/truememory/mps_utils.py
@@ -8,11 +8,82 @@ from __future__ import annotations
 
 import gc
 import logging
+import os
 import threading
 
 logger = logging.getLogger(__name__)
 
 _device_lock = threading.Lock()
+
+_VALID_DEVICE_VALUES = ("cpu", "mps", "cuda", "auto")
+
+
+def auto_detect_device() -> str:
+    """Auto-detect the best torch device: cuda -> mps -> cpu.
+
+    This is the detection order every load site used before issue #577;
+    call sites that want explicit detection pass this as ``default_auto``
+    to :func:`resolve_device`.
+    """
+    try:
+        import torch
+        if torch.cuda.is_available():
+            return "cuda:0"
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            return "mps"
+    except ImportError:
+        pass
+    return "cpu"
+
+
+def resolve_device(default_auto: str | None = None) -> str | None:
+    """Resolve the inference device, honoring ``TRUEMEMORY_DEVICE`` (issue #577).
+
+    ``TRUEMEMORY_DEVICE`` accepts ``cpu`` | ``mps`` | ``cuda`` | ``auto``:
+
+    * ``cpu`` — always honored (the escape hatch for MPS OOM retry storms
+      on memory-constrained Macs).
+    * ``mps`` / ``cuda`` — honored when the accelerator is actually
+      available; otherwise a warning is logged and resolution falls back
+      to *default_auto*.
+    * ``auto``, unset — *default_auto*.
+    * anything else — warning + *default_auto*.
+
+    *default_auto* is the call site's auto behavior: pass
+    ``auto_detect_device()`` to keep explicit cuda→mps→cpu detection, or
+    ``None`` to let the framework (e.g. SentenceTransformer) pick its own
+    device.
+    """
+    raw = os.environ.get("TRUEMEMORY_DEVICE", "").strip().lower()
+    if not raw or raw == "auto":
+        return default_auto
+    if raw not in _VALID_DEVICE_VALUES:
+        logger.warning(
+            "Invalid TRUEMEMORY_DEVICE=%r (expected cpu|mps|cuda|auto) — "
+            "falling back to auto device selection.",
+            raw,
+        )
+        return default_auto
+    if raw == "cpu":
+        return "cpu"
+    try:
+        import torch
+        if raw == "cuda" and torch.cuda.is_available():
+            return "cuda:0"
+        if (
+            raw == "mps"
+            and hasattr(torch.backends, "mps")
+            and torch.backends.mps.is_available()
+        ):
+            return "mps"
+    except ImportError:
+        pass
+    logger.warning(
+        "TRUEMEMORY_DEVICE=%s requested but that device is not available — "
+        "falling back to auto device selection.",
+        raw,
+    )
+    return default_auto
 
 
 def is_mps_oom(exc: Exception) -> bool:

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -221,16 +221,10 @@ def get_reranker(model_name: str | None = None, device: str | None = None):
         from sentence_transformers import CrossEncoder
 
         if device is None:
-            try:
-                import torch
-                if torch.cuda.is_available():
-                    device = "cuda:0"
-                elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                    device = "mps"
-                else:
-                    device = "cpu"
-            except ImportError:
-                device = "cpu"
+            # Issue #577: honor TRUEMEMORY_DEVICE (cpu|mps|cuda|auto) before
+            # auto-detection. An explicit device= parameter wins over the env.
+            from truememory.mps_utils import auto_detect_device, resolve_device
+            device = resolve_device(auto_detect_device())
 
         _model = CrossEncoder(name, device=device)
         _model_name = name


### PR DESCRIPTION
## Summary
Fixes the production MPS-OOM failure mode: device override, sticky-CPU degradation with recovery outside the global lock, a rerank-path OOM handler, a snapshot-based single-text fast lane, and per-call client deadlines. Fixes #577

## Root Cause
`_set_mps_memory_cap` self-caps MPS to ~1.95GiB on a 32GB Mac; ingestion batches exceed it. OOM recovery ran **under the single global lock** (starving every client — measured 65s session starts), recovery re-promoted the model to MPS (guaranteeing the next OOM), the rerank path had **no OOM handler** (raw RuntimeError reached clients, reproduced 3/3 in the baseline probe), and the client used a flat 120s timeout even on session-critical hook paths.

## Fix
- `resolve_device()` honoring `TRUEMEMORY_DEVICE` (cpu|mps|cuda|auto) at server embed load, server reranker load, local-fallback reranker, and throttler; documented in docs/env-vars.md.
- Sticky-CPU OOM degradation: single `_recover_embed_oom_locked()` path — mark + flush + drop + CPU reload atomic in one lock hold, batch retry outside the lock, never re-promotes to MPS. Rerank path gets the same policy.
- Single-text fast lane: contended hook recalls served from a frozen `_EmbedState` snapshot (one atomic reference read — no torn state), strictly tier/model-matching with conservative decline; allowlist limited to ids with explicit deterministic loader branches.
- Client deadline kwarg (default 120s unchanged); hooks pass `TRUEMEMORY_HOOK_RECALL_TIMEOUT` (default 5s, 0 disables) and fall back to FTS-only on expiry.

## Dependency Impact
All consumers of `get_reranker`/`rerank`/`predict`/`encode` verified via rg sweep (report in `_working/blastoff/pr_review/pr_577_report.md`). `test_issue_489` H4 rewritten — it asserted the exact MPS re-promotion this fix removes. Acknowledged follow-up: `tier_switch/manager.py` builds its own throttler with local device detect (out of consensus scope).

## Test Plan
- 22-test regression suite `tests/test_issue_577_model_server_oom.py`: device override, sticky-CPU, recovery-not-under-lock, rerank OOM, fast-lane parity (incl. sticky-CPU + global drift + custom decline), no-global-mutation, concurrency interleave (pre-fix code demonstrably forks the vector space — two different models built; post-fix declines), deadline kwarg. Fail-first stash cycles documented per round.
- Full suite: **1123 passed / 0 new failures** vs frozen baseline (1101). Ruff clean.

## Validation
7-model panel, three rounds: 6/7 → 4/7 (dissents drove a real fix: fast-lane global mutation via `set_embedding_model`, plus the atomic-snapshot refactor) → **7/7 unanimous**.