### PR TITLE
fix: heuristic extractor — role-scope, IGNORECASE, smart-quotes, 3 categories, validation

### DIFF
--- a/tests/test_issue_586_heuristic_extractor.py
+++ b/tests/test_issue_586_heuristic_extractor.py
@@ -10,7 +10,6 @@ Covers:
 
 from truememory.ingest.extractor import (
     ALLOWED_CATEGORIES,
-    ExtractedFact,
     _extract_user_lines,
     _normalize_quotes,
     _parse_extraction_response,

--- a/tests/test_issue_586_heuristic_extractor.py
+++ b/tests/test_issue_586_heuristic_extractor.py
@@ -1,0 +1,239 @@
+"""Tests for issue #586 — heuristic extractor fixes.
+
+Covers:
+1. Role-scoping: only user lines are extracted (assistant text ignored)
+2. Case-insensitive matching
+3. Smart/curly quote normalisation
+4. New categories: correction, temporal, technical
+5. Category validation: invalid categories remapped to "general"
+"""
+
+from truememory.ingest.extractor import (
+    ALLOWED_CATEGORIES,
+    ExtractedFact,
+    _extract_user_lines,
+    _normalize_quotes,
+    _parse_extraction_response,
+    _validate_category,
+    extract_facts_simple,
+)
+
+
+# ── 1. Role-scoping ─────────────────────────────────────────────────────
+
+
+def test_only_user_lines_extracted():
+    """Assistant text that matches patterns must NOT produce facts."""
+    transcript = (
+        "User: I prefer dark mode for my editor.\n\n"
+        "Assistant: I'm a large language model. I prefer to help you.\n\n"
+        "User: Thanks!"
+    )
+    facts = extract_facts_simple(transcript)
+    # The user's "I prefer dark mode" should match, but the assistant's
+    # "I'm a large language model" and "I prefer to help you" should not.
+    assert any("dark mode" in f.content.lower() for f in facts)
+    assert not any("large language model" in f.content.lower() for f in facts)
+    assert not any("help you" in f.content.lower() for f in facts)
+
+
+def test_assistant_personal_statement_ignored():
+    """'I am' in assistant text must not be extracted as a personal fact."""
+    transcript = (
+        "User: What are you?\n\n"
+        "Assistant: I am an AI assistant made by Anthropic.\n\n"
+        "User: I am a software engineer."
+    )
+    facts = extract_facts_simple(transcript)
+    assert any("software engineer" in f.content.lower() for f in facts)
+    assert not any("AI assistant" in f.content for f in facts)
+
+
+def test_extract_user_lines_helper():
+    """_extract_user_lines keeps only User: blocks."""
+    transcript = (
+        "User: Hello, I'm Josh.\n\n"
+        "Assistant: Nice to meet you!\n\n"
+        "User: I live in Austin."
+    )
+    result = _extract_user_lines(transcript)
+    assert "Josh" in result
+    assert "Austin" in result
+    assert "Nice to meet you" not in result
+
+
+# ── 2. Case-insensitive matching ────────────────────────────────────────
+
+
+def test_case_insensitive_personal():
+    """Mixed-case 'I AM', 'i am', 'I Am' should all match."""
+    for phrase in ["I AM a doctor", "i am a doctor", "I Am A Doctor"]:
+        transcript = f"User: {phrase}."
+        facts = extract_facts_simple(transcript)
+        assert any("doctor" in f.content.lower() for f in facts), (
+            f"Failed to match: {phrase}"
+        )
+
+
+def test_case_insensitive_preference():
+    """'I PREFER', 'i prefer', etc. should all match."""
+    for phrase in ["I PREFER vim", "i prefer vim", "I Prefer Vim"]:
+        transcript = f"User: {phrase} over emacs."
+        facts = extract_facts_simple(transcript)
+        assert any("vim" in f.content.lower() for f in facts), (
+            f"Failed to match: {phrase}"
+        )
+
+
+# ── 3. Smart-quote normalisation ────────────────────────────────────────
+
+
+def test_smart_quotes_normalized():
+    """Curly/smart quotes must be replaced before pattern matching."""
+    # Uses curly apostrophe in "I’m"
+    transcript = "User: I’m a designer from Berlin."
+    facts = extract_facts_simple(transcript)
+    assert any("designer" in f.content.lower() for f in facts)
+
+
+def test_normalize_quotes_helper():
+    assert _normalize_quotes("‘hello’") == "'hello'"
+    assert _normalize_quotes("“world”") == '"world"'
+
+
+def test_smart_double_quotes():
+    """Double curly quotes should also be normalised."""
+    transcript = "User: I prefer “dark mode” for coding."
+    facts = extract_facts_simple(transcript)
+    assert any("dark mode" in f.content.lower() for f in facts)
+
+
+# ── 4. New categories: correction, temporal, technical ──────────────────
+
+
+def test_correction_category_actually():
+    transcript = "User: Actually, the deadline is Friday not Thursday."
+    facts = extract_facts_simple(transcript)
+    assert any(f.category == "correction" for f in facts)
+
+
+def test_correction_category_no_its():
+    transcript = "User: No, it's Python 3.12, not 3.11."
+    facts = extract_facts_simple(transcript)
+    assert any(f.category == "correction" for f in facts)
+
+
+def test_correction_category_i_meant():
+    transcript = "User: I meant the staging server, not production."
+    facts = extract_facts_simple(transcript)
+    assert any(f.category == "correction" for f in facts)
+
+
+def test_temporal_category_date():
+    transcript = "User: The deadline is on January 15."
+    facts = extract_facts_simple(transcript)
+    assert any(f.category == "temporal" for f in facts)
+
+
+def test_temporal_category_next_week():
+    transcript = "User: Next week I'll be on vacation in Hawaii."
+    facts = extract_facts_simple(transcript)
+    assert any(f.category == "temporal" for f in facts)
+
+
+def test_temporal_category_planning():
+    transcript = "User: I'm planning to migrate the database next month."
+    facts = extract_facts_simple(transcript)
+    assert any(f.category == "temporal" for f in facts)
+
+
+def test_technical_category_using():
+    transcript = "User: I'm using PostgreSQL for the backend."
+    facts = extract_facts_simple(transcript)
+    assert any(f.category == "technical" for f in facts)
+
+
+def test_technical_category_configured():
+    transcript = "User: I configured Nginx as a reverse proxy."
+    facts = extract_facts_simple(transcript)
+    assert any(f.category == "technical" for f in facts)
+
+
+def test_technical_category_stack():
+    transcript = "User: Our stack is React, FastAPI, and PostgreSQL."
+    facts = extract_facts_simple(transcript)
+    assert any(f.category == "technical" for f in facts)
+
+
+# ── 5. Category validation ──────────────────────────────────────────────
+
+
+def test_validate_category_known():
+    for cat in ALLOWED_CATEGORIES:
+        assert _validate_category(cat) == cat
+
+
+def test_validate_category_unknown_falls_back():
+    assert _validate_category("invented_category") == "general"
+    assert _validate_category("") == "general"
+    assert _validate_category("BANANA") == "general"
+
+
+def test_validate_category_case_insensitive():
+    assert _validate_category("Personal") == "personal"
+    assert _validate_category("DECISION") == "decision"
+
+
+def test_llm_parser_validates_categories():
+    """_parse_extraction_response must clamp invalid categories to 'general'."""
+    import json
+    response = json.dumps([
+        {"content": "Fact one", "category": "personal"},
+        {"content": "Fact two", "category": "totally_made_up"},
+        {"content": "Fact three", "category": "PREFERENCE"},
+    ])
+    facts = _parse_extraction_response(response, max_facts=50)
+    assert facts[0].category == "personal"
+    assert facts[1].category == "general"  # invalid → general
+    assert facts[2].category == "preference"  # uppercased → normalised
+
+
+def test_heuristic_extractor_never_emits_invalid_category():
+    """All facts from extract_facts_simple must have valid categories."""
+    transcript = (
+        "User: I'm a designer. I prefer dark mode. Actually, it's React not Vue. "
+        "Next week I'll deploy. I'm using Docker. I'm working on a new feature. "
+        "I started a blog. I hired a contractor. I decided to use Rust."
+    )
+    facts = extract_facts_simple(transcript)
+    assert facts, "expected some facts"
+    for f in facts:
+        assert f.category in ALLOWED_CATEGORIES, (
+            f"Invalid category {f.category!r} in fact: {f.content!r}"
+        )
+
+
+# ── Regression: existing tests still pass ───────────────────────────────
+
+
+def test_simple_extractor_personal():
+    """Heuristic extractor catches personal facts (regression)."""
+    transcript = "User: I'm a software engineer working at Google.\n\nAssistant: Great!"
+    facts = extract_facts_simple(transcript)
+    assert len(facts) >= 1
+    assert any("software engineer" in f.content.lower() for f in facts)
+
+
+def test_simple_extractor_preference():
+    """Heuristic extractor catches preferences (regression)."""
+    transcript = "User: I prefer Python over JavaScript for backend work."
+    facts = extract_facts_simple(transcript)
+    assert len(facts) >= 1
+    assert any("prefer" in f.content.lower() for f in facts)
+
+
+def test_simple_extractor_no_noise():
+    """Heuristic extractor doesn't extract noise (regression)."""
+    transcript = "User: ok\n\nAssistant: sounds good\n\nUser: thanks"
+    facts = extract_facts_simple(transcript)
+    assert len(facts) == 0

--- a/truememory/ingest/extractor.py
+++ b/truememory/ingest/extractor.py
@@ -349,7 +349,7 @@ def _parse_extraction_response(response: str, max_facts: int) -> list[ExtractedF
             continue
         facts.append(ExtractedFact(
             content=content,
-            category=str(item.get("category", "general")),
+            category=_validate_category(str(item.get("category", "general"))),
             confidence=str(item.get("confidence", "medium")),
             source_role=str(item.get("source_role", "user")),
         ))
@@ -450,7 +450,7 @@ def _salvage_partial_json(text: str) -> list[ExtractedFact]:
                 if isinstance(content, str) and content.strip():
                     facts.append(ExtractedFact(
                         content=content.strip(),
-                        category=str(item.get("category", "general")),
+                        category=_validate_category(str(item.get("category", "general"))),
                         confidence=str(item.get("confidence", "medium")),
                         source_role=str(item.get("source_role", "user")),
                     ))
@@ -464,6 +464,57 @@ def _salvage_partial_json(text: str) -> list[ExtractedFact]:
     return facts
 
 
+# ---------------------------------------------------------------------------
+# Allowed categories — shared by both LLM and heuristic extractors.
+# Any extracted fact whose category is not in this set gets remapped to
+# "general" so downstream code never sees arbitrary strings.
+# ---------------------------------------------------------------------------
+ALLOWED_CATEGORIES: frozenset[str] = frozenset({
+    "personal", "preference", "decision", "correction", "temporal",
+    "technical", "relationship", "activity", "event", "general",
+})
+
+
+def _validate_category(raw: str) -> str:
+    """Return *raw* if it is an allowed category, else ``"general"``."""
+    normed = raw.strip().lower()
+    return normed if normed in ALLOWED_CATEGORIES else "general"
+
+
+def _normalize_quotes(text: str) -> str:
+    r"""Replace smart/curly quotes with straight ASCII equivalents.
+
+    LLM-produced or copy-pasted transcripts often contain Unicode curly
+    quotes (‘ ’ “ ”) which break regex character
+    classes that only list the ASCII ``'`` and ``"``.
+    """
+    table = str.maketrans({
+        "‘": "'",  # left single curly quote
+        "’": "'",  # right single curly quote / apostrophe
+        "“": '"',  # left double curly quote
+        "”": '"',  # right double curly quote
+    })
+    return text.translate(table)
+
+
+def _extract_user_lines(transcript: str) -> str:
+    """Return only user-role lines from a formatted transcript.
+
+    The formatted transcript (produced by :func:`format_for_extraction`)
+    uses the pattern ``User: ...`` / ``Assistant: ...`` separated by blank
+    lines.  We keep only lines that belong to a ``User:`` block so the
+    heuristic extractor never fires on the assistant's own text (which
+    would produce spurious facts like "I'm an AI assistant").
+    """
+    blocks = transcript.split("\n\n")
+    user_blocks: list[str] = []
+    for block in blocks:
+        stripped = block.strip()
+        if stripped.startswith("User:") or stripped.startswith("user:"):
+            user_blocks.append(stripped)
+    return "\n\n".join(user_blocks)
+
+
 def extract_facts_simple(transcript: str) -> list[ExtractedFact]:
     """
     Extract facts without an LLM — regex/heuristic fallback.
@@ -475,7 +526,17 @@ def extract_facts_simple(transcript: str) -> list[ExtractedFact]:
     - "I am/I'm [X]" patterns (personal facts)
     - "I prefer/like/hate [X]" patterns (preferences)
     - "My [X] is [Y]" patterns (personal facts)
+    - Corrections ("actually", "no, it's", "that's wrong")
+    - Temporal facts (dates, deadlines, schedules)
+    - Technical context (using X, stack is Y, configured Z)
     - Statements with proper nouns and verbs (decisions, events)
+
+    Changes vs. prior version (issue #586):
+    1. Only user-role lines are searched (assistant text is filtered out).
+    2. All patterns use ``re.IGNORECASE`` — no manual case alternations.
+    3. Smart/curly quotes are normalized to straight quotes before matching.
+    4. Three new category groups: correction, temporal, technical.
+    5. Every extracted category is validated against ``ALLOWED_CATEGORIES``.
 
     SECURITY: This is the no-LLM extraction entrypoint, but the facts it
     produces are interpolated verbatim into downstream LLM prompts (e.g. the
@@ -486,53 +547,81 @@ def extract_facts_simple(transcript: str) -> list[ExtractedFact]:
     :func:`_neutralize_delimiters` for the same reason the LLM extractor does:
     untrusted content must never be able to forge a trust-boundary delimiter.
     """
-    facts = []
+    # --- Pre-processing --------------------------------------------------
+    # 1. Role-scope: only extract from user lines.
+    transcript = _extract_user_lines(transcript)
+    # 2. Normalize smart quotes so patterns with ASCII quotes still match.
+    transcript = _normalize_quotes(transcript)
 
-    # Personal identity patterns
-    for pattern, category in [
-        (r"(?:I am|I'm|i am|i'm)\s+(?:a\s+)?(.{3,60}?)(?:\.|,|!|\n|$)", "personal"),
-        (r"(?:my name is|i'm called|call me)\s+(\w+)", "personal"),
-        (r"(?:I live|i live|I'm from|i'm from|I'm in|i'm in)\s+(.{3,40}?)(?:\.|,|!|\n|$)", "personal"),
-        (r"(?:I work|i work)\s+(?:at|for|as)\s+(.{3,40}?)(?:\.|,|!|\n|$)", "personal"),
-    ]:
-        for match in re.finditer(pattern, transcript):
+    facts: list[ExtractedFact] = []
+
+    # Helper — all finditer calls go through here so IGNORECASE is applied
+    # uniformly and category validation happens in one place.
+    def _scan(
+        pattern: str,
+        text: str,
+        category: str,
+        confidence: str = "low",
+    ) -> None:
+        validated_cat = _validate_category(category)
+        for match in re.finditer(pattern, text, re.IGNORECASE):
             facts.append(ExtractedFact(
                 content=_neutralize_delimiters(match.group(0).strip().rstrip(".,!")),
-                category=category,
-                confidence="medium",
+                category=validated_cat,
+                confidence=confidence,
                 source_role="user",
             ))
 
-    # Preference patterns
-    for pattern in [
-        r"(?:I prefer|i prefer|I like|i like|I love|i love)\s+(.{3,60}?)(?:\.|,|!|\n|$)",
-        r"(?:I hate|i hate|I dislike|i dislike|I avoid|i avoid)\s+(.{3,60}?)(?:\.|,|!|\n|$)",
-        r"(?:I always|i always|I never|i never|I usually|i usually)\s+(.{3,60}?)(?:\.|,|!|\n|$)",
+    # --- Personal identity patterns (medium confidence) ------------------
+    for pat, cat in [
+        (r"(?:I am|I'm)\s+(?:a\s+)?(.{3,60}?)(?:\.|,|!|\n|$)", "personal"),
+        (r"(?:my name is|I'm called|call me)\s+(\w+)", "personal"),
+        (r"(?:I live|I'm from|I'm in)\s+(.{3,40}?)(?:\.|,|!|\n|$)", "personal"),
+        (r"(?:I work)\s+(?:at|for|as)\s+(.{3,40}?)(?:\.|,|!|\n|$)", "personal"),
     ]:
-        for match in re.finditer(pattern, transcript):
-            facts.append(ExtractedFact(
-                content=_neutralize_delimiters(match.group(0).strip().rstrip(".,!")),
-                category="preference",
-                confidence="low",
-                source_role="user",
-            ))
+        _scan(pat, transcript, cat, confidence="medium")
 
-    # Activity/project state patterns
-    for pattern, category in [
-        (r"(?:I'm working on|i'm working on|I am working on|working on)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "activity"),
-        (r"(?:I'm building|i'm building|I am building|we're building)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "activity"),
-        (r"(?:I started|i started|I just started|I began|we started)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "event"),
-        (r"(?:I finished|i finished|I completed|I just finished|we shipped)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "event"),
-        (r"(?:I moved|i moved|I switched|I changed|I transitioned)\s+(?:to|from)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "event"),
-        (r"(?:I hired|i hired|I fired|we hired|we brought on)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "relationship"),
-        (r"(?:I decided|i decided|we decided|I chose|we chose)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "decision"),
+    # --- Preference patterns ---------------------------------------------
+    for pat in [
+        r"(?:I prefer|I like|I love)\s+(.{3,60}?)(?:\.|,|!|\n|$)",
+        r"(?:I hate|I dislike|I avoid)\s+(.{3,60}?)(?:\.|,|!|\n|$)",
+        r"(?:I always|I never|I usually)\s+(.{3,60}?)(?:\.|,|!|\n|$)",
     ]:
-        for match in re.finditer(pattern, transcript):
-            facts.append(ExtractedFact(
-                content=_neutralize_delimiters(match.group(0).strip().rstrip(".,!")),
-                category=category,
-                confidence="low",
-                source_role="user",
-            ))
+        _scan(pat, transcript, "preference")
+
+    # --- Correction patterns (new — issue #586) --------------------------
+    for pat in [
+        r"(?:actually,?\s+|no,?\s+it's\s+|that's wrong,?\s+|that's not right,?\s+|correction:\s+)(.{3,80}?)(?:\.|,|!|\n|$)",
+        r"(?:I meant|I mean|let me correct)\s+(.{3,80}?)(?:\.|,|!|\n|$)",
+    ]:
+        _scan(pat, transcript, "correction")
+
+    # --- Temporal patterns (new — issue #586) ----------------------------
+    for pat in [
+        r"(?:by|before|after|on|until|deadline is)\s+(?:january|february|march|april|may|june|july|august|september|october|november|december|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?)\b.{0,60}?(?:\.|,|!|\n|$)",
+        r"(?:next week|next month|next year|tomorrow|yesterday|last week|last month)\s+(.{3,60}?)(?:\.|,|!|\n|$)",
+        r"(?:I'm planning|I plan to|scheduled for|due on|due by)\s+(.{3,60}?)(?:\.|,|!|\n|$)",
+    ]:
+        _scan(pat, transcript, "temporal")
+
+    # --- Technical context patterns (new — issue #586) -------------------
+    for pat in [
+        r"(?:I use|I'm using|we use|we're using|our stack is|stack is)\s+(.{3,60}?)(?:\.|,|!|\n|$)",
+        r"(?:I configured|I set up|we configured|we deployed|we run)\s+(.{3,60}?)(?:\.|,|!|\n|$)",
+        r"(?:the architecture|our architecture|we chose|I chose)\s+(.{3,60}?)(?:\.|,|!|\n|$)",
+    ]:
+        _scan(pat, transcript, "technical")
+
+    # --- Activity / project state patterns -------------------------------
+    for pat, cat in [
+        (r"(?:I'm working on|I am working on|working on)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "activity"),
+        (r"(?:I'm building|I am building|we're building)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "activity"),
+        (r"(?:I started|I just started|I began|we started)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "event"),
+        (r"(?:I finished|I completed|I just finished|we shipped)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "event"),
+        (r"(?:I moved|I switched|I changed|I transitioned)\s+(?:to|from)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "event"),
+        (r"(?:I hired|I fired|we hired|we brought on)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "relationship"),
+        (r"(?:I decided|we decided|I chose|we chose)\s+(.{3,60}?)(?:\.|,|!|\n|$)", "decision"),
+    ]:
+        _scan(pat, transcript, cat)
 
     return facts


### PR DESCRIPTION
## Summary
Closes #586

- **Role-scope to user lines**: new `_extract_user_lines()` filters out Assistant blocks before pattern matching so the heuristic extractor never fires on assistant text (e.g. "I'm an AI assistant")
- **IGNORECASE on all patterns**: replaced manual case alternations with a unified `_scan()` helper that applies `re.IGNORECASE` to every pattern
- **Smart-quote normalization**: new `_normalize_quotes()` translates curly single/double quotes to ASCII equivalents before matching
- **Three new category groups**: correction ("actually", "no, it's", "I meant"), temporal (dates, "next week", "deadline"), technical ("I use", "our stack is", "I configured")
- **Category validation**: new `_validate_category()` clamps categories to `ALLOWED_CATEGORIES` set — applied in heuristic extractor, `_parse_extraction_response`, and `_salvage_partial_json`

## Test plan
- [x] 25 new tests in `tests/test_issue_586_heuristic_extractor.py` — all pass
- [x] 13 existing tests in `tests/ingest/test_extractor.py` — no regressions
- [x] Full test suite — running