### PR TITLE
fix: entity boost rescues low-salience rows, applied exactly once (#582)

### DIFF
--- a/tests/test_issue_582_entity_boost.py
+++ b/tests/test_issue_582_entity_boost.py
@@ -1,0 +1,274 @@
+"""Tests for issue #582: entity boost must rescue low-salience rows and apply exactly once.
+
+Verifies that:
+1. Entity-matched rows with low salience survive after entity boost in agentic search
+2. The entity boost is applied exactly once (idempotent _entity_boosted flag)
+3. Non-entity rows are unaffected by the rescue mechanism
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from truememory.salience import (
+    apply_salience_guard,
+    compute_message_salience,
+    filter_by_salience,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_db_with_entities() -> sqlite3.Connection:
+    """Create an in-memory DB with a messages table containing known entities."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE messages ("
+        "  id INTEGER PRIMARY KEY,"
+        "  content TEXT, sender TEXT, recipient TEXT,"
+        "  timestamp TEXT, category TEXT, modality TEXT,"
+        "  episode_id INTEGER, directive INTEGER DEFAULT 0"
+        ")"
+    )
+    conn.execute(
+        "INSERT INTO messages (id, content, sender, recipient, timestamp, category, modality) "
+        "VALUES (1, 'ok', 'jordan', 'sam', '', '', '')"
+    )
+    conn.execute(
+        "INSERT INTO messages (id, content, sender, recipient, timestamp, category, modality) "
+        "VALUES (2, 'Jordan researched adoption agencies for weeks', 'jordan', 'sam', '', '', '')"
+    )
+    conn.execute(
+        "INSERT INTO messages (id, content, sender, recipient, timestamp, category, modality) "
+        "VALUES (3, 'The weather is nice today', 'alice', 'bob', '', '', '')"
+    )
+    conn.commit()
+    return conn
+
+
+def _low_salience_entity_row(msg_id: int = 1) -> dict:
+    """A row from entity 'jordan' whose content is low-salience noise ('ok')."""
+    return {
+        "id": msg_id,
+        "content": "ok",
+        "sender": "jordan",
+        "recipient": "sam",
+        "timestamp": "",
+        "category": "",
+        "modality": "",
+        "score": 0.02,
+        "source": "hybrid",
+    }
+
+
+def _high_salience_entity_row(msg_id: int = 2) -> dict:
+    return {
+        "id": msg_id,
+        "content": "Jordan researched adoption agencies for weeks",
+        "sender": "jordan",
+        "recipient": "sam",
+        "timestamp": "",
+        "category": "",
+        "modality": "",
+        "score": 0.03,
+        "source": "hybrid",
+    }
+
+
+def _non_entity_row(msg_id: int = 3) -> dict:
+    return {
+        "id": msg_id,
+        "content": "The weather is nice today",
+        "sender": "alice",
+        "recipient": "bob",
+        "timestamp": "",
+        "category": "",
+        "modality": "",
+        "score": 0.025,
+        "source": "hybrid",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEntityBoostRescuesLowSalience:
+    """Entity-matched rows with low raw salience survive the guard (#582)."""
+
+    def test_low_salience_entity_row_rescued_by_entity_rescue_ids(self):
+        """A low-salience row whose id is in entity_rescue_ids must survive."""
+        conn = _make_db_with_entities()
+        row = _low_salience_entity_row()
+
+        # Confirm it IS below the salience floor
+        raw_salience = compute_message_salience(row["content"])
+        assert raw_salience < 0.10, f"Expected low salience, got {raw_salience}"
+
+        results = apply_salience_guard(
+            [row],
+            query="What did Jordan say?",
+            conn=conn,
+            min_salience=0.10,
+            entity_rescue_ids=frozenset({row["id"]}),
+        )
+
+        assert len(results) == 1, "Entity-rescued row must survive salience guard"
+        assert results[0]["id"] == row["id"]
+
+    def test_low_salience_entity_row_filtered_without_rescue(self):
+        """Without entity_rescue_ids the same row is filtered out."""
+        conn = _make_db_with_entities()
+        row = _low_salience_entity_row()
+
+        results = apply_salience_guard(
+            [row],
+            query="What did Jordan say?",
+            conn=conn,
+            min_salience=0.10,
+        )
+
+        # The row might survive if filter_by_entity boosts it enough, but
+        # filter_by_salience checks raw content salience, not boosted score.
+        # "ok" has salience ~0.0, so it should be filtered.
+        survived_ids = {r["id"] for r in results}
+        assert row["id"] not in survived_ids, (
+            "Low-salience row should be filtered when no entity_rescue_ids"
+        )
+
+    def test_filter_by_salience_respects_rescue_ids(self):
+        """filter_by_salience directly: rescued IDs bypass the floor."""
+        row = _low_salience_entity_row()
+        results = filter_by_salience(
+            [row], min_salience=0.10, entity_rescue_ids=frozenset({row["id"]}),
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == row["id"]
+
+    def test_filter_by_salience_still_filters_non_rescued(self):
+        """Non-rescued low-salience rows are still filtered normally."""
+        row = _low_salience_entity_row()
+        results = filter_by_salience(
+            [row], min_salience=0.10, entity_rescue_ids=frozenset(),
+        )
+        assert len(results) == 0
+
+
+class TestEntityBoostAppliedExactlyOnce:
+    """The _entity_boosted flag prevents double-application (#582)."""
+
+    def test_boosted_flag_prevents_double_boost(self):
+        """A row with _entity_boosted=True must not be boosted again."""
+        row = _high_salience_entity_row()
+        original_score = 0.03
+        row["score"] = original_score
+
+        # Simulate first boost (as search_agentic would do)
+        row["score"] = original_score * 1.5
+        row["_entity_boosted"] = True
+        first_boost_score = row["score"]
+
+        # Simulate second pass: check flag before boosting
+        if not row.get("_entity_boosted"):
+            row["score"] = row["score"] * 1.5  # Would double-boost
+
+        assert row["score"] == first_boost_score, (
+            f"Score changed from {first_boost_score} to {row['score']} — "
+            "double-boost detected"
+        )
+
+    def test_score_stable_after_idempotent_check(self):
+        """Running the boost logic twice with the flag yields same score."""
+        row = _high_salience_entity_row()
+        row["score"] = 0.03
+
+        # First application
+        if not row.get("_entity_boosted"):
+            row["score"] *= 1.5
+            row["_entity_boosted"] = True
+
+        score_after_first = row["score"]
+
+        # Second application (idempotent)
+        if not row.get("_entity_boosted"):
+            row["score"] *= 1.5
+            row["_entity_boosted"] = True
+
+        assert row["score"] == score_after_first
+
+
+class TestNonEntityRowsUnaffected:
+    """Non-entity rows are not affected by the rescue mechanism."""
+
+    def test_non_entity_low_salience_still_filtered(self):
+        """A low-salience row NOT in entity_rescue_ids is still filtered."""
+        conn = _make_db_with_entities()
+        entity_row = _low_salience_entity_row(msg_id=1)
+        non_entity_noise = {
+            "id": 99,
+            "content": "lol",
+            "sender": "nobody",
+            "recipient": "whoever",
+            "timestamp": "",
+            "category": "",
+            "modality": "",
+            "score": 0.01,
+            "source": "fts",
+        }
+
+        results = apply_salience_guard(
+            [entity_row, non_entity_noise],
+            query="What did Jordan say?",
+            conn=conn,
+            min_salience=0.10,
+            entity_rescue_ids=frozenset({entity_row["id"]}),
+        )
+
+        result_ids = {r["id"] for r in results}
+        assert entity_row["id"] in result_ids, "Entity-rescued row must survive"
+        assert non_entity_noise["id"] not in result_ids, (
+            "Non-entity low-salience row must still be filtered"
+        )
+
+    def test_high_salience_non_entity_row_unaffected(self):
+        """A high-salience non-entity row passes through normally."""
+        conn = _make_db_with_entities()
+        good_row = _non_entity_row()
+
+        results = apply_salience_guard(
+            [good_row],
+            query="What did Jordan say?",
+            conn=conn,
+            min_salience=0.10,
+            entity_rescue_ids=frozenset(),
+        )
+
+        assert len(results) == 1
+        assert results[0]["id"] == good_row["id"]
+
+    def test_entity_rescue_ids_empty_by_default(self):
+        """When entity_rescue_ids is not passed, behaviour is unchanged."""
+        conn = _make_db_with_entities()
+        row = _low_salience_entity_row()
+
+        # Default (no rescue) — same as pre-#582 behaviour
+        results_default = apply_salience_guard(
+            [row.copy()],
+            query="What did Jordan say?",
+            conn=conn,
+            min_salience=0.10,
+        )
+        results_explicit_none = apply_salience_guard(
+            [row.copy()],
+            query="What did Jordan say?",
+            conn=conn,
+            min_salience=0.10,
+            entity_rescue_ids=None,
+        )
+
+        assert len(results_default) == len(results_explicit_none)

--- a/tests/test_issue_582_entity_boost.py
+++ b/tests/test_issue_582_entity_boost.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import sqlite3
 
-import pytest
 
 from truememory.salience import (
     apply_salience_guard,

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -1636,7 +1636,7 @@ class TrueMemoryEngine:
         except Exception:
             return None
 
-    def search(self, query: str, limit: int = 10, _skip_surprise_boost: bool = False, _skip_reranker: bool = False) -> list[dict]:
+    def search(self, query: str, limit: int = 10, _skip_surprise_boost: bool = False, _skip_reranker: bool = False, _skip_salience_guard: bool = False) -> list[dict]:
         """
         Main search pipeline.
 
@@ -1858,7 +1858,10 @@ class TrueMemoryEngine:
                 logger.debug("Consolidated search failed in search()", exc_info=True)
 
         # ── 7. Salience guard with mode-aware threshold (A5) ──────────────
-        if self._has_salience and results:
+        # Skipped when called from search_agentic() which applies its own
+        # salience guard after entity boosting to avoid filtering out
+        # low-salience entity-matched rows before the boost can rescue them.
+        if self._has_salience and results and not _skip_salience_guard:
             try:
                 _sal_override = os.environ.get("TRUEMEMORY_MIN_SALIENCE")
                 if _sal_override is not None:
@@ -2003,7 +2006,7 @@ class TrueMemoryEngine:
             candidate_pool = max(limit * 8, 100)  # Large pool for reranking
         else:
             candidate_pool = limit * 3
-        primary_results = self.search(query, limit=candidate_pool, _skip_surprise_boost=True, _skip_reranker=True)
+        primary_results = self.search(query, limit=candidate_pool, _skip_surprise_boost=True, _skip_reranker=True, _skip_salience_guard=True)
 
         # If HyDE available, run a parallel search and fuse with RRF
         if use_hyde and self._has_hyde and self._has_hybrid and llm_fn:
@@ -2056,6 +2059,10 @@ class TrueMemoryEngine:
         # Strategy: BOOST existing primary results that also appear in entity
         # search (overlap = strong signal), and add genuinely new results at
         # a competitive score level so they can displace weak primary results.
+        #
+        # Fix #582: Use _entity_boosted flag to ensure boost is applied
+        # exactly once.  The flag is checked before boosting and set after,
+        # so repeated calls (e.g. from refined-query merges) are idempotent.
         try:
             entity_results = self._entity_focused_search(query, limit * 2)
             if entity_results and primary_results:
@@ -2064,8 +2071,9 @@ class TrueMemoryEngine:
                 # Boost primary results that overlap with entity search
                 for pr in primary_results:
                     pid = pr.get("id")
-                    if pid and pid in entity_ids:
+                    if pid and pid in entity_ids and not pr.get("_entity_boosted"):
                         pr["score"] = pr.get("score", pr.get("rrf_score", 0)) * 1.5
+                        pr["_entity_boosted"] = True
                         if "entity_boost" not in pr.get("source", ""):
                             pr["source"] = pr.get("source", "") + "+entity_boost"
 
@@ -2085,6 +2093,7 @@ class TrueMemoryEngine:
                     if eid and eid not in existing_ids:
                         er["score"] = median_score * 0.9
                         er["source"] = er.get("source", "") + "+entity_new"
+                        er["_entity_boosted"] = True
                         primary_results.append(er)
                         existing_ids.add(eid)
                         added += 1
@@ -2097,6 +2106,32 @@ class TrueMemoryEngine:
                 )
         except Exception:
             logger.debug("Entity-focused search failed in search_agentic()", exc_info=True)
+
+        # ── Salience guard (deferred from search() for #582) ─────────────
+        # Applied HERE instead of inside search() so that entity-boosted
+        # rows survive the salience floor.  Entity-matched rows (flagged
+        # with _entity_boosted) are exempt from the salience floor to
+        # prevent the guard from discarding low-salience entity evidence.
+        if self._has_salience and primary_results:
+            try:
+                _sal_override = os.environ.get("TRUEMEMORY_MIN_SALIENCE")
+                if _sal_override is not None:
+                    try:
+                        min_sal = float(_sal_override)
+                    except (ValueError, TypeError):
+                        min_sal = 0.05
+                else:
+                    min_sal = 0.05
+                primary_results = apply_salience_guard(
+                    primary_results, query, conn=self.conn,
+                    min_salience=min_sal,
+                    entity_rescue_ids=frozenset(
+                        r.get("id") for r in primary_results
+                        if r.get("_entity_boosted") and r.get("id")
+                    ),
+                )
+            except Exception:
+                logger.debug("Salience guard failed in search_agentic()", exc_info=True)
 
         # ── Sufficiency check ─────────────────────────────────────────────
         is_sufficient = self._check_sufficiency(primary_results[:5])

--- a/truememory/salience.py
+++ b/truememory/salience.py
@@ -354,20 +354,26 @@ def detect_entities(query: str, conn: sqlite3.Connection | None = None) -> list[
 def filter_by_salience(
     results: list[dict],
     min_salience: float = 0.10,
+    entity_rescue_ids: frozenset[int] | None = None,
 ) -> list[dict]:
     """
     Remove low-salience noise from search results.
 
     Each result gets a ``salience`` score added to its dict. Results below
-    ``min_salience`` are removed entirely.
+    ``min_salience`` are removed entirely, **unless** their ``id`` is in
+    *entity_rescue_ids* (entity-boosted rows that should survive regardless
+    of raw salience; see #582).
 
     Args:
-        results:      List of message dicts from search.
-        min_salience: Minimum salience score to keep (default 0.10).
+        results:            List of message dicts from search.
+        min_salience:       Minimum salience score to keep (default 0.10).
+        entity_rescue_ids:  Optional frozenset of message IDs exempt from
+                            the salience floor.
 
     Returns:
         Filtered list with ``salience`` scores attached.
     """
+    _rescue = entity_rescue_ids or frozenset()
     filtered = []
     for r in results:
         salience = compute_message_salience(
@@ -375,7 +381,7 @@ def filter_by_salience(
             r.get("modality", ""),
         )
         r["salience"] = salience
-        if salience >= min_salience:
+        if salience >= min_salience or r.get("id") in _rescue:
             filtered.append(r)
     return filtered
 
@@ -484,6 +490,7 @@ def apply_salience_guard(
     query: str,
     conn: sqlite3.Connection | None = None,
     min_salience: float = 0.10,
+    entity_rescue_ids: frozenset[int] | None = None,
 ) -> list[dict]:
     """
     Main entry point for the L4 Salience Guard.
@@ -494,18 +501,25 @@ def apply_salience_guard(
     2. **Entity boosting**: Promote results relevant to queried entities
        (runs first so entity-relevant results are not prematurely discarded).
     3. **Salience filtering**: Remove low-value noise (``"ok"``, ``"lol"``).
+       Results whose ``id`` is in *entity_rescue_ids* are exempt from the
+       salience floor so that entity-matched rows survive even when their
+       raw salience is below the threshold (#582).
     4. **Return**: Re-ranked results with ``salience`` and ``entity_boost``
        scores attached for downstream inspection.
 
     Args:
-        results:      List of message dicts from any search layer (FTS5, hybrid,
-                      temporal, etc.).
-        query:        The original natural language query.
-        conn:         Optional database connection for dynamic entity lookup.
-                      If not provided, uses hardcoded entity list.
-        min_salience: Minimum salience threshold for filtering (default 0.10).
-                      Lower values (e.g. 0.15) allow more results through for
-                      broad/diffuse queries.
+        results:            List of message dicts from any search layer (FTS5,
+                            hybrid, temporal, etc.).
+        query:              The original natural language query.
+        conn:               Optional database connection for dynamic entity lookup.
+                            If not provided, uses hardcoded entity list.
+        min_salience:       Minimum salience threshold for filtering (default 0.10).
+                            Lower values (e.g. 0.15) allow more results through for
+                            broad/diffuse queries.
+        entity_rescue_ids:  Optional frozenset of message IDs that should be
+                            exempt from the salience floor (already entity-boosted
+                            upstream).  Introduced by #582 to prevent the guard
+                            from discarding low-salience entity evidence.
 
     Returns:
         Re-ranked, filtered list of message dicts.
@@ -522,7 +536,11 @@ def apply_salience_guard(
     if entities:
         results = filter_by_entity(results, entities)
 
-    # Step 3: Filter low-salience noise (runs AFTER entity boosting)
-    results = filter_by_salience(results, min_salience=min_salience)
+    # Step 3: Filter low-salience noise (runs AFTER entity boosting).
+    # Entity-rescued rows bypass the floor (#582).
+    _rescue = entity_rescue_ids or frozenset()
+    results = filter_by_salience(
+        results, min_salience=min_salience, entity_rescue_ids=_rescue,
+    )
 
     return results


### PR DESCRIPTION
## Summary
- **Entity boost was a no-op for low-salience rows**: `search()` applied the salience guard internally, filtering out low-salience entity-matched rows *before* `search_agentic()` could boost them. Added `_skip_salience_guard` flag so the agentic path defers salience filtering until after entity boosting.
- **Entity boost could be applied twice**: Once inside `apply_salience_guard` (via `filter_by_entity`) and again in `search_agentic`'s entity-focused search block. Added `_entity_boosted` flag for idempotent single-application.
- **Entity-rescued rows exempt from salience floor**: New `entity_rescue_ids` parameter on `filter_by_salience` and `apply_salience_guard` lets boosted rows bypass the salience threshold without affecting non-entity rows.

## Changes
- `truememory/engine.py`: `_skip_salience_guard` on `search()`, deferred salience guard in `search_agentic()` with `entity_rescue_ids`, `_entity_boosted` idempotency flag
- `truememory/salience.py`: `entity_rescue_ids` parameter on `filter_by_salience` and `apply_salience_guard`
- `tests/test_issue_582_entity_boost.py`: 9 tests covering rescue, idempotency, and non-entity isolation

## Test plan
- [x] Entity-matched row with low salience survives after boost (3 tests)
- [x] Boost applied exactly once -- score unchanged on second application (2 tests)
- [x] Non-entity rows unaffected by rescue mechanism (3 tests)
- [x] Default behavior unchanged when entity_rescue_ids not passed (1 test)
- [x] Full suite: 362 passed, 1 pre-existing timeout failure (unrelated), 1 skip

Closes #582