### PR TITLE
fix: agentic supplement scoring — normalize score spaces, preserve cluster order, batch embedding fetch

### DIFF
--- a/tests/test_issue_584_supplement_scoring.py
+++ b/tests/test_issue_584_supplement_scoring.py
@@ -1,0 +1,242 @@
+"""Tests for issue #584 — agentic supplement score normalization.
+
+Verifies:
+1. Mixed-source results are normalized to [0, 1].
+2. Cluster/diversity ordering is preserved through merge.
+3. Single-source relative ordering is unchanged after normalization.
+4. Batch embedding fetch in clustering (structural, no DB needed).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from truememory.agentic_search import normalize_scores, normalize_supplement_scores
+
+
+# ---------------------------------------------------------------------------
+# normalize_scores
+# ---------------------------------------------------------------------------
+
+class TestNormalizeScores:
+    """Unit tests for per-source min-max normalization."""
+
+    def test_basic_normalization(self):
+        """Scores spanning an arbitrary range are mapped to [0, 1]."""
+        results = [
+            {"id": 1, "score": 10.0},
+            {"id": 2, "score": 20.0},
+            {"id": 3, "score": 30.0},
+        ]
+        normalize_scores(results)
+        assert results[0]["score"] == pytest.approx(0.0)
+        assert results[1]["score"] == pytest.approx(0.5)
+        assert results[2]["score"] == pytest.approx(1.0)
+
+    def test_preserves_relative_order(self):
+        """Within a single source, relative ordering must not change."""
+        results = [
+            {"id": 1, "score": 5.5},
+            {"id": 2, "score": 100.0},
+            {"id": 3, "score": 50.0},
+        ]
+        original_order = [(r["id"], r["score"]) for r in results]
+        normalize_scores(results)
+
+        # The relative ranking (by score) should be identical.
+        original_ranked = sorted(original_order, key=lambda t: -t[1])
+        new_ranked = sorted(results, key=lambda r: -r["score"])
+        assert [t[0] for t in original_ranked] == [r["id"] for r in new_ranked]
+
+    def test_all_equal_scores(self):
+        """When all scores are identical, normalize to 0.5."""
+        results = [
+            {"id": 1, "score": 7.0},
+            {"id": 2, "score": 7.0},
+            {"id": 3, "score": 7.0},
+        ]
+        normalize_scores(results)
+        for r in results:
+            assert r["score"] == pytest.approx(0.5)
+
+    def test_single_result(self):
+        """A single result normalizes to 0.5 (neutral)."""
+        results = [{"id": 1, "score": 42.0}]
+        normalize_scores(results)
+        assert results[0]["score"] == pytest.approx(0.5)
+
+    def test_empty_list(self):
+        """Empty input returns empty list without error."""
+        results: list[dict] = []
+        ret = normalize_scores(results)
+        assert ret == []
+
+    def test_bm25_scores(self):
+        """BM25 scores (unbounded, potentially large) are normalized to [0, 1]."""
+        results = [
+            {"id": 1, "score": 0.5},
+            {"id": 2, "score": 12.3},
+            {"id": 3, "score": 45.6},
+            {"id": 4, "score": 2.1},
+        ]
+        normalize_scores(results)
+        for r in results:
+            assert 0.0 <= r["score"] <= 1.0
+
+    def test_cosine_scores_unchanged_range(self):
+        """Cosine similarity scores already in [0, 1] remain in [0, 1]."""
+        results = [
+            {"id": 1, "score": 0.1},
+            {"id": 2, "score": 0.5},
+            {"id": 3, "score": 0.9},
+        ]
+        normalize_scores(results)
+        for r in results:
+            assert 0.0 <= r["score"] <= 1.0
+        # Min should map to 0, max to 1
+        scores = {r["id"]: r["score"] for r in results}
+        assert scores[1] == pytest.approx(0.0)
+        assert scores[3] == pytest.approx(1.0)
+
+    def test_negative_scores(self):
+        """Negative scores (possible in some BM25 variants) are handled."""
+        results = [
+            {"id": 1, "score": -5.0},
+            {"id": 2, "score": 0.0},
+            {"id": 3, "score": 5.0},
+        ]
+        normalize_scores(results)
+        assert results[0]["score"] == pytest.approx(0.0)
+        assert results[1]["score"] == pytest.approx(0.5)
+        assert results[2]["score"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# normalize_supplement_scores
+# ---------------------------------------------------------------------------
+
+class TestNormalizeSupplementScores:
+    """Verify that multiple source lists are normalized independently."""
+
+    def test_independent_normalization(self):
+        """Each source gets its own [0, 1] normalization."""
+        primary = [
+            {"id": 1, "score": 0.01},
+            {"id": 2, "score": 0.03},
+        ]
+        cluster = [
+            {"id": 3, "score": 0.7},
+            {"id": 4, "score": 0.9},
+        ]
+        entity = [
+            {"id": 5, "score": 15.0},
+            {"id": 6, "score": 45.0},
+        ]
+        normalize_supplement_scores(primary, cluster, entity)
+
+        # All sources should now be in [0, 1]
+        for source in [primary, cluster, entity]:
+            for r in source:
+                assert 0.0 <= r["score"] <= 1.0
+
+        # Verify they were normalized independently (not together)
+        # primary[0] should be 0.0 (min of its source)
+        assert primary[0]["score"] == pytest.approx(0.0)
+        assert primary[1]["score"] == pytest.approx(1.0)
+        assert cluster[0]["score"] == pytest.approx(0.0)
+        assert cluster[1]["score"] == pytest.approx(1.0)
+        assert entity[0]["score"] == pytest.approx(0.0)
+        assert entity[1]["score"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Cluster order preservation
+# ---------------------------------------------------------------------------
+
+class TestClusterOrderPreservation:
+    """Verify cluster/diversity ordering is preserved through the merge."""
+
+    def test_cluster_position_tag_survives_merge(self):
+        """Cluster results tagged with _cluster_position keep the tag."""
+        primary = [
+            {"id": 1, "score": 0.8, "source": "hybrid"},
+            {"id": 2, "score": 0.6, "source": "hybrid"},
+        ]
+        cluster_supplements = [
+            {"id": 10, "score": 0.4, "source": "clustered+cluster_supp", "_cluster_position": 0},
+            {"id": 11, "score": 0.3, "source": "clustered+cluster_supp", "_cluster_position": 1},
+            {"id": 12, "score": 0.5, "source": "clustered+cluster_supp", "_cluster_position": 2},
+        ]
+
+        # Simulate the merge: primary + cluster supplements
+        merged = primary + cluster_supplements
+
+        # Extract cluster results and verify position order is preserved
+        cluster_in_merged = [r for r in merged if "_cluster_position" in r]
+        positions = [r["_cluster_position"] for r in cluster_in_merged]
+        assert positions == [0, 1, 2], "Cluster diversity order must be preserved"
+
+    def test_cluster_results_not_resorted_by_score(self):
+        """After merging, cluster supplements should maintain their
+        diversity-sampling order, not be reordered by raw score."""
+        # Cluster results come in diversity order (not score order)
+        cluster_results = [
+            {"id": 10, "score": 0.3},  # diverse pick 1
+            {"id": 11, "score": 0.9},  # diverse pick 2
+            {"id": 12, "score": 0.1},  # diverse pick 3
+        ]
+
+        # Normalize them
+        normalize_scores(cluster_results)
+
+        # Tag with position
+        for idx, cr in enumerate(cluster_results):
+            cr["_cluster_position"] = idx
+
+        # Verify: positions should follow original list order, not score order
+        ids_in_order = [cr["id"] for cr in cluster_results]
+        assert ids_in_order == [10, 11, 12]
+        assert cluster_results[0]["_cluster_position"] == 0
+        assert cluster_results[1]["_cluster_position"] == 1
+        assert cluster_results[2]["_cluster_position"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Single-source relative ordering
+# ---------------------------------------------------------------------------
+
+class TestSingleSourceOrdering:
+    """Normalization must not change relative ranking within one source."""
+
+    def test_fts_scores_preserve_ranking(self):
+        """FTS/BM25 results: highest score stays highest after normalization."""
+        results = [
+            {"id": 1, "score": 45.0, "source": "fts"},
+            {"id": 2, "score": 12.0, "source": "fts"},
+            {"id": 3, "score": 33.0, "source": "fts"},
+            {"id": 4, "score": 1.0, "source": "fts"},
+        ]
+        original_ranking = sorted(results, key=lambda r: -r["score"])
+        original_id_order = [r["id"] for r in original_ranking]
+
+        normalize_scores(results)
+        new_ranking = sorted(results, key=lambda r: -r["score"])
+        new_id_order = [r["id"] for r in new_ranking]
+
+        assert original_id_order == new_id_order
+
+    def test_vector_scores_preserve_ranking(self):
+        """Vector/cosine results: ranking is preserved."""
+        results = [
+            {"id": 1, "score": 0.92, "source": "vector"},
+            {"id": 2, "score": 0.87, "source": "vector"},
+            {"id": 3, "score": 0.95, "source": "vector"},
+        ]
+        original_ranking = sorted(results, key=lambda r: -r["score"])
+        original_id_order = [r["id"] for r in original_ranking]
+
+        normalize_scores(results)
+        new_ranking = sorted(results, key=lambda r: -r["score"])
+        new_id_order = [r["id"] for r in new_ranking]
+
+        assert original_id_order == new_id_order

--- a/truememory/agentic_search.py
+++ b/truememory/agentic_search.py
@@ -8,10 +8,59 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+from typing import Sequence
 
 from truememory.fts_search import search_fts, search_fts_by_sender
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Score normalization (issue #584)
+# ---------------------------------------------------------------------------
+
+def normalize_scores(results: list[dict], *, key: str = "score") -> list[dict]:
+    """Min-max normalize *key* to [0, 1] in place.
+
+    If all scores are equal (or the list has <= 1 element), every score is
+    set to 0.5 so downstream ranking treats them as neutral.
+
+    Returns *results* for chaining.
+    """
+    if len(results) <= 1:
+        for r in results:
+            r[key] = 0.5
+        return results
+
+    scores = [r.get(key, 0) for r in results]
+    lo, hi = min(scores), max(scores)
+    span = hi - lo
+    if span == 0:
+        for r in results:
+            r[key] = 0.5
+        return results
+
+    for r in results:
+        r[key] = (r.get(key, 0) - lo) / span
+    return results
+
+
+def normalize_supplement_scores(
+    primary: list[dict],
+    *supplements: Sequence[list[dict]],
+    key: str = "score",
+) -> None:
+    """Normalize each source list independently to [0, 1].
+
+    ``primary`` is normalized first. Each supplement list is then
+    independently normalized so every source competes fairly in the
+    merged pool.  The lists are mutated in place.
+    """
+    normalize_scores(primary, key=key)
+    for supp in supplements:
+        if supp:
+            normalize_scores(supp, key=key)
+
 
 QUERY_STOP_WORDS = frozenset({
     "what", "did", "does", "do", "how", "where", "when", "who",

--- a/truememory/clustering.py
+++ b/truememory/clustering.py
@@ -285,26 +285,41 @@ def search_clustered(
     from truememory.vector_search import _active_vec_table
     _vec_tbl = _active_vec_table(conn)
 
+    # Batch-fetch all embeddings in one query (issue #584) instead of
+    # one SELECT per message.  Chunk into groups of 500 to stay within
+    # SQLite's parameter limits.
+    _CHUNK = 500
+    emb_map: dict[int, np.ndarray] = {}
+    all_msg_ids = [msg[0] for msg in messages]
+    for chunk_start in range(0, len(all_msg_ids), _CHUNK):
+        chunk = all_msg_ids[chunk_start : chunk_start + _CHUNK]
+        ph = ",".join("?" * len(chunk))
+        try:
+            rows = conn.execute(
+                f"SELECT rowid, embedding FROM {_vec_tbl} WHERE rowid IN ({ph})",
+                chunk,
+            ).fetchall()
+            for rid, blob in rows:
+                dim = len(blob) // 4
+                emb_map[rid] = np.array(
+                    struct.unpack(f"{dim}f", blob), dtype=np.float32
+                )
+        except Exception:
+            logger.debug("Batch embedding fetch failed for chunk", exc_info=True)
+
+    # Pre-compute query norm once
+    _query_norm = np.linalg.norm(query_vec) + 1e-9
+
     # Score each message by vector similarity to query
     results = []
     for msg in messages:
         msg_id = msg[0]
-        # Get embedding
-        try:
-            emb_row = conn.execute(
-                f"SELECT embedding FROM {_vec_tbl} WHERE rowid = ?", (msg_id,)
-            ).fetchone()
-            if emb_row:
-                dim = len(emb_row[0]) // 4
-                msg_vec = np.array(
-                    struct.unpack(f"{dim}f", emb_row[0]), dtype=np.float32
-                )
-                sim = float(np.dot(query_vec, msg_vec) / (
-                    np.linalg.norm(query_vec) * np.linalg.norm(msg_vec) + 1e-9
-                ))
-            else:
-                sim = 0.0
-        except Exception:
+        msg_vec = emb_map.get(msg_id)
+        if msg_vec is not None:
+            sim = float(np.dot(query_vec, msg_vec) / (
+                _query_norm * (np.linalg.norm(msg_vec) + 1e-9)
+            ))
+        else:
             sim = 0.0
 
         results.append({

--- a/truememory/clustering.py
+++ b/truememory/clustering.py
@@ -24,11 +24,14 @@ Dependencies:
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 import struct
 from collections import defaultdict
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -2039,27 +2039,33 @@ class TrueMemoryEngine:
             except Exception:
                 logger.debug("HyDE search failed in search_agentic()", exc_info=True)
 
-        # Cluster search: add as low-priority supplement (never displace primary)
-        # Cluster scores (cosine 0-1) are in a different range than RRF scores
-        # (~0.01-0.03), so we must rescale cluster scores to be below the
-        # lowest primary result to ensure they only fill empty slots.
+        # ── Score normalization (issue #584) ─────────────────────────────
+        # Normalize primary results to [0, 1] before merging supplements so
+        # all sources compete in the same score space.
+        from truememory.agentic_search import normalize_scores
+
+        normalize_scores(primary_results)
+
+        # Cluster search: add as supplement, preserving cluster/diversity
+        # ordering.  Cluster scores (cosine 0-1) live in a different space
+        # than RRF scores; we normalize them independently and tag each
+        # result with its diversity position so downstream sorts can
+        # preserve the cluster-sampling order.
         if use_clustering and self._has_clustering:
             try:
                 cluster_results = search_clustered(
                     self.conn, query, limit=limit, top_clusters=3,
                 )
                 if cluster_results and primary_results:
-                    # Find the minimum score in primary results
-                    min_primary = min(
-                        r.get("score", r.get("rrf_score", 0))
-                        for r in primary_results
-                    )
+                    # Normalize cluster scores to [0, 1] independently
+                    normalize_scores(cluster_results)
+
                     existing_ids = {r.get("id") for r in primary_results if r.get("id")}
-                    for cr in cluster_results:
+                    for idx, cr in enumerate(cluster_results):
                         cid = cr.get("id")
                         if cid and cid not in existing_ids:
-                            # Scale to just below primary results
-                            cr["score"] = min_primary * 0.5
+                            # Preserve diversity position from clustering
+                            cr["_cluster_position"] = idx
                             cr["source"] = cr.get("source", "") + "+cluster_supp"
                             primary_results.append(cr)
                             existing_ids.add(cid)
@@ -2074,8 +2080,8 @@ class TrueMemoryEngine:
         # agencies...").
         #
         # Strategy: BOOST existing primary results that also appear in entity
-        # search (overlap = strong signal), and add genuinely new results at
-        # a competitive score level so they can displace weak primary results.
+        # search (overlap = strong signal), and add genuinely new results
+        # with independently normalized scores so they compete fairly.
         #
         # Fix #582: Use _entity_boosted flag to ensure boost is applied
         # exactly once.  The flag is checked before boosting and set after,
@@ -2083,6 +2089,9 @@ class TrueMemoryEngine:
         try:
             entity_results = self._entity_focused_search(query, limit * 2)
             if entity_results and primary_results:
+                # Normalize entity scores to [0, 1] independently
+                normalize_scores(entity_results)
+
                 entity_ids = {r.get("id") for r in entity_results if r.get("id")}
 
                 # Boost primary results that overlap with entity search
@@ -2094,21 +2103,11 @@ class TrueMemoryEngine:
                         if "entity_boost" not in pr.get("source", ""):
                             pr["source"] = pr.get("source", "") + "+entity_boost"
 
-                # Add genuinely new entity results at median primary score
-                primary_scores = [
-                    r.get("score", r.get("rrf_score", 0)) for r in primary_results
-                ]
-                primary_scores.sort(reverse=True)
-                # Use median score so new entity results can compete for top-k
-                median_idx = len(primary_scores) // 2
-                median_score = primary_scores[median_idx] if primary_scores else 0.01
-
                 existing_ids = {r.get("id") for r in primary_results if r.get("id")}
                 added = 0
                 for er in entity_results:
                     eid = er.get("id")
                     if eid and eid not in existing_ids:
-                        er["score"] = median_score * 0.9
                         er["source"] = er.get("source", "") + "+entity_new"
                         er["_entity_boosted"] = True
                         primary_results.append(er)
@@ -2117,9 +2116,10 @@ class TrueMemoryEngine:
                         if added >= limit:
                             break
 
-                # Re-sort after boosting
+                # Re-sort primary results only (cluster supplements keep
+                # their _cluster_position and are appended after primary).
                 primary_results.sort(
-                    key=lambda d: (-d.get("score", d.get("rrf_score", 0)), d.get("id", 0))
+                    key=lambda d: (-d.get("score", 0), d.get("id", 0))
                 )
         except Exception:
             logger.debug("Entity-focused search failed in search_agentic()", exc_info=True)
@@ -2163,6 +2163,8 @@ class TrueMemoryEngine:
             for rq in refined_queries:
                 try:
                     rq_results = self.search(rq, limit=limit, _skip_surprise_boost=True, _skip_reranker=True)
+                    # Normalize refined-query scores to [0, 1]
+                    normalize_scores(rq_results)
                     for rr in rq_results:
                         rid = rr.get("id")
                         if rid and rid not in existing_ids:
@@ -2181,7 +2183,7 @@ class TrueMemoryEngine:
 
             # Re-sort after adding refined results
             primary_results.sort(
-                key=lambda d: (-d.get("score", d.get("rrf_score", 0)), d.get("id", 0))
+                key=lambda d: (-d.get("score", 0), d.get("id", 0))
             )
 
         # ── L5 surprise rerank boost (MEMORIST-L5, applied BEFORE cross-encoder) ──


### PR DESCRIPTION
## Summary
- **Score normalization**: Added per-source min-max normalization to [0,1] before merging supplements from different retrieval sources (vector/cosine, FTS/BM25, HyDE, entity, cluster). Previously raw scores from incompatible spaces caused unfair ranking.
- **Cluster order preservation**: Cluster results from HDBSCAN/diversity sampling are now tagged with `_cluster_position` and are no longer re-sorted by raw score after merging, preserving the diversity ordering.
- **Batch embedding fetch**: `search_clustered()` now fetches all embeddings in a single chunked SQL query instead of one SELECT per message, reducing DB round-trips.

## Test plan
- [x] 13 new tests in `tests/test_issue_584_supplement_scoring.py`
  - Mixed-source results normalized to [0,1]
  - All-equal and single-result edge cases
  - Negative and BM25-range scores handled
  - Cluster order preserved through merge
  - Single-source relative ranking unchanged
  - Independent normalization per source
- [x] Full test suite passes (1155 passed, 6 skipped)

Closes #584