### PR TITLE
perf: consolidation compute outside transaction — unblock concurrent writers (#591)

### DIFF
--- a/tests/test_issue_591_consolidation_txn.py
+++ b/tests/test_issue_591_consolidation_txn.py
@@ -1,0 +1,395 @@
+"""Tests for issue #591: detect_contradictions and build_structured_facts must
+not hold the SQLite write lock during expensive regex computation.
+
+Pre-fix: detect_contradictions interleaved regex scanning with INSERTs into
+fact_timeline inside one long implicit transaction, blocking concurrent
+writers for the entire duration.  build_structured_facts had the same
+problem with its regex scanning and INSERT into summaries.
+
+Fix: both functions now follow the three-phase pattern established in #401
+for build_summaries: read -> compute (no transaction) -> short atomic write.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from truememory.storage import create_db
+from truememory import consolidation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _seed_contradictions(conn, n_changes=5):
+    """Insert messages that trigger contradiction detection patterns."""
+    rows = []
+    techs = [
+        ("PostgreSQL", "TimescaleDB"),
+        ("TimescaleDB", "ClickHouse"),
+        ("React", "Vue"),
+        ("AWS", "GCP"),
+        ("Slack", "Discord"),
+    ]
+    for i, (old, new) in enumerate(techs[:n_changes]):
+        rows.append((
+            f"We switched from {old} to {new} last week.",
+            "alice", "bob",
+            f"2026-{(i + 1):02d}-15T10:00:00Z",
+            "session", "conversation",
+        ))
+    # Add some filler messages so there is enough data
+    for i in range(20):
+        rows.append((
+            f"General update #{i}: things are going well with the project.",
+            "alice", "bob",
+            f"2026-01-{(i % 27) + 1:02d}T09:00:00Z",
+            "session", "conversation",
+        ))
+    conn.executemany(
+        "INSERT INTO messages "
+        "(content, sender, recipient, timestamp, category, modality) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+
+
+def _seed_structured_facts(conn):
+    """Insert messages that trigger structured fact extraction patterns."""
+    rows = [
+        ("Alice is our CTO and she runs the engineering team.",
+         "bob", "carol", "2026-01-10T10:00:00Z", "session", "conversation"),
+        ("We hired Dave as a senior engineer last month.",
+         "alice", "bob", "2026-02-05T10:00:00Z", "session", "conversation"),
+        ("Our office is in downtown Austin near the river.",
+         "alice", "bob", "2026-01-20T10:00:00Z", "session", "conversation"),
+        ("The company headquarters is in San Francisco.",
+         "carol", "dave", "2026-03-01T10:00:00Z", "session", "conversation"),
+    ]
+    # Add filler for realism
+    for i in range(15):
+        rows.append((
+            f"Status report #{i}: Sprint velocity is stable.",
+            "alice", "bob",
+            f"2026-01-{(i % 27) + 1:02d}T08:00:00Z",
+            "session", "conversation",
+        ))
+    conn.executemany(
+        "INSERT INTO messages "
+        "(content, sender, recipient, timestamp, category, modality) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# detect_contradictions — correctness
+# ---------------------------------------------------------------------------
+
+class TestDetectContradictionsCorrectness:
+
+    def test_detects_explicit_change(self, tmp_path):
+        """Contradictions from 'switched from X to Y' are detected."""
+        conn = create_db(str(tmp_path / "c.db"))
+        _seed_contradictions(conn)
+        result = consolidation.detect_contradictions(conn)
+        assert len(result) > 0
+        subjects = [r["subject"] for r in result]
+        # Should detect database-related change (PostgreSQL -> TimescaleDB)
+        assert any("database" in s for s in subjects), (
+            f"Expected a database contradiction, got subjects: {subjects}"
+        )
+        conn.close()
+
+    def test_fact_timeline_populated(self, tmp_path):
+        """fact_timeline table has rows after detect_contradictions."""
+        conn = create_db(str(tmp_path / "c.db"))
+        _seed_contradictions(conn)
+        consolidation.detect_contradictions(conn)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM fact_timeline"
+        ).fetchone()[0]
+        assert count > 0
+        conn.close()
+
+    def test_supersession_links(self, tmp_path):
+        """Superseded facts have superseded_by set to the newer fact's ID."""
+        conn = create_db(str(tmp_path / "c.db"))
+        _seed_contradictions(conn)
+        consolidation.detect_contradictions(conn)
+        superseded = conn.execute(
+            "SELECT COUNT(*) FROM fact_timeline WHERE superseded_by IS NOT NULL"
+        ).fetchone()[0]
+        assert superseded > 0, "Expected at least one superseded fact"
+        # Verify superseded_by points to a real row
+        broken = conn.execute(
+            "SELECT COUNT(*) FROM fact_timeline f "
+            "WHERE f.superseded_by IS NOT NULL "
+            "AND f.superseded_by NOT IN (SELECT id FROM fact_timeline)"
+        ).fetchone()[0]
+        assert broken == 0, "superseded_by points to non-existent row"
+        conn.close()
+
+    def test_idempotent(self, tmp_path):
+        """Running detect_contradictions twice produces the same results."""
+        conn = create_db(str(tmp_path / "c.db"))
+        _seed_contradictions(conn)
+        r1 = consolidation.detect_contradictions(conn)
+        count1 = conn.execute(
+            "SELECT COUNT(*) FROM fact_timeline"
+        ).fetchone()[0]
+        r2 = consolidation.detect_contradictions(conn)
+        count2 = conn.execute(
+            "SELECT COUNT(*) FROM fact_timeline"
+        ).fetchone()[0]
+        assert len(r1) == len(r2)
+        assert count1 == count2
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# detect_contradictions — transaction behavior
+# ---------------------------------------------------------------------------
+
+class TestDetectContradictionsTxn:
+
+    def test_no_write_lock_during_compute(self, tmp_path, monkeypatch):
+        """A concurrent writer must succeed WHILE _compute_contradictions runs.
+
+        We hook _compute_contradictions so that during its execution a second
+        connection performs a quick write.  If the write lock were held this
+        would fail with 'database is locked'.
+        """
+        db = str(tmp_path / "c.db")
+        conn = create_db(db)
+        conn.execute("PRAGMA journal_mode=WAL")
+        _seed_contradictions(conn)
+
+        state = {"attempted": False, "ok": None, "err": None}
+        real_compute = consolidation._compute_contradictions
+
+        def hooked(all_msgs):
+            result = real_compute(all_msgs)
+            if not state["attempted"]:
+                state["attempted"] = True
+                try:
+                    other = sqlite3.connect(db, timeout=0.5)
+                    other.execute("PRAGMA busy_timeout=500")
+                    other.execute(
+                        "INSERT INTO messages "
+                        "(content, sender, recipient, timestamp, category, modality) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        ("concurrent probe", "x", "y",
+                         "2026-06-01T00:00:00Z", "session", "conversation"),
+                    )
+                    other.commit()
+                    other.close()
+                    state["ok"] = True
+                except Exception as e:
+                    state["ok"] = False
+                    state["err"] = repr(e)
+            return result
+
+        monkeypatch.setattr(consolidation, "_compute_contradictions", hooked)
+        consolidation.detect_contradictions(conn)
+        conn.close()
+
+        assert state["attempted"], "compute hook never ran"
+        assert state["ok"] is True, (
+            f"#591 regression: concurrent write blocked during "
+            f"detect_contradictions compute phase: {state['err']}"
+        )
+
+    def test_atomic_rollback_on_write_failure(self, tmp_path):
+        """If the write phase fails, fact_timeline is not left empty."""
+        db = str(tmp_path / "c.db")
+        conn = create_db(db)
+        _seed_contradictions(conn)
+        # First run to populate fact_timeline
+        consolidation.detect_contradictions(conn)
+        before = conn.execute(
+            "SELECT COUNT(*) FROM fact_timeline"
+        ).fetchone()[0]
+        assert before > 0
+
+        # Use a proxy that fails on INSERT INTO fact_timeline
+        class _FailInsert:
+            """Proxy: forwards everything but fails on fact_timeline INSERT."""
+            def __init__(self, real):
+                object.__setattr__(self, "_real", real)
+                object.__setattr__(self, "_count", 0)
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def __setattr__(self, name, value):
+                setattr(self._real, name, value)
+
+            def execute(self, sql, *args, **kwargs):
+                if "INSERT INTO fact_timeline" in str(sql):
+                    n = object.__getattribute__(self, "_count")
+                    object.__setattr__(self, "_count", n + 1)
+                    if n == 0:
+                        raise sqlite3.OperationalError(
+                            "simulated write failure"
+                        )
+                return self._real.execute(sql, *args, **kwargs)
+
+        proxy = _FailInsert(conn)
+        with pytest.raises(sqlite3.OperationalError):
+            consolidation.detect_contradictions(proxy)
+
+        after = conn.execute(
+            "SELECT COUNT(*) FROM fact_timeline"
+        ).fetchone()[0]
+        assert after == before, (
+            "rollback should preserve prior fact_timeline when write fails"
+        )
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# build_structured_facts — correctness
+# ---------------------------------------------------------------------------
+
+class TestBuildStructuredFactsCorrectness:
+
+    def test_extracts_team_and_locations(self, tmp_path):
+        """Structured facts include team roster and location records."""
+        conn = create_db(str(tmp_path / "c.db"))
+        _seed_structured_facts(conn)
+        n = consolidation.build_structured_facts(conn)
+        assert n > 0
+        rows = conn.execute(
+            "SELECT summary FROM summaries WHERE period = 'structured_fact'"
+        ).fetchall()
+        texts = [r[0] for r in rows]
+        has_roster = any("Team Roster" in t for t in texts)
+        has_location = any("Known Locations" in t or "Location" in t for t in texts)
+        assert has_roster or has_location, (
+            f"Expected team roster or location facts, got: {texts}"
+        )
+        conn.close()
+
+    def test_idempotent(self, tmp_path):
+        """Running build_structured_facts twice produces the same count."""
+        conn = create_db(str(tmp_path / "c.db"))
+        _seed_structured_facts(conn)
+        n1 = consolidation.build_structured_facts(conn)
+        n2 = consolidation.build_structured_facts(conn)
+        assert n1 == n2
+        # Should not duplicate rows
+        total = conn.execute(
+            "SELECT COUNT(*) FROM summaries WHERE period = 'structured_fact'"
+        ).fetchone()[0]
+        assert total == n2
+        conn.close()
+
+    def test_does_not_clobber_other_summaries(self, tmp_path):
+        """build_structured_facts only deletes structured_fact rows."""
+        conn = create_db(str(tmp_path / "c.db"))
+        _seed_structured_facts(conn)
+        # Build regular summaries first
+        consolidation.build_summaries(conn)
+        monthly_before = conn.execute(
+            "SELECT COUNT(*) FROM summaries WHERE period = 'monthly'"
+        ).fetchone()[0]
+        # Now build structured facts
+        consolidation.build_structured_facts(conn)
+        monthly_after = conn.execute(
+            "SELECT COUNT(*) FROM summaries WHERE period = 'monthly'"
+        ).fetchone()[0]
+        assert monthly_after == monthly_before, (
+            "build_structured_facts should not delete monthly summaries"
+        )
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# build_structured_facts — transaction behavior
+# ---------------------------------------------------------------------------
+
+class TestBuildStructuredFactsTxn:
+
+    def test_no_write_lock_during_compute(self, tmp_path, monkeypatch):
+        """A concurrent writer must succeed WHILE _compute_structured_facts runs."""
+        db = str(tmp_path / "c.db")
+        conn = create_db(db)
+        conn.execute("PRAGMA journal_mode=WAL")
+        _seed_structured_facts(conn)
+
+        state = {"attempted": False, "ok": None, "err": None}
+        real_compute = consolidation._compute_structured_facts
+
+        def hooked(all_msgs):
+            result = real_compute(all_msgs)
+            if not state["attempted"]:
+                state["attempted"] = True
+                try:
+                    other = sqlite3.connect(db, timeout=0.5)
+                    other.execute("PRAGMA busy_timeout=500")
+                    other.execute(
+                        "INSERT INTO messages "
+                        "(content, sender, recipient, timestamp, category, modality) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        ("concurrent probe", "x", "y",
+                         "2026-06-01T00:00:00Z", "session", "conversation"),
+                    )
+                    other.commit()
+                    other.close()
+                    state["ok"] = True
+                except Exception as e:
+                    state["ok"] = False
+                    state["err"] = repr(e)
+            return result
+
+        monkeypatch.setattr(consolidation, "_compute_structured_facts", hooked)
+        consolidation.build_structured_facts(conn)
+        conn.close()
+
+        assert state["attempted"], "compute hook never ran"
+        assert state["ok"] is True, (
+            f"#591 regression: concurrent write blocked during "
+            f"build_structured_facts compute phase: {state['err']}"
+        )
+
+    def test_atomic_rollback_on_write_failure(self, tmp_path):
+        """If the write phase fails, prior structured_fact rows survive."""
+        db = str(tmp_path / "c.db")
+        conn = create_db(db)
+        _seed_structured_facts(conn)
+        consolidation.build_structured_facts(conn)
+        before = conn.execute(
+            "SELECT COUNT(*) FROM summaries WHERE period = 'structured_fact'"
+        ).fetchone()[0]
+        assert before > 0
+
+        class _FailExecMany:
+            """Proxy that makes executemany raise."""
+            def __init__(self, real):
+                object.__setattr__(self, "_real", real)
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def __setattr__(self, name, value):
+                setattr(self._real, name, value)
+
+            def executemany(self, *a, **k):
+                raise sqlite3.OperationalError("simulated write failure")
+
+        proxy = _FailExecMany(conn)
+        with pytest.raises(sqlite3.OperationalError):
+            consolidation.build_structured_facts(proxy)
+
+        after = conn.execute(
+            "SELECT COUNT(*) FROM summaries WHERE period = 'structured_fact'"
+        ).fetchone()[0]
+        assert after == before, (
+            "rollback should preserve prior structured_fact rows when write fails"
+        )
+        conn.close()

--- a/truememory/consolidation.py
+++ b/truememory/consolidation.py
@@ -311,6 +311,212 @@ def build_entity_timelines(conn: sqlite3.Connection) -> dict:
     return dict(timelines)
 
 
+def _compute_contradictions(all_msgs: list[dict]) -> tuple[list[tuple], list[tuple], list[dict]]:
+    """Compute contradiction facts entirely in memory (no DB access).
+
+    This is the expensive phase: regex scanning every message against every
+    change pattern.  Factored out of :func:`detect_contradictions` so it can
+    run OUTSIDE the write transaction (#591).
+
+    Returns:
+        ``(insert_rows, supersede_updates, contradictions)``
+
+        *insert_rows* — list of tuples
+        ``(local_id, subject, fact, source_message_id, timestamp,
+        entity_scope, valid_from)`` ready for bulk INSERT.
+
+        *supersede_updates* — list of ``(superseded_local_id,
+        superseding_local_id, valid_to_timestamp)`` pairs expressed with
+        local (in-memory) IDs so the caller can translate to real DB IDs
+        after inserting.
+
+        *contradictions* — the user-facing list of contradiction dicts.
+    """
+    # Local auto-increment for in-memory IDs (translated to real DB IDs
+    # after the bulk INSERT).
+    next_local_id = 1
+    # subject -> [(fact_value, timestamp, msg_id, local_id)]
+    fact_history: dict[str, list[tuple]] = defaultdict(list)
+    contradictions: list[dict] = []
+    insert_rows: list[tuple] = []
+    supersede_updates: list[tuple] = []  # (old_local_id, new_local_id, valid_to)
+
+    for msg in all_msgs:
+        content = msg["content"]
+        timestamp = msg["timestamp"]
+        msg_id = msg["id"]
+
+        for pattern_def in _CHANGE_PATTERNS:
+            matches = pattern_def["pattern"].finditer(content)
+
+            for match in matches:
+                groups = match.groups()
+
+                if pattern_def["type"] == "explicit_change" and len(groups) >= 2:
+                    old_val = groups[0].strip()
+                    new_val = groups[1].strip()
+                    subject = _normalize_subject(old_val, content)
+
+                    entity_context = ""
+                    nearby_nouns = re.findall(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b', content[:100])
+                    common_words = {"The", "This", "That", "We", "They", "Our", "My", "But", "And", "Just", "Not"}
+                    entities = [n for n in nearby_nouns if n not in common_words and len(n) > 2]
+                    if entities:
+                        entity_context = entities[0].lower()
+
+                    # Record the old fact if not already tracked
+                    if subject not in fact_history or not fact_history[subject]:
+                        old_local_id = next_local_id
+                        next_local_id += 1
+                        insert_rows.append((
+                            old_local_id, subject, old_val, msg_id,
+                            timestamp, entity_context, timestamp,
+                        ))
+                        fact_history[subject].append(
+                            (old_val, timestamp, msg_id, old_local_id)
+                        )
+
+                    # Record the new fact and supersede the old
+                    new_local_id = next_local_id
+                    next_local_id += 1
+                    insert_rows.append((
+                        new_local_id, subject, new_val, msg_id,
+                        timestamp, entity_context, timestamp,
+                    ))
+
+                    if fact_history[subject]:
+                        prev = fact_history[subject][-1]
+                        supersede_updates.append(
+                            (prev[3], new_local_id, timestamp)
+                        )
+
+                    fact_history[subject].append(
+                        (new_val, timestamp, msg_id, new_local_id)
+                    )
+
+                    contradictions.append({
+                        "subject": subject,
+                        "old_fact": old_val,
+                        "new_fact": new_val,
+                        "old_timestamp": fact_history[subject][-2][1]
+                        if len(fact_history[subject]) >= 2 else "",
+                        "new_timestamp": timestamp,
+                        "source_message_id": msg_id,
+                    })
+
+                elif pattern_def["type"] == "pricing" and len(groups) >= 2:
+                    price = groups[0].strip()
+                    unit = groups[1].strip()
+
+                    entity_context = ""
+                    nearby_nouns = re.findall(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b', content)
+                    common_words = {"The", "This", "That", "We", "They", "Our", "My", "But", "And", "Just", "Not"}
+                    entities = [n for n in nearby_nouns if n not in common_words and len(n) > 2]
+                    if entities:
+                        entity_context = entities[0].lower()
+
+                    subject = f"pricing_{entity_context}_{unit}" if entity_context else f"pricing_{unit}"
+
+                    new_local_id = next_local_id
+                    next_local_id += 1
+                    insert_rows.append((
+                        new_local_id, subject, price, msg_id,
+                        timestamp, entity_context, timestamp,
+                    ))
+
+                    if subject in fact_history and fact_history[subject]:
+                        prev = fact_history[subject][-1]
+                        if prev[0] != price:
+                            supersede_updates.append(
+                                (prev[3], new_local_id, timestamp)
+                            )
+                            contradictions.append({
+                                "subject": subject,
+                                "old_fact": prev[0],
+                                "new_fact": price,
+                                "old_timestamp": prev[1],
+                                "new_timestamp": timestamp,
+                                "source_message_id": msg_id,
+                            })
+
+                    fact_history[subject].append(
+                        (price, timestamp, msg_id, new_local_id)
+                    )
+
+                elif pattern_def["type"] in ("location_change",
+                                              "schedule_change"):
+                    if groups:
+                        fact_val = groups[0].strip()
+                        if (len(fact_val) < _MIN_FACT_LEN
+                                or len(fact_val) > _MAX_FACT_LEN):
+                            continue
+
+                        subject = _normalize_subject(fact_val, content)
+
+                        entity_context = ""
+                        nearby_nouns = re.findall(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b', content[:100])
+                        common_words = {"The", "This", "That", "We", "They", "Our", "My", "But", "And", "Just", "Not"}
+                        entities = [n for n in nearby_nouns if n not in common_words and len(n) > 2]
+                        if entities:
+                            entity_context = entities[0].lower()
+
+                        new_local_id = next_local_id
+                        next_local_id += 1
+                        insert_rows.append((
+                            new_local_id, subject, fact_val, msg_id,
+                            timestamp, entity_context, timestamp,
+                        ))
+
+                        if (subject in fact_history
+                                and fact_history[subject]):
+                            prev = fact_history[subject][-1]
+                            if prev[0].lower() != fact_val.lower():
+                                supersede_updates.append(
+                                    (prev[3], new_local_id, timestamp)
+                                )
+                                contradictions.append({
+                                    "subject": subject,
+                                    "old_fact": prev[0],
+                                    "new_fact": fact_val,
+                                    "old_timestamp": prev[1],
+                                    "new_timestamp": timestamp,
+                                    "source_message_id": msg_id,
+                                })
+
+                        fact_history[subject].append(
+                            (fact_val, timestamp, msg_id, new_local_id)
+                        )
+
+                elif pattern_def["type"] == "status_change" and groups:
+                    person = groups[0].strip()
+                    if (len(person) < _MIN_FACT_LEN
+                            or len(person) > _MAX_FACT_LEN):
+                        continue
+
+                    verb_match = re.search(
+                        r"(quit|left|started|joined|hired|fired|"
+                        r"resigned|promoted)",
+                        content, re.IGNORECASE,
+                    )
+                    verb = verb_match.group(1).lower() if verb_match else "changed"
+
+                    subject = f"status_{person.lower()}"
+                    fact_val = f"{person} {verb}"
+                    entity_context = person.lower()
+
+                    new_local_id = next_local_id
+                    next_local_id += 1
+                    insert_rows.append((
+                        new_local_id, subject, fact_val, msg_id,
+                        timestamp, entity_context, timestamp,
+                    ))
+                    fact_history[subject].append(
+                        (fact_val, timestamp, msg_id, new_local_id)
+                    )
+
+    return insert_rows, supersede_updates, contradictions
+
+
 def detect_contradictions(conn: sqlite3.Connection) -> list[dict]:
     """
     Find facts that changed over time (contradictions).
@@ -331,226 +537,73 @@ def detect_contradictions(conn: sqlite3.Connection) -> list[dict]:
     newer fact supersedes an older one, the older record's
     ``superseded_by`` column is updated.
 
+    The implementation follows a three-phase pattern (#591) so that
+    expensive regex computation does NOT hold the SQLite write lock:
+
+    1. **Read** messages (short read, or no transaction).
+    2. **Compute** contradictions entirely in memory
+       (:func:`_compute_contradictions`).
+    3. **Write** results in one short, atomic transaction.
+
     Returns:
         List of contradiction records, each a dict with ``subject``,
         ``old_fact``, ``new_fact``, ``old_timestamp``, ``new_timestamp``,
         ``source_message_id``.
     """
+    # --- Phase 1: read ---------------------------------------------------
     all_msgs = _get_all_messages_chrono(conn)
 
-    # Clear existing fact_timeline for a clean rebuild
-    conn.execute("DELETE FROM fact_timeline")
+    # --- Phase 2: compute (no transaction held) --------------------------
+    insert_rows, supersede_updates, contradictions = _compute_contradictions(
+        all_msgs,
+    )
 
-    # Track facts by subject: subject -> [(fact_value, timestamp, msg_id, db_id)]
-    fact_history: dict[str, list[tuple]] = defaultdict(list)
-    contradictions: list[dict] = []
+    # --- Phase 3: write (short atomic transaction) -----------------------
+    # Same manual-transaction pattern used by build_summaries (#401).
+    if conn.in_transaction:
+        conn.commit()
+    prev_isolation = conn.isolation_level
+    try:
+        conn.isolation_level = None
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("DELETE FROM fact_timeline")
 
-    for msg in all_msgs:
-        content = msg["content"]
-        timestamp = msg["timestamp"]
-        msg_id = msg["id"]
+        # Bulk-insert all fact rows and build local_id -> real_db_id map.
+        local_to_db: dict[int, int] = {}
+        for row in insert_rows:
+            local_id = row[0]
+            cursor = conn.execute(
+                "INSERT INTO fact_timeline "
+                "(subject, fact, source_message_id, timestamp, "
+                " entity_scope, valid_from) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                row[1:],
+            )
+            local_to_db[local_id] = cursor.lastrowid
 
-        for pattern_def in _CHANGE_PATTERNS:
-            matches = pattern_def["pattern"].finditer(content)
+        # Apply supersession updates using real DB IDs.
+        for old_local, new_local, valid_to in supersede_updates:
+            old_db_id = local_to_db[old_local]
+            new_db_id = local_to_db[new_local]
+            conn.execute(
+                "UPDATE fact_timeline SET superseded_by = ? WHERE id = ?",
+                (new_db_id, old_db_id),
+            )
+            conn.execute(
+                "UPDATE fact_timeline SET valid_to = ? WHERE id = ?",
+                (valid_to, old_db_id),
+            )
 
-            for match in matches:
-                groups = match.groups()
+        conn.execute("COMMIT")
+    except Exception:
+        try:
+            conn.execute("ROLLBACK")
+        except Exception:
+            pass
+        raise
+    finally:
+        conn.isolation_level = prev_isolation
 
-                if pattern_def["type"] == "explicit_change" and len(groups) >= 2:
-                    old_val = groups[0].strip()
-                    new_val = groups[1].strip()
-                    subject = _normalize_subject(old_val, content)
-
-                    # Try to extract entity context
-                    entity_context = ""
-                    nearby_nouns = re.findall(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b', content[:100])
-                    common_words = {"The", "This", "That", "We", "They", "Our", "My", "But", "And", "Just", "Not"}
-                    entities = [n for n in nearby_nouns if n not in common_words and len(n) > 2]
-                    if entities:
-                        entity_context = entities[0].lower()
-
-                    # Record the old fact if not already tracked
-                    if subject not in fact_history or not fact_history[subject]:
-                        cursor = conn.execute(
-                            "INSERT INTO fact_timeline "
-                            "(subject, fact, source_message_id, timestamp, entity_scope, valid_from) "
-                            "VALUES (?, ?, ?, ?, ?, ?)",
-                            (subject, old_val, msg_id, timestamp, entity_context, timestamp),
-                        )
-                        old_db_id = cursor.lastrowid
-                        fact_history[subject].append(
-                            (old_val, timestamp, msg_id, old_db_id)
-                        )
-
-                    # Record the new fact and supersede the old
-                    cursor = conn.execute(
-                        "INSERT INTO fact_timeline "
-                        "(subject, fact, source_message_id, timestamp, entity_scope, valid_from) "
-                        "VALUES (?, ?, ?, ?, ?, ?)",
-                        (subject, new_val, msg_id, timestamp, entity_context, timestamp),
-                    )
-                    new_db_id = cursor.lastrowid
-
-                    # Update the previous fact's superseded_by and valid_to
-                    if fact_history[subject]:
-                        prev = fact_history[subject][-1]
-                        conn.execute(
-                            "UPDATE fact_timeline SET superseded_by = ? "
-                            "WHERE id = ?",
-                            (new_db_id, prev[3]),
-                        )
-                        conn.execute(
-                            "UPDATE fact_timeline SET valid_to = ? WHERE id = ?",
-                            (timestamp, prev[3]),
-                        )
-
-                    fact_history[subject].append(
-                        (new_val, timestamp, msg_id, new_db_id)
-                    )
-
-                    contradictions.append({
-                        "subject": subject,
-                        "old_fact": old_val,
-                        "new_fact": new_val,
-                        "old_timestamp": fact_history[subject][-2][1]
-                        if len(fact_history[subject]) >= 2 else "",
-                        "new_timestamp": timestamp,
-                        "source_message_id": msg_id,
-                    })
-
-                elif pattern_def["type"] == "pricing" and len(groups) >= 2:
-                    price = groups[0].strip()
-                    unit = groups[1].strip()
-
-                    # Extract entity context (company/product name) from surrounding text
-                    entity_context = ""
-                    # Look for proper nouns near the price
-                    nearby_nouns = re.findall(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b', content)
-                    common_words = {"The", "This", "That", "We", "They", "Our", "My", "But", "And", "Just", "Not"}
-                    entities = [n for n in nearby_nouns if n not in common_words and len(n) > 2]
-                    if entities:
-                        entity_context = entities[0].lower()
-
-                    subject = f"pricing_{entity_context}_{unit}" if entity_context else f"pricing_{unit}"
-
-                    cursor = conn.execute(
-                        "INSERT INTO fact_timeline "
-                        "(subject, fact, source_message_id, timestamp, entity_scope, valid_from) "
-                        "VALUES (?, ?, ?, ?, ?, ?)",
-                        (subject, price, msg_id, timestamp, entity_context, timestamp),
-                    )
-                    new_db_id = cursor.lastrowid
-
-                    # Check if this contradicts a previous pricing fact
-                    if subject in fact_history and fact_history[subject]:
-                        prev = fact_history[subject][-1]
-                        if prev[0] != price:
-                            conn.execute(
-                                "UPDATE fact_timeline SET superseded_by = ? "
-                                "WHERE id = ?",
-                                (new_db_id, prev[3]),
-                            )
-                            conn.execute(
-                                "UPDATE fact_timeline SET valid_to = ? WHERE id = ?",
-                                (timestamp, prev[3]),
-                            )
-                            contradictions.append({
-                                "subject": subject,
-                                "old_fact": prev[0],
-                                "new_fact": price,
-                                "old_timestamp": prev[1],
-                                "new_timestamp": timestamp,
-                                "source_message_id": msg_id,
-                            })
-
-                    fact_history[subject].append(
-                        (price, timestamp, msg_id, new_db_id)
-                    )
-
-                elif pattern_def["type"] in ("location_change",
-                                              "schedule_change"):
-                    if groups:
-                        fact_val = groups[0].strip()
-                        if (len(fact_val) < _MIN_FACT_LEN
-                                or len(fact_val) > _MAX_FACT_LEN):
-                            continue
-
-                        subject = _normalize_subject(fact_val, content)
-
-                        # Try to extract entity context
-                        entity_context = ""
-                        nearby_nouns = re.findall(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b', content[:100])
-                        common_words = {"The", "This", "That", "We", "They", "Our", "My", "But", "And", "Just", "Not"}
-                        entities = [n for n in nearby_nouns if n not in common_words and len(n) > 2]
-                        if entities:
-                            entity_context = entities[0].lower()
-
-                        cursor = conn.execute(
-                            "INSERT INTO fact_timeline "
-                            "(subject, fact, source_message_id, timestamp, entity_scope, valid_from) "
-                            "VALUES (?, ?, ?, ?, ?, ?)",
-                            (subject, fact_val, msg_id, timestamp, entity_context, timestamp),
-                        )
-                        new_db_id = cursor.lastrowid
-
-                        # Check for contradiction with previous fact on
-                        # same subject
-                        if (subject in fact_history
-                                and fact_history[subject]):
-                            prev = fact_history[subject][-1]
-                            if prev[0].lower() != fact_val.lower():
-                                conn.execute(
-                                    "UPDATE fact_timeline "
-                                    "SET superseded_by = ? WHERE id = ?",
-                                    (new_db_id, prev[3]),
-                                )
-                                conn.execute(
-                                    "UPDATE fact_timeline SET valid_to = ? WHERE id = ?",
-                                    (timestamp, prev[3]),
-                                )
-                                contradictions.append({
-                                    "subject": subject,
-                                    "old_fact": prev[0],
-                                    "new_fact": fact_val,
-                                    "old_timestamp": prev[1],
-                                    "new_timestamp": timestamp,
-                                    "source_message_id": msg_id,
-                                })
-
-                        fact_history[subject].append(
-                            (fact_val, timestamp, msg_id, new_db_id)
-                        )
-
-                elif pattern_def["type"] == "status_change" and groups:
-                    person = groups[0].strip()
-                    if (len(person) < _MIN_FACT_LEN
-                            or len(person) > _MAX_FACT_LEN):
-                        continue
-
-                    # Extract the verb
-                    verb_match = re.search(
-                        r"(quit|left|started|joined|hired|fired|"
-                        r"resigned|promoted)",
-                        content, re.IGNORECASE,
-                    )
-                    verb = verb_match.group(1).lower() if verb_match else "changed"
-
-                    subject = f"status_{person.lower()}"
-                    fact_val = f"{person} {verb}"
-                    entity_context = person.lower()
-
-                    cursor = conn.execute(
-                        "INSERT INTO fact_timeline "
-                        "(subject, fact, source_message_id, timestamp, entity_scope, valid_from) "
-                        "VALUES (?, ?, ?, ?, ?, ?)",
-                        (subject, fact_val, msg_id, timestamp, entity_context, timestamp),
-                    )
-                    new_db_id = cursor.lastrowid
-                    fact_history[subject].append(
-                        (fact_val, timestamp, msg_id, new_db_id)
-                    )
-
-    conn.commit()
     return contradictions
 
 
@@ -1154,20 +1207,23 @@ def build_entity_summary_sheets(conn):
     return count
 
 
-def build_structured_facts(conn):
-    """
-    Extract structured facts (team roster, locations, key events) and store
-    as searchable summary records. Enables aggregation queries.
-    """
-    from datetime import datetime, timezone
-    now = datetime.now(timezone.utc).isoformat()
-    count = 0
+def _compute_structured_facts(all_msgs: list[dict]) -> list[tuple]:
+    """Compute structured fact rows entirely in memory (no DB access).
 
-    all_msgs = _get_all_messages_chrono(conn)
+    Factored out of :func:`build_structured_facts` so the expensive regex
+    scanning runs OUTSIDE the write transaction (#591).
+
+    Returns:
+        List of row tuples ready for INSERT into the ``summaries`` table:
+        ``(period, start_date, end_date, entity, summary, key_facts_json,
+        message_ids_json, created_at)``.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    rows: list[tuple] = []
 
     # --- Team roster extraction ---
-    team_members = set()
-    team_roles = {}
+    team_members: set[str] = set()
+    team_roles: dict[str, str] = {}
     role_patterns = re.compile(
         r'(\w+(?:\s+\w+)?)\s+(?:is|as)\s+(?:our\s+)?(?:the\s+)?'
         r'(CTO|CEO|COO|CFO|VP|lead|manager|engineer|designer|intern|cofounder|co-founder)',
@@ -1183,8 +1239,10 @@ def build_structured_facts(conn):
                 team_members.add(name)
                 team_roles[name] = role
 
-    # Also add all senders as potential team/contact members
-    hire_pattern = re.compile(r'(?:hired|brought on|recruited|onboarded)\s+(\w+(?:\s+\w+)?)', re.IGNORECASE)
+    hire_pattern = re.compile(
+        r'(?:hired|brought on|recruited|onboarded)\s+(\w+(?:\s+\w+)?)',
+        re.IGNORECASE,
+    )
     for msg in all_msgs:
         matches = hire_pattern.finditer(msg["content"])
         for m in matches:
@@ -1194,21 +1252,25 @@ def build_structured_facts(conn):
 
     if team_members:
         roster_text = "Team Roster:\n" + "\n".join(
-            f"  {name}: {team_roles.get(name, 'member')}" for name in sorted(team_members)
+            f"  {name}: {team_roles.get(name, 'member')}"
+            for name in sorted(team_members)
         )
-        conn.execute(
-            "INSERT INTO summaries "
-            "(period, start_date, end_date, entity, summary, key_facts, message_ids, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            ("structured_fact", "", "", "", roster_text, json.dumps(list(team_members)), "[]", now)
-        )
-        count += 1
+        rows.append((
+            "structured_fact", "", "", "", roster_text,
+            json.dumps(list(team_members)), "[]", now,
+        ))
 
     # --- Location extraction ---
-    locations = set()
+    locations: set[str] = set()
     location_patterns = [
-        re.compile(r'(?:office|headquarters|hq)\s+(?:at|in|is)\s+(.+?)(?:[.,!?]|$)', re.IGNORECASE),
-        re.compile(r'(?:moved|relocated|based)\s+(?:to|in)\s+(.+?)(?:[.,!?]|$)', re.IGNORECASE),
+        re.compile(
+            r'(?:office|headquarters|hq)\s+(?:at|in|is)\s+(.+?)(?:[.,!?]|$)',
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r'(?:moved|relocated|based)\s+(?:to|in)\s+(.+?)(?:[.,!?]|$)',
+            re.IGNORECASE,
+        ),
     ]
 
     for msg in all_msgs:
@@ -1220,14 +1282,61 @@ def build_structured_facts(conn):
                     locations.add(loc)
 
     if locations:
-        location_text = "Known Locations:\n" + "\n".join(f"  {loc}" for loc in sorted(locations))
-        conn.execute(
-            "INSERT INTO summaries "
-            "(period, start_date, end_date, entity, summary, key_facts, message_ids, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            ("structured_fact", "", "", "", location_text, json.dumps(list(locations)), "[]", now)
+        location_text = "Known Locations:\n" + "\n".join(
+            f"  {loc}" for loc in sorted(locations)
         )
-        count += 1
+        rows.append((
+            "structured_fact", "", "", "", location_text,
+            json.dumps(list(locations)), "[]", now,
+        ))
 
-    conn.commit()
-    return count
+    return rows
+
+
+def build_structured_facts(conn):
+    """
+    Extract structured facts (team roster, locations, key events) and store
+    as searchable summary records. Enables aggregation queries.
+
+    The implementation follows a three-phase pattern (#591) so that
+    expensive regex computation does NOT hold the SQLite write lock:
+
+    1. **Read** messages (short read, or no transaction).
+    2. **Compute** structured facts entirely in memory
+       (:func:`_compute_structured_facts`).
+    3. **Write** results in one short, atomic transaction.
+    """
+    # --- Phase 1: read ---------------------------------------------------
+    all_msgs = _get_all_messages_chrono(conn)
+
+    # --- Phase 2: compute (no transaction held) --------------------------
+    rows = _compute_structured_facts(all_msgs)
+
+    # --- Phase 3: write (short atomic transaction) -----------------------
+    if conn.in_transaction:
+        conn.commit()
+    prev_isolation = conn.isolation_level
+    try:
+        conn.isolation_level = None
+        conn.execute("BEGIN IMMEDIATE")
+        # Remove old structured_fact rows (don't touch other summary types).
+        conn.execute("DELETE FROM summaries WHERE period = 'structured_fact'")
+        if rows:
+            conn.executemany(
+                "INSERT INTO summaries "
+                "(period, start_date, end_date, entity, summary, "
+                " key_facts, message_ids, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                rows,
+            )
+        conn.execute("COMMIT")
+    except Exception:
+        try:
+            conn.execute("ROLLBACK")
+        except Exception:
+            pass
+        raise
+    finally:
+        conn.isolation_level = prev_isolation
+
+    return len(rows)


### PR DESCRIPTION
## Summary

- **`detect_contradictions`** and **`build_structured_facts`** previously held the SQLite write lock for their entire duration (read + expensive regex computation + write), blocking concurrent MCP writers for seconds.
- Restructured both to the three-phase pattern from #401: read data, compute in memory (no transaction), write in one short atomic transaction with rollback-on-error safety.
- `build_structured_facts` now only deletes its own `structured_fact` rows instead of relying on external cleanup, preventing accidental clobbering of other summary types.

## Test plan

- [x] 11 new tests in `tests/test_issue_591_consolidation_txn.py`:
  - Correctness: contradiction detection, fact_timeline population, supersession links, idempotency
  - Correctness: structured fact extraction, idempotency, no clobbering of other summaries
  - Transaction: concurrent writer succeeds during compute phase (both functions)
  - Transaction: atomic rollback preserves prior data on write failure (both functions)
- [x] All 17 existing consolidation tests pass (`test_consolidation_lock.py`, `test_consolidation_gaps.py`, `test_issue_484_consolidate_lock.py`, `test_issue_455_consolidation_mcp.py`)
- [x] Full test suite passing

Closes #591