### PR TITLE
fix(ingest): encoding gate degrades open when PE dead, contradictions always pass (#585)

### DIFF
--- a/tests/test_issue_585_encoding_gate_pe.py
+++ b/tests/test_issue_585_encoding_gate_pe.py
@@ -151,7 +151,11 @@ def test_non_contradiction_can_be_blocked():
     from truememory.ingest.encoding_gate import EncodingGate
 
     gate = EncodingGate(memory=MockMemoryWithContent(), threshold=0.99)
-    decision = gate.evaluate("The weather is nice today", "general")
+    # Mock PE computation so the gate doesn't try to load the real model.
+    # Return a low PE value — this keeps _pe_available=True so the gate
+    # uses its normal threshold logic instead of degrading open.
+    with patch.object(gate, "_compute_prediction_error", return_value=0.1):
+        decision = gate.evaluate("The weather is nice today", "general")
     # With threshold=0.99, normal facts should be blocked
     assert decision.should_encode is False
 
@@ -188,8 +192,10 @@ def test_pe_degradation_in_batch_summary():
     gate._pe_available = False
     gate._pe_degradation_count = 3
 
-    # Run an evaluate so batch has data
-    gate.evaluate("Some fact", "personal")
+    # Mock PE computation so evaluate() doesn't try to load the real model
+    # and inadvertently change _pe_degradation_count.
+    with patch.object(gate, "_compute_prediction_error", return_value=0.0):
+        gate.evaluate("Some fact", "personal")
 
     summary = gate.log_batch_summary()
     assert summary["pe_degradation_count"] == 3

--- a/tests/test_issue_585_encoding_gate_pe.py
+++ b/tests/test_issue_585_encoding_gate_pe.py
@@ -1,7 +1,6 @@
 """Tests for issue #585: encoding gate PE degradation and contradiction bypass."""
 
-import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 
 class MockMemory:
@@ -85,7 +84,7 @@ def test_pe_unavailable_full_evaluate_passes():
         side_effect=RuntimeError("model not found"),
     ):
         # First evaluate triggers model load failure
-        decision = gate.evaluate("User likes Python over JavaScript", "preference")
+        gate.evaluate("User likes Python over JavaScript", "preference")
 
     # Gate should have degraded open
     assert gate._pe_available is False

--- a/tests/test_issue_585_encoding_gate_pe.py
+++ b/tests/test_issue_585_encoding_gate_pe.py
@@ -1,0 +1,240 @@
+"""Tests for issue #585: encoding gate PE degradation and contradiction bypass."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class MockMemory:
+    """Minimal mock memory that returns search results."""
+
+    def __init__(self, results=None):
+        self._results = results or []
+
+    def search(self, query, **kwargs):
+        return self._results
+
+    def search_vectors(self, query, limit=5):
+        return self._results
+
+
+class MockMemoryWithContent(MockMemory):
+    def __init__(self, content="User lives in Seattle", score=0.5):
+        super().__init__([{"content": content, "score": score}])
+
+
+class EmptyMemory(MockMemory):
+    def __init__(self):
+        super().__init__([])
+
+
+# ---------------------------------------------------------------------------
+# PE unavailable -> gate degrades OPEN (all facts pass)
+# ---------------------------------------------------------------------------
+
+def test_pe_unavailable_all_pass():
+    """When PE model fails to load, all memories should pass (open gate)."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    gate = EncodingGate(memory=MockMemoryWithContent())
+
+    # Simulate PE model failure
+    with patch(
+        "truememory.ingest.encoding_gate.EncodingGate._compute_prediction_error",
+        side_effect=_fail_pe_and_mark(gate),
+    ):
+        pass
+
+    # Directly mark PE as unavailable (simulating model load failure)
+    gate._pe_available = False
+    gate._pe_degradation_count = 1
+
+    decision = gate.evaluate("Some random fact with low novelty")
+    assert decision.should_encode is True, (
+        f"PE degraded gate should pass everything, got should_encode={decision.should_encode}"
+    )
+    assert "pe-degraded" in decision.reason
+
+
+def test_pe_model_load_failure_sets_flag():
+    """When get_model() raises, _pe_available should become False."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    gate = EncodingGate(memory=MockMemoryWithContent())
+    # Ensure _last_search_results is populated so PE tries to load model
+    gate._last_search_results = [{"content": "test memory", "score": 0.5}]
+
+    with patch(
+        "truememory.vector_search.get_model",
+        side_effect=RuntimeError("model not found"),
+    ):
+        pe = gate._compute_prediction_error("User moved to Portland")
+
+    assert pe == 0.0
+    assert gate._pe_available is False
+    assert gate._pe_degradation_count >= 1
+
+
+def test_pe_unavailable_full_evaluate_passes():
+    """Full evaluate() should pass facts when PE model is dead."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    gate = EncodingGate(memory=MockMemoryWithContent())
+
+    with patch(
+        "truememory.vector_search.get_model",
+        side_effect=RuntimeError("model not found"),
+    ):
+        # First evaluate triggers model load failure
+        decision = gate.evaluate("User likes Python over JavaScript", "preference")
+
+    # Gate should have degraded open
+    assert gate._pe_available is False
+
+    # Second evaluate should also pass (gate stays open)
+    decision2 = gate.evaluate("User prefers dark mode", "preference")
+    assert decision2.should_encode is True
+
+
+# ---------------------------------------------------------------------------
+# PE available + low score -> memory blocked (existing behavior preserved)
+# ---------------------------------------------------------------------------
+
+def test_pe_available_low_score_blocked():
+    """With PE available, a low-scoring fact should still be blocked."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    gate = EncodingGate(memory=MockMemoryWithContent(), threshold=0.90)
+    # PE is available (default), high threshold ensures blocking
+    decision = gate.evaluate("ok", "general")
+    # "ok" is noise — should be blocked by salience floor or threshold
+    assert decision.should_encode is False
+
+
+# ---------------------------------------------------------------------------
+# Contradictions always pass regardless of PE score
+# ---------------------------------------------------------------------------
+
+def test_contradiction_markers_always_pass():
+    """Facts with contradiction markers should always pass the gate."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    gate = EncodingGate(memory=EmptyMemory(), threshold=0.99)
+
+    contradiction_facts = [
+        "Actually, I moved to Portland not Seattle",
+        "Correction: my name is spelled differently",
+        "I no longer work at Google",
+        "User switched to vim from emacs",
+        "It's not Python but JavaScript that I prefer",
+    ]
+
+    for fact in contradiction_facts:
+        decision = gate.evaluate(fact, "personal")
+        assert decision.should_encode is True, (
+            f"Contradiction should pass: {fact!r}, got should_encode={decision.should_encode}, "
+            f"reason={decision.reason}"
+        )
+        assert "contradiction-bypass" in decision.reason
+
+
+def test_correction_category_always_passes():
+    """Facts with category='correction' should always pass the gate."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    gate = EncodingGate(memory=EmptyMemory(), threshold=0.99)
+    decision = gate.evaluate("User prefers tabs over spaces", "correction")
+    assert decision.should_encode is True
+    assert "contradiction-bypass" in decision.reason
+
+
+def test_non_contradiction_can_be_blocked():
+    """Non-contradiction facts should still be subject to normal gating."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    gate = EncodingGate(memory=MockMemoryWithContent(), threshold=0.99)
+    decision = gate.evaluate("The weather is nice today", "general")
+    # With threshold=0.99, normal facts should be blocked
+    assert decision.should_encode is False
+
+
+# ---------------------------------------------------------------------------
+# PE degradation counter
+# ---------------------------------------------------------------------------
+
+def test_pe_degradation_counter_increments():
+    """Each PE failure should increment the degradation counter."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    gate = EncodingGate(memory=MockMemoryWithContent())
+    gate._last_search_results = [{"content": "test", "score": 0.5}]
+
+    with patch(
+        "truememory.vector_search.get_model",
+        side_effect=RuntimeError("boom"),
+    ):
+        gate._compute_prediction_error("fact one")
+        assert gate._pe_degradation_count == 1
+
+        # Reset model to None so it tries again
+        gate._embed_model = None
+        gate._compute_prediction_error("fact two")
+        assert gate._pe_degradation_count == 2
+
+
+def test_pe_degradation_in_batch_summary():
+    """log_batch_summary should include PE degradation info when present."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    gate = EncodingGate(memory=MockMemoryWithContent())
+    gate._pe_available = False
+    gate._pe_degradation_count = 3
+
+    # Run an evaluate so batch has data
+    gate.evaluate("Some fact", "personal")
+
+    summary = gate.log_batch_summary()
+    assert summary["pe_degradation_count"] == 3
+    assert summary["pe_available"] is False
+
+
+def test_pe_degradation_absent_when_healthy():
+    """log_batch_summary should NOT include PE degradation when PE is fine."""
+    from truememory.ingest.encoding_gate import EncodingGate
+
+    gate = EncodingGate(memory=EmptyMemory())
+    gate.evaluate("Some fact", "personal")
+
+    summary = gate.log_batch_summary()
+    assert "pe_degradation_count" not in summary
+
+
+# ---------------------------------------------------------------------------
+# _is_contradiction unit tests
+# ---------------------------------------------------------------------------
+
+def test_is_contradiction_function():
+    """Direct tests for _is_contradiction helper."""
+    from truememory.ingest.encoding_gate import _is_contradiction
+
+    # Should be True
+    assert _is_contradiction("Actually, I live in Austin", "personal") is True
+    assert _is_contradiction("Correction: wrong email", "general") is True
+    assert _is_contradiction("I no longer use npm", "preference") is True
+    assert _is_contradiction("It's not X but Y", "personal") is True
+    assert _is_contradiction("any text", "correction") is True
+    assert _is_contradiction("She switched to Android", "personal") is True
+
+    # Should be False
+    assert _is_contradiction("I like pizza", "personal") is False
+    assert _is_contradiction("The meeting is at 3pm", "event") is False
+    assert _is_contradiction("ok", "general") is False
+
+
+# Helper for mocking
+def _fail_pe_and_mark(gate):
+    """Side effect that marks PE as failed."""
+    def _inner(*args, **kwargs):
+        gate._pe_available = False
+        gate._pe_degradation_count += 1
+        return 0.0
+    return _inner

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -143,6 +143,43 @@ _CATEGORY_THRESHOLD_OVERRIDE = {
     "activity": -0.02,
 }
 
+# Patterns that indicate contradictions or corrections — these memories
+# are critical for accuracy and must always pass the gate regardless of
+# PE score or gate threshold (#585).
+_CONTRADICTION_MARKERS = (
+    "actually,",
+    "actually ",
+    "correction:",
+    "correction -",
+    "no longer ",
+    "not anymore",
+    "changed to ",
+    "switched to ",
+    "moved to ",
+    "used to be ",
+    "instead of ",
+    "wrong about ",
+    "was wrong",
+    "is wrong",
+    "not true",
+    "isn't true",
+    "that's incorrect",
+    "that is incorrect",
+)
+
+
+def _is_contradiction(fact: str, category: str = "") -> bool:
+    """Return True if the fact looks like a contradiction or correction."""
+    cat = (category or "").strip().lower()
+    if cat == "correction":
+        return True
+    lower = fact.lower().strip()
+    # Check for "not X but Y" pattern
+    if " not " in lower and " but " in lower:
+        return True
+    return any(lower.startswith(m) or (f" {m}" if not m.endswith(" ") else f" {m}") in lower
+               for m in _CONTRADICTION_MARKERS)
+
 
 class EncodingGate:
     """
@@ -197,6 +234,8 @@ class EncodingGate:
         self._norm = total if total > 0 else 1.0
         self._last_search_results: list[dict] = []
         self._embed_model = None
+        self._pe_available: bool = True   # assume available until first failure
+        self._pe_degradation_count: int = 0  # track PE failures for status (#585)
         self._batch_scores: list[float] = []
         self._batch_novelties: list[float] = []
         self._batch_saliences: list[float] = []
@@ -207,7 +246,16 @@ class EncodingGate:
         Pass a candidate fact through the encoding gate.
 
         Returns an EncodingDecision with the full signal breakdown.
+
+        Degradation policy (#585):
+        - If the PE model is unavailable, the gate degrades OPEN (pass
+          everything) rather than silently dropping memories.
+        - Contradictions and corrections always pass regardless of score.
         """
+        # Contradiction bypass: corrections are critical for memory accuracy
+        # and must never be dropped by the gate (#585).
+        is_contradiction = _is_contradiction(fact, category)
+
         novelty = self._compute_novelty(fact)
         salience = self._compute_salience(fact, category)
         pred_error = self._compute_prediction_error(fact)
@@ -220,18 +268,32 @@ class EncodingGate:
         )
         score = max(0.0, min(1.0, raw / self._norm))
 
-        # Salience floor: reject messages the salience scorer considers
-        # pure noise, regardless of how novel or surprising they are.
-        # Prevents high-novelty off-topic chatter from passing the gate.
-        floored = salience < self.salience_floor
-        if floored:
-            should_encode = False
+        # PE degradation: if the PE model is dead, open the gate and let
+        # everything through rather than silently dropping facts (#585).
+        if not self._pe_available:
+            should_encode = True
+            floored = False
+            reason = self._explain(novelty, salience, pred_error, score, True, False)
+            reason = reason.replace("ENCODE", "ENCODE(pe-degraded)", 1)
+        # Contradiction/correction bypass: always encode (#585).
+        elif is_contradiction:
+            should_encode = True
+            floored = salience < self.salience_floor
+            reason = self._explain(novelty, salience, pred_error, score, True, floored)
+            reason = reason.replace("ENCODE", "ENCODE(contradiction-bypass)", 1)
         else:
-            cat = (category or "").strip().lower()
-            effective_threshold = self.threshold + _CATEGORY_THRESHOLD_OVERRIDE.get(cat, 0.0)
-            effective_threshold = max(0.10, effective_threshold)
-            should_encode = score >= effective_threshold
-        reason = self._explain(novelty, salience, pred_error, score, should_encode, floored)
+            # Salience floor: reject messages the salience scorer considers
+            # pure noise, regardless of how novel or surprising they are.
+            # Prevents high-novelty off-topic chatter from passing the gate.
+            floored = salience < self.salience_floor
+            if floored:
+                should_encode = False
+            else:
+                cat = (category or "").strip().lower()
+                effective_threshold = self.threshold + _CATEGORY_THRESHOLD_OVERRIDE.get(cat, 0.0)
+                effective_threshold = max(0.10, effective_threshold)
+                should_encode = score >= effective_threshold
+            reason = self._explain(novelty, salience, pred_error, score, should_encode, floored)
 
         verdict = "ENCODE" if should_encode else "SKIP"
         log.debug(
@@ -429,7 +491,15 @@ class EncodingGate:
             try:
                 from truememory.vector_search import get_model
                 self._embed_model = get_model()
-            except Exception:
+            except Exception as e:
+                # PE model failed to load — degrade open (#585)
+                if self._pe_available:
+                    log.warning(
+                        "PE model failed to load: %s — gate will degrade OPEN "
+                        "(all facts pass until model recovers)", e,
+                    )
+                self._pe_available = False
+                self._pe_degradation_count += 1
                 return 0.0
         model = self._embed_model
 
@@ -467,6 +537,13 @@ class EncodingGate:
 
         except Exception as e:
             log.debug("PE embedding scorer failed: %s", e)
+            # Runtime encode failure — mark PE as degraded (#585)
+            if self._pe_available:
+                log.warning(
+                    "PE scorer crashed at runtime: %s — gate will degrade OPEN", e,
+                )
+            self._pe_available = False
+            self._pe_degradation_count += 1
             return 0.0
 
     # ------------------------------------------------------------------
@@ -551,13 +628,17 @@ class EncodingGate:
             _stats(self._batch_pes),
         )
 
-        return {
+        summary: dict = {
             "evaluated": n,
             "passed": passed,
             "blocked": blocked,
             "score_min": min(self._batch_scores),
             "score_max": max(self._batch_scores),
         }
+        if self._pe_degradation_count > 0:
+            summary["pe_degradation_count"] = self._pe_degradation_count
+            summary["pe_available"] = self._pe_available
+        return summary
 
     def reset_batch(self):
         """Clear the batch-level caches (call between transcripts)."""


### PR DESCRIPTION
## Summary
- When the PE embedding model fails to load or crashes at runtime, the encoding gate now **degrades OPEN** (passes all facts through) instead of silently dropping memories by contributing PE=0.0 to the score
- **Contradictions and corrections always bypass the gate** regardless of score — detected via marker phrases ("actually", "correction:", "no longer", "not X but Y", etc.) and `category="correction"`
- Added `_pe_degradation_count` counter surfaced in `log_batch_summary()` for `truememory_status` reporting

## Test plan
- [x] 11 new tests in `tests/test_issue_585_encoding_gate_pe.py`
- [x] PE unavailable → all memories pass through (open gate)
- [x] PE model load failure sets `_pe_available = False` and increments counter
- [x] PE available + low score → memory blocked (existing behavior preserved)
- [x] Contradiction content always passes even with extreme threshold
- [x] Correction category always passes
- [x] Non-contradictions can still be blocked
- [x] PE failure counter increments on each failure
- [x] `log_batch_summary()` includes degradation info when PE failed
- [x] `log_batch_summary()` omits degradation info when PE healthy
- [x] `_is_contradiction()` unit tests for marker detection
- [x] All existing encoding gate tests pass (no regressions)

Closes #585