### PR TITLE
fix: RRF id-space hardening — id-0, type-stable tiebreaks, HyDE fusion errors (#583)

### DIFF
--- a/tests/test_issue_583_rrf_hardening.py
+++ b/tests/test_issue_583_rrf_hardening.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import logging
 
-import pytest
 
 from truememory.hybrid import reciprocal_rank_fusion
 

--- a/tests/test_issue_583_rrf_hardening.py
+++ b/tests/test_issue_583_rrf_hardening.py
@@ -1,0 +1,188 @@
+"""
+Tests for issue #583: RRF id-space hardening.
+
+Covers:
+  1. id=0 results are preserved (not collapsed or dropped)
+  2. Mixed int/str ID tiebreaks don't crash and produce stable ordering
+  3. HyDE fusion errors log a warning but don't drop all results
+  4. Normal RRF behaviour is unchanged
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from truememory.hybrid import reciprocal_rank_fusion
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+def _make_doc(doc_id, content="test"):
+    """Build a minimal result dict."""
+    return {"id": doc_id, "content": content}
+
+
+# ── 1. id=0 preserved ────────────────────────────────────────────────
+
+class TestIdZeroPreserved:
+    """id=0 is a valid SQLite rowid and must not be collapsed or dropped."""
+
+    def test_single_list_id_zero(self):
+        results = reciprocal_rank_fusion([[_make_doc(0, "zero"), _make_doc(1, "one")]])
+        ids = {r["id"] for r in results}
+        assert 0 in ids, "id=0 was dropped"
+        assert 1 in ids
+
+    def test_two_lists_id_zero_merges(self):
+        """id=0 appearing in two lists should get a higher fused score."""
+        list_a = [_make_doc(0, "a"), _make_doc(1, "b")]
+        list_b = [_make_doc(0, "a"), _make_doc(2, "c")]
+        results = reciprocal_rank_fusion([list_a, list_b])
+        ids = [r["id"] for r in results]
+        assert ids[0] == 0, "id=0 should rank first (appears in both lists)"
+        assert len(results) == 3
+
+    def test_id_zero_not_collapsed_with_other_zeros(self):
+        """Multiple docs all with id=0 in separate lists should merge correctly."""
+        list_a = [_make_doc(0, "version_a")]
+        list_b = [_make_doc(0, "version_b_longer_fields")]
+        results = reciprocal_rank_fusion([list_a, list_b])
+        assert len(results) == 1  # same id, merged
+        assert results[0]["rrf_score"] > 0
+
+
+# ── 2. Type-stable tiebreaks ─────────────────────────────────────────
+
+class TestTypeStableTiebreaks:
+    """Mixed int/str IDs must not crash the sort and must produce stable order."""
+
+    def test_mixed_int_str_ids_no_crash(self):
+        """Tiebreaking between int and str IDs must not raise TypeError."""
+        list_a = [_make_doc(1), _make_doc("abc")]
+        list_b = [_make_doc("abc"), _make_doc(1)]
+        # Both docs have the same RRF score — tiebreak must handle mixed types
+        results = reciprocal_rank_fusion([list_a, list_b])
+        ids = {str(r["id"]) for r in results}
+        assert "1" in ids
+        assert "abc" in ids
+
+    def test_int_and_str_same_value_merge(self):
+        """int(42) and str('42') refer to the same logical doc — they should merge."""
+        list_a = [_make_doc(42, "int version")]
+        list_b = [_make_doc("42", "str version")]
+        results = reciprocal_rank_fusion([list_a, list_b])
+        # After str-normalisation they should merge into one entry
+        assert len(results) == 1
+        assert results[0]["rrf_score"] > 0
+
+    def test_deterministic_ordering(self):
+        """Same inputs should always produce same output order."""
+        lists = [[_make_doc(3), _make_doc(1), _make_doc(2)]]
+        r1 = reciprocal_rank_fusion(lists)
+        r2 = reciprocal_rank_fusion(lists)
+        assert [r["id"] for r in r1] == [r["id"] for r in r2]
+
+
+# ── 3. HyDE fusion error logging ─────────────────────────────────────
+
+class TestHydeFusionErrorLogging:
+    """HyDE errors must log a warning, not silently swallow."""
+
+    def test_hyde_multi_search_logs_warning_on_search_failure(self, caplog):
+        """hyde_multi_search should log.warning (not debug) when a HyDE search fails."""
+        from truememory.hyde import hyde_multi_search
+        import unittest.mock as mock
+
+        call_count = {"n": 0}
+
+        def _mock_search_hybrid(conn, query, **kw):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return [_make_doc(1, "result")]
+            raise RuntimeError("simulated HyDE search failure")
+
+        def _mock_llm(prompt):
+            return "A hypothetical conversation about the topic with details."
+
+        # hyde_multi_search does `from truememory.hybrid import search_hybrid`
+        # inside the function body, so we patch the source module.
+        with mock.patch("truememory.hybrid.search_hybrid", side_effect=_mock_search_hybrid):
+            with caplog.at_level(logging.WARNING, logger="truememory.hyde"):
+                results = hyde_multi_search(
+                    conn=None,
+                    query="test query",
+                    llm_fn=_mock_llm,
+                    limit=5,
+                )
+        assert len(results) >= 1
+        assert any("HyDE" in rec.message for rec in caplog.records), (
+            "Expected a WARNING-level log about HyDE failure"
+        )
+
+    def test_hyde_search_logs_warning_on_fusion_failure(self, caplog):
+        """hyde_search should log.warning when the HyDE search itself fails."""
+        from truememory.hyde import hyde_search
+        import unittest.mock as mock
+
+        call_count = {"n": 0}
+
+        def _mock_search(conn, query, **kw):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return [_make_doc(1)]
+            raise RuntimeError("boom")
+
+        def _mock_llm(prompt):
+            return "A hypothetical document with enough characters to pass."
+
+        with mock.patch("truememory.hybrid.search_hybrid", side_effect=_mock_search):
+            with caplog.at_level(logging.WARNING, logger="truememory.hyde"):
+                results = hyde_search(
+                    conn=None, query="test", llm_fn=_mock_llm, limit=5,
+                )
+        assert len(results) >= 1, "Should fall back to original results"
+        assert any("HyDE" in r.message and r.levelno >= logging.WARNING for r in caplog.records)
+
+
+# ── 4. Normal RRF behaviour unchanged ────────────────────────────────
+
+class TestNormalRRFBehaviour:
+    """Regression tests: standard RRF semantics are preserved."""
+
+    def test_empty_input(self):
+        assert reciprocal_rank_fusion([]) == []
+        assert reciprocal_rank_fusion([[]]) == []
+
+    def test_single_list(self):
+        docs = [_make_doc(10), _make_doc(20), _make_doc(30)]
+        results = reciprocal_rank_fusion([docs])
+        assert len(results) == 3
+        # First doc should have the highest score
+        assert results[0]["id"] == 10
+
+    def test_two_list_fusion(self):
+        list_a = [_make_doc(1), _make_doc(2)]
+        list_b = [_make_doc(2), _make_doc(3)]
+        results = reciprocal_rank_fusion([list_a, list_b])
+        # doc 2 appears in both lists — should be ranked first
+        assert results[0]["id"] == 2
+
+    def test_scores_are_positive(self):
+        results = reciprocal_rank_fusion([[_make_doc(1)]])
+        assert all(r["rrf_score"] > 0 for r in results)
+        assert all(r["score"] == r["rrf_score"] for r in results)
+
+    def test_k_parameter(self):
+        docs = [_make_doc(1)]
+        r60 = reciprocal_rank_fusion([docs], k=60)
+        r10 = reciprocal_rank_fusion([docs], k=10)
+        # Lower k means higher score for rank-1 doc
+        assert r10[0]["rrf_score"] > r60[0]["rrf_score"]
+
+    def test_none_id_skipped(self):
+        """Docs with id=None should be silently skipped."""
+        results = reciprocal_rank_fusion([[{"id": None, "content": "x"}, _make_doc(1)]])
+        assert len(results) == 1
+        assert results[0]["id"] == 1

--- a/truememory/hybrid.py
+++ b/truememory/hybrid.py
@@ -37,8 +37,11 @@ Dependencies:
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 from collections import defaultdict
+
+log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -79,29 +82,35 @@ def reciprocal_rank_fusion(
         return []
 
     # Accumulate scores and keep the best copy of each document.
-    scores: dict[int, float] = defaultdict(float)
-    best_doc: dict[int, dict] = {}
+    # Keys are normalised to str so id=0 (falsy int) is never collapsed
+    # and mixed int/str IDs referring to the same logical doc merge correctly.
+    scores: dict[str, float] = defaultdict(float)
+    best_doc: dict[str, dict] = {}
 
     for result_list in non_empty:
         for rank_0, doc in enumerate(result_list):
-            doc_id = doc["id"]
+            doc_id = doc.get("id")
+            if doc_id is None:
+                continue  # skip docs with no id
+            key = str(doc_id)
             rank_1 = rank_0 + 1  # RRF uses 1-based ranks
-            scores[doc_id] += 1.0 / (k + rank_1)
+            scores[key] += 1.0 / (k + rank_1)
 
             # Keep the copy with the most fields (or the first seen).
-            if doc_id not in best_doc or len(doc) > len(best_doc[doc_id]):
-                best_doc[doc_id] = doc
+            if key not in best_doc or len(doc) > len(best_doc[key]):
+                best_doc[key] = doc
 
     # Build fused result list.
     fused: list[dict] = []
-    for doc_id, rrf_score in scores.items():
-        entry = dict(best_doc[doc_id])  # shallow copy
+    for key, rrf_score in scores.items():
+        entry = dict(best_doc[key])  # shallow copy
         entry["rrf_score"] = round(rrf_score, 8)
         entry["score"] = entry["rrf_score"]
         fused.append(entry)
 
-    # Sort by RRF score descending (tie-break by id for determinism).
-    fused.sort(key=lambda d: (-d["rrf_score"], d["id"]))
+    # Sort by RRF score descending; tie-break by str(id) for determinism
+    # (str comparison is type-stable even when original IDs are mixed types).
+    fused.sort(key=lambda d: (-d["rrf_score"], str(d.get("id", ""))))
     return fused
 
 
@@ -202,57 +211,70 @@ def search_hybrid(
     # ------------------------------------------------------------------
     # 2. Build rank maps for provenance tracking.
     # ------------------------------------------------------------------
-    fts_ranks: dict[int, int] = {
-        doc["id"]: rank + 1 for rank, doc in enumerate(fts_results)
+    # Use str keys so id=0 is never treated as falsy / collapsed.
+    fts_ranks: dict[str, int] = {
+        str(doc["id"]): rank + 1 for rank, doc in enumerate(fts_results)
+        if doc.get("id") is not None
     }
-    vec_ranks: dict[int, int] = {
-        doc["id"]: rank + 1 for rank, doc in enumerate(vec_results)
+    vec_ranks: dict[str, int] = {
+        str(doc["id"]): rank + 1 for rank, doc in enumerate(vec_results)
+        if doc.get("id") is not None
     }
-    sep_ranks: dict[int, int] = {
-        doc["id"]: rank + 1 for rank, doc in enumerate(sep_results)
+    sep_ranks: dict[str, int] = {
+        str(doc["id"]): rank + 1 for rank, doc in enumerate(sep_results)
+        if doc.get("id") is not None
     } if sep_results else {}
 
     # ------------------------------------------------------------------
     # 3. 3-list weighted RRF fusion.
     # ------------------------------------------------------------------
     k = 60
-    scores: dict[int, float] = defaultdict(float)
-    best_doc: dict[int, dict] = {}
+    scores: dict[str, float] = defaultdict(float)
+    best_doc: dict[str, dict] = {}
 
     for rank_0, doc in enumerate(fts_results):
-        doc_id = doc["id"]
-        scores[doc_id] += fts_weight * (1.0 / (k + rank_0 + 1))
-        if doc_id not in best_doc or len(doc) > len(best_doc[doc_id]):
-            best_doc[doc_id] = doc
+        doc_id = doc.get("id")
+        if doc_id is None:
+            continue
+        key = str(doc_id)
+        scores[key] += fts_weight * (1.0 / (k + rank_0 + 1))
+        if key not in best_doc or len(doc) > len(best_doc[key]):
+            best_doc[key] = doc
 
     for rank_0, doc in enumerate(vec_results):
-        doc_id = doc["id"]
-        scores[doc_id] += vec_weight * (1.0 / (k + rank_0 + 1))
-        if doc_id not in best_doc or len(doc) > len(best_doc[doc_id]):
-            best_doc[doc_id] = doc
+        doc_id = doc.get("id")
+        if doc_id is None:
+            continue
+        key = str(doc_id)
+        scores[key] += vec_weight * (1.0 / (k + rank_0 + 1))
+        if key not in best_doc or len(doc) > len(best_doc[key]):
+            best_doc[key] = doc
 
     sep_weight = vec_weight * 0.8  # slightly lower weight for separation
     for rank_0, doc in enumerate(sep_results):
-        doc_id = doc["id"]
-        scores[doc_id] += sep_weight * (1.0 / (k + rank_0 + 1))
-        if doc_id not in best_doc or len(doc) > len(best_doc[doc_id]):
-            best_doc[doc_id] = doc
+        doc_id = doc.get("id")
+        if doc_id is None:
+            continue
+        key = str(doc_id)
+        scores[key] += sep_weight * (1.0 / (k + rank_0 + 1))
+        if key not in best_doc or len(doc) > len(best_doc[key]):
+            best_doc[key] = doc
 
     # ------------------------------------------------------------------
     # 4. Assemble results with provenance metadata.
     # ------------------------------------------------------------------
     fused: list[dict] = []
-    for doc_id, rrf_score in scores.items():
-        entry = dict(best_doc[doc_id])  # shallow copy
+    for key, rrf_score in scores.items():
+        entry = dict(best_doc[key])  # shallow copy
 
-        in_fts = doc_id in fts_ranks
-        in_vec = doc_id in vec_ranks
-        in_sep = doc_id in sep_ranks
+        in_fts = key in fts_ranks
+        in_vec = key in vec_ranks
+        in_sep = key in sep_ranks
 
         entry["rrf_score"] = round(rrf_score, 8)
         entry["score"] = entry["rrf_score"]
-        entry["fts_rank"] = fts_ranks.get(doc_id)
-        entry["vec_rank"] = vec_ranks.get(doc_id)
+        entry["fts_rank"] = fts_ranks.get(key)
+        entry["vec_rank"] = vec_ranks.get(key)
 
         sources = []
         if in_fts:
@@ -265,7 +287,8 @@ def search_hybrid(
 
         fused.append(entry)
 
-    # Sort by RRF score descending (tie-break by id for determinism).
-    fused.sort(key=lambda d: (-d["rrf_score"], d["id"]))
+    # Sort by RRF score descending; tie-break by str(id) for determinism
+    # (str comparison is type-stable even when original IDs are mixed types).
+    fused.sort(key=lambda d: (-d["rrf_score"], str(d.get("id", ""))))
 
     return fused[:limit]

--- a/truememory/hyde.py
+++ b/truememory/hyde.py
@@ -163,10 +163,14 @@ def hyde_search(
         return original_results[:limit]
 
     # Search with hypothetical document
-    hyde_results = search_hybrid(
-        conn, hyp_doc, limit=candidate_pool,
-        fts_weight=fts_weight, vec_weight=vec_weight,
-    )
+    try:
+        hyde_results = search_hybrid(
+            conn, hyp_doc, limit=candidate_pool,
+            fts_weight=fts_weight, vec_weight=vec_weight,
+        )
+    except Exception as e:
+        log.warning("HyDE fusion failed (search with hypothetical doc): %s", e)
+        return original_results[:limit]
 
     # Tag sources
     for r in original_results:
@@ -175,7 +179,11 @@ def hyde_search(
         r["source"] = r.get("source", "hybrid") + "+hyde"
 
     # Fuse with RRF
-    fused = reciprocal_rank_fusion([original_results, hyde_results])
+    try:
+        fused = reciprocal_rank_fusion([original_results, hyde_results])
+    except Exception as e:
+        log.warning("HyDE RRF fusion failed, returning original results: %s", e)
+        return original_results[:limit]
     return fused[:limit]
 
 
@@ -229,7 +237,7 @@ def hyde_multi_search(
             )
             all_result_lists.append(hyde_results)
         except Exception as e:
-            log.debug("HyDE hybrid search failed for hypothetical doc: %s", e)
+            log.warning("HyDE hybrid search failed for hypothetical doc: %s", e)
 
     if len(all_result_lists) == 1:
         return original_results[:limit]


### PR DESCRIPTION
## Summary
- **id-0 collapse fixed:** All doc IDs are now normalised to `str` keys in RRF score accumulators and rank maps, so `id=0` (a falsy int) is never collapsed, dropped, or merged incorrectly with other docs.
- **Type-stable tiebreaks:** Sort tie-break key uses `str(id)` instead of raw `id`, preventing `TypeError` when int and string IDs coexist in the same result set.
- **HyDE fusion errors surfaced:** `hyde_multi_search` now logs at `WARNING` level (was `DEBUG`) when a HyDE search fails. `hyde_search` adds `try/except` around the HyDE search call with a `WARNING` log and graceful fallback to original results.

## Test plan
- [x] 14 new tests in `tests/test_issue_583_rrf_hardening.py`
  - id=0 preserved in single-list and multi-list fusion
  - Mixed int/str ID tiebreaks don't crash
  - int(42) and str("42") merge as same doc
  - HyDE fusion errors emit WARNING-level logs
  - Fallback to original results on HyDE failure
  - Normal RRF behaviour regression tests (empty input, single list, two-list fusion, scores, k parameter, None-id skip)
- [ ] Full test suite (CI)

Closes #583