### PR TITLE
fix(temporal): guard date concatenation and use exclusive upper bound

### DIFF
--- a/tests/test_issue_593_temporal_dates.py
+++ b/tests/test_issue_593_temporal_dates.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import sqlite3
 
-import pytest
 
 from truememory.temporal import (
     _exclusive_upper_bound,

--- a/tests/test_issue_593_temporal_dates.py
+++ b/tests/test_issue_593_temporal_dates.py
@@ -1,0 +1,254 @@
+"""Tests for issue #593: temporal date-boundary guards.
+
+Verifies:
+    1. None dates handled gracefully (no crash).
+    2. Malformed dates handled gracefully (treated as None).
+    3. Exclusive upper bound — event at midnight of the next day is excluded.
+    4. Normal date range works correctly.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from truememory.temporal import (
+    _exclusive_upper_bound,
+    _validate_iso_date,
+    detect_temporal_intent,
+    get_timeline,
+    search_temporal,
+)
+from truememory.fts_search import search_fts_in_range
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_db() -> sqlite3.Connection:
+    """Create an in-memory DB with a minimal messages + FTS5 schema."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE messages ("
+        "  id INTEGER PRIMARY KEY,"
+        "  content TEXT,"
+        "  sender TEXT,"
+        "  recipient TEXT,"
+        "  timestamp TEXT,"
+        "  category TEXT DEFAULT '',"
+        "  modality TEXT DEFAULT 'text',"
+        "  directive INTEGER DEFAULT 0,"
+        "  episode_id INTEGER"
+        ")"
+    )
+    conn.execute(
+        "CREATE VIRTUAL TABLE messages_fts USING fts5("
+        "  content, sender, recipient,"
+        "  content=messages, content_rowid=id"
+        ")"
+    )
+    return conn
+
+
+def _insert(conn: sqlite3.Connection, content: str, ts: str, sender: str = "alice"):
+    cur = conn.execute(
+        "INSERT INTO messages (content, sender, recipient, timestamp) VALUES (?, ?, '', ?)",
+        (content, sender, ts),
+    )
+    mid = cur.lastrowid
+    conn.execute(
+        "INSERT INTO messages_fts (rowid, content, sender, recipient) VALUES (?, ?, ?, '')",
+        (mid, content, sender),
+    )
+    conn.commit()
+    return mid
+
+
+# ---------------------------------------------------------------------------
+# _validate_iso_date
+# ---------------------------------------------------------------------------
+
+class TestValidateIsoDate:
+    def test_none_returns_none(self):
+        assert _validate_iso_date(None) is None
+
+    def test_empty_returns_none(self):
+        assert _validate_iso_date("") is None
+
+    def test_malformed_returns_none(self):
+        assert _validate_iso_date("not-a-date") is None
+        assert _validate_iso_date("2025/06/15") is None
+        assert _validate_iso_date("06-15-2025") is None
+
+    def test_valid_date_only(self):
+        assert _validate_iso_date("2025-06-15") == "2025-06-15"
+
+    def test_valid_datetime(self):
+        assert _validate_iso_date("2025-06-15T10:30:00") == "2025-06-15T10:30:00"
+
+    def test_whitespace_stripped(self):
+        assert _validate_iso_date("  2025-06-15  ") == "2025-06-15"
+
+    def test_non_string_returns_none(self):
+        assert _validate_iso_date(12345) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _exclusive_upper_bound
+# ---------------------------------------------------------------------------
+
+class TestExclusiveUpperBound:
+    def test_normal_date(self):
+        assert _exclusive_upper_bound("2025-06-15") == "2025-06-16"
+
+    def test_end_of_month(self):
+        assert _exclusive_upper_bound("2025-06-30") == "2025-07-01"
+
+    def test_end_of_year(self):
+        assert _exclusive_upper_bound("2025-12-31") == "2026-01-01"
+
+    def test_leap_day(self):
+        assert _exclusive_upper_bound("2024-02-29") == "2024-03-01"
+
+    def test_full_timestamp_passthrough(self):
+        ts = "2025-06-15T10:30:00"
+        assert _exclusive_upper_bound(ts) == ts
+
+
+# ---------------------------------------------------------------------------
+# get_timeline: None / malformed dates don't crash
+# ---------------------------------------------------------------------------
+
+class TestGetTimelineGuards:
+    def test_none_after_and_before(self):
+        conn = _make_db()
+        _insert(conn, "hello", "2025-06-15T12:00:00")
+        results = get_timeline(conn, after=None, before=None)
+        assert len(results) == 1
+
+    def test_malformed_after_ignored(self):
+        conn = _make_db()
+        _insert(conn, "hello", "2025-06-15T12:00:00")
+        # Malformed date should be treated as None (no filter), not crash
+        results = get_timeline(conn, after="garbage", before=None)
+        assert len(results) == 1
+
+    def test_malformed_before_ignored(self):
+        conn = _make_db()
+        _insert(conn, "hello", "2025-06-15T12:00:00")
+        results = get_timeline(conn, after=None, before="garbage")
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Exclusive upper bound: midnight event is NOT double-counted
+# ---------------------------------------------------------------------------
+
+class TestExclusiveUpperBoundFiltering:
+    """An event at exactly midnight of the next day must be excluded."""
+
+    def _setup_db(self):
+        conn = _make_db()
+        # Event on March 5
+        _insert(conn, "meeting notes from march 5", "2025-03-05T14:00:00")
+        # Event at the very end of March 5
+        _insert(conn, "late night work march 5", "2025-03-05T23:59:59")
+        # Event at midnight of March 6 — should NOT be included in "March 5" queries
+        _insert(conn, "midnight event march 6", "2025-03-06T00:00:00")
+        # Event clearly on March 6
+        _insert(conn, "march 6 morning standup", "2025-03-06T09:00:00")
+        return conn
+
+    def test_get_timeline_exclusive_upper(self):
+        conn = self._setup_db()
+        results = get_timeline(conn, after="2025-03-05", before="2025-03-05")
+        contents = [r["content"] for r in results]
+        assert "meeting notes from march 5" in contents
+        assert "late night work march 5" in contents
+        # Midnight of 2025-03-06 should NOT appear
+        assert "midnight event march 6" not in contents
+        assert "march 6 morning standup" not in contents
+
+    def test_search_temporal_exclusive_upper(self):
+        conn = self._setup_db()
+        # Build fake results that include all 4 messages
+        all_results = get_timeline(conn)
+        assert len(all_results) == 4
+
+        # "in March 2025" triggers the month-boundary range detection,
+        # which sets after="2025-03-01" and before="2025-03-31".
+        # We use a tighter query: "between March 5 2025 and March 5 2025"
+        # to test the single-day exclusive upper bound.
+        results = search_temporal(
+            conn, "what happened between March 5 2025 and March 5 2025",
+            hybrid_results=all_results,
+            limit=10,
+        )
+        # Only the two March-5 events should remain
+        contents = [r["content"] for r in results]
+        # The March-5 events must be present
+        assert any("march 5" in c.lower() for c in contents)
+        # The midnight March-6 event must NOT be present
+        assert "midnight event march 6" not in contents
+
+
+# ---------------------------------------------------------------------------
+# Normal date range works correctly
+# ---------------------------------------------------------------------------
+
+class TestNormalDateRange:
+    def test_timeline_range(self):
+        conn = _make_db()
+        _insert(conn, "event A", "2025-01-10T08:00:00")
+        _insert(conn, "event B", "2025-01-15T12:00:00")
+        _insert(conn, "event C", "2025-01-20T18:00:00")
+        _insert(conn, "event D", "2025-02-01T09:00:00")
+
+        results = get_timeline(conn, after="2025-01-10", before="2025-01-20")
+        contents = [r["content"] for r in results]
+        assert "event A" in contents
+        assert "event B" in contents
+        assert "event C" in contents
+        assert "event D" not in contents
+
+    def test_fts_in_range_none_dates(self):
+        """search_fts_in_range with None dates should not crash."""
+        conn = _make_db()
+        _insert(conn, "test message about coding", "2025-06-15T12:00:00")
+        # Should not crash — None dates are simply ignored
+        results = search_fts_in_range(conn, "coding", after=None, before=None, limit=10)
+        assert len(results) == 1
+
+    def test_fts_in_range_exclusive_upper(self):
+        conn = _make_db()
+        _insert(conn, "coding session morning", "2025-06-15T08:00:00")
+        _insert(conn, "coding session midnight", "2025-06-16T00:00:00")
+        results = search_fts_in_range(
+            conn, "coding", after="2025-06-15", before="2025-06-15", limit=10
+        )
+        contents = [r["content"] for r in results]
+        assert "coding session morning" in contents
+        assert "coding session midnight" not in contents
+
+
+# ---------------------------------------------------------------------------
+# detect_temporal_intent still works with the new guards
+# ---------------------------------------------------------------------------
+
+class TestDetectTemporalIntent:
+    def test_empty_query(self):
+        result = detect_temporal_intent("")
+        assert result["has_temporal"] is False
+
+    def test_date_range_query(self):
+        result = detect_temporal_intent("what happened from January 2025 to March 2025")
+        assert result["has_temporal"] is True
+        assert result["after"] == "2025-01-01"
+        assert result["before"] == "2025-03-01"
+
+    def test_yesterday(self):
+        result = detect_temporal_intent("what happened yesterday")
+        assert result["has_temporal"] is True
+        assert result["after"] is not None
+        assert result["before"] is not None

--- a/truememory/fts_search.py
+++ b/truememory/fts_search.py
@@ -232,15 +232,20 @@ def search_fts_in_range(
 
     results = _rows_to_results(rows)
 
-    # Apply timestamp bounds (inclusive on both ends).
-    # Date-only bounds ("YYYY-MM-DD") must include the full day, so we
-    # append "T23:59:59" to 'before' to cover timestamps with a time
-    # component (e.g. "2025-07-01T10:00:00" must match before="2025-07-01").
+    # Apply timestamp bounds: inclusive lower, exclusive upper.
+    # For date-only upper bounds ("YYYY-MM-DD"), we use the start of the
+    # *next* day as the exclusive ceiling so that events on `before` are
+    # included but midnight of the next day is not.
+    from truememory.temporal import _validate_iso_date, _exclusive_upper_bound
+
+    after = _validate_iso_date(after)
+    before = _validate_iso_date(before)
+
     if after is not None:
         results = [r for r in results if r["timestamp"] >= after]
     if before is not None:
-        before_cmp = before + "T23:59:59" if len(before) == 10 else before
-        results = [r for r in results if r["timestamp"] <= before_cmp]
+        before_excl = _exclusive_upper_bound(before)
+        results = [r for r in results if r["timestamp"] < before_excl]
 
     # Trim to requested limit, then normalize scores across the final set
     results = results[:limit]

--- a/truememory/temporal.py
+++ b/truememory/temporal.py
@@ -31,6 +31,48 @@ from truememory.storage import _row_to_dict, _SELECT_COLS
 
 
 # ---------------------------------------------------------------------------
+# Date-boundary helpers (used by temporal.py and fts_search.py)
+# ---------------------------------------------------------------------------
+
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _validate_iso_date(value: str | None) -> str | None:
+    """Return *value* unchanged if it looks like ``YYYY-MM-DD``, else ``None``.
+
+    Guards against ``None``, empty strings, and malformed dates before they
+    are concatenated into SQL parameters or comparison strings.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    value = value.strip()
+    if _ISO_DATE_RE.match(value):
+        return value
+    # Also accept full ISO timestamps (YYYY-MM-DDTHH:MM:SS…)
+    if len(value) >= 10 and _ISO_DATE_RE.match(value[:10]):
+        return value
+    return None
+
+
+def _exclusive_upper_bound(date_str: str) -> str:
+    """Convert a date-only ``YYYY-MM-DD`` into the *next* day for ``< ?`` comparisons.
+
+    If the input already contains a time component, return it as-is (the
+    caller is expected to use ``<`` instead of ``<=``).
+
+    >>> _exclusive_upper_bound("2025-06-15")
+    '2025-06-16'
+    >>> _exclusive_upper_bound("2025-12-31")
+    '2026-01-01'
+    """
+    if len(date_str) == 10:  # "YYYY-MM-DD"
+        dt = datetime.fromisoformat(date_str)
+        return (dt + timedelta(days=1)).strftime("%Y-%m-%d")
+    # Full timestamp — return as-is; the caller should use strict `<`.
+    return date_str
+
+
+# ---------------------------------------------------------------------------
 # Month name mapping
 # ---------------------------------------------------------------------------
 
@@ -512,11 +554,13 @@ def search_temporal(
     if not intent["has_temporal"]:
         return results[:limit]
 
-    after = intent["after"]
-    before = intent["before"]
+    after = _validate_iso_date(intent["after"])
+    before = _validate_iso_date(intent["before"])
 
     # --- Filter by time window ---
     if after or before:
+        # Compute exclusive upper bound once (next day for date-only strings).
+        before_excl = _exclusive_upper_bound(before) if before else None
         filtered = []
         for r in results:
             ts = r.get("timestamp", "")
@@ -524,7 +568,7 @@ def search_temporal(
                 continue
             if after and ts < after:
                 continue
-            if before and ts > before + "T23:59:59":
+            if before_excl and ts >= before_excl:
                 continue
             filtered.append(r)
         results = filtered
@@ -569,7 +613,10 @@ def get_timeline(
         entity: If provided, restrict to messages where the entity is
                 either the sender or the recipient (case-insensitive).
         after:  Inclusive lower bound timestamp (ISO string).
-        before: Inclusive upper bound timestamp (ISO string).
+        before: Exclusive upper bound date (ISO string).  For a date-only
+                value the bound is the start of the *next* day so that
+                events on ``before`` are included but midnight of the next
+                day is not.
 
     Returns:
         List of message dicts in chronological order.
@@ -577,17 +624,17 @@ def get_timeline(
     clauses: list[str] = []
     params: list[str] = []
 
+    after = _validate_iso_date(after)
+    before = _validate_iso_date(before)
+
     if after is not None:
         clauses.append("timestamp >= ?")
         params.append(after)
     if before is not None:
-        # Include the full day for date-only bounds
-        if len(before) == 10:  # "YYYY-MM-DD"
-            clauses.append("timestamp <= ?")
-            params.append(before + "T23:59:59")
-        else:
-            clauses.append("timestamp <= ?")
-            params.append(before)
+        # Exclusive upper bound: use '<' with the next day so that events
+        # on `before` are included but midnight of `before+1` is not.
+        clauses.append("timestamp < ?")
+        params.append(_exclusive_upper_bound(before))
     if entity is not None:
         entity_lower = entity.lower()
         clauses.append("(LOWER(sender) = ? OR LOWER(recipient) = ?)")


### PR DESCRIPTION
## Summary
- Guard all date concatenation in `temporal.py` and `fts_search.py` with `_validate_iso_date()` — None or malformed dates are safely rejected instead of crashing on string concat
- Switch from inclusive upper bound (`<= date + "T23:59:59"`) to exclusive next-day bound (`< date+1day`) across all 4 date-boundary sites, preventing midnight double-counting
- Add `_exclusive_upper_bound()` helper that computes the next calendar day for `<` comparisons

Closes #593

## Test plan
- [x] 23 new tests in `tests/test_issue_593_temporal_dates.py`:
  - `TestValidateIsoDate` (7 tests): None, empty, malformed, valid date, valid datetime, whitespace, non-string
  - `TestExclusiveUpperBound` (5 tests): normal date, end-of-month, end-of-year, leap day, full timestamp passthrough
  - `TestGetTimelineGuards` (3 tests): None after/before, malformed after, malformed before
  - `TestExclusiveUpperBoundFiltering` (2 tests): get_timeline exclusive upper, search_temporal exclusive upper
  - `TestNormalDateRange` (3 tests): timeline range, fts_in_range with None dates, fts_in_range exclusive upper
  - `TestDetectTemporalIntent` (3 tests): empty query, date range, yesterday
- [x] Full test suite passes