### PR TITLE
chore: remove phantom dashboard entry point and optional extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,6 @@ dependencies = [
 reranker = []
 gpu = []
 agentic = []
-dashboard = [
-    "fastapi>=0.100,<1.0",
-    "uvicorn[standard]>=0.20,<1.0",
-    "pywebview>=5.0,<7.0",
-]
 dev = ["pytest>=7.0,<10.0", "pytest-timeout>=2.2,<3.0", "ruff>=0.4,<1.0", "build>=1.2,<2.0", "twine>=5.0,<7.0"]
 all = ["truememory[agentic]"]
 
@@ -57,7 +52,6 @@ all = ["truememory[agentic]"]
 truememory-mcp = "truememory.mcp_server:main"
 truememory-ingest = "truememory.ingest.cli:main"
 truememory-model-server = "truememory.model_server:main"
-truememory-dashboard = "truememory.dashboard.cli:main"
 
 [tool.setuptools.package-data]
 truememory = ["assets/*.icns"]
@@ -121,14 +115,4 @@ exclude = [
     "*.pyc",
     "__pycache__",
     ".DS_Store",
-    "/truememory/dashboard/frontend/node_modules",
-    "/truememory/dashboard/frontend/src",
-    "/truememory/dashboard/frontend/package.json",
-    "/truememory/dashboard/frontend/bun.lock",
-    "/truememory/dashboard/frontend/vite.config.ts",
-    "/truememory/dashboard/frontend/tailwind.config.ts",
-    "/truememory/dashboard/frontend/tsconfig.json",
-    "/truememory/dashboard/frontend/tsconfig.app.json",
-    "/truememory/dashboard/frontend/tsconfig.node.json",
-    "/truememory/dashboard/frontend/postcss.config.js",
 ]

--- a/tests/test_issue_594_packaging.py
+++ b/tests/test_issue_594_packaging.py
@@ -1,0 +1,89 @@
+"""Regression test for issue #594 — dashboard packaging fork.
+
+pyproject.toml declared a ``truememory-dashboard`` entry point whose target
+module (``truememory.dashboard.cli:main``) never existed in the repo.  This
+shipped a broken console-script in every wheel.
+
+The fix removes the phantom entry point (and its optional-dependency extra).
+This test locks the invariant: **every ``[project.scripts]`` entry point must
+resolve to an importable module + callable**.
+"""
+from __future__ import annotations
+
+import importlib
+import pathlib
+import re
+
+
+def _parse_entry_points() -> list[tuple[str, str, str]]:
+    """Return ``[(name, module, attr), ...]`` from pyproject.toml ``[project.scripts]``."""
+    toml_path = pathlib.Path(__file__).resolve().parents[1] / "pyproject.toml"
+    text = toml_path.read_text()
+
+    in_scripts = False
+    results: list[tuple[str, str, str]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == "[project.scripts]":
+            in_scripts = True
+            continue
+        if in_scripts:
+            if stripped.startswith("["):
+                break
+            m = re.match(r'^([\w-]+)\s*=\s*"([\w.]+):(\w+)"', stripped)
+            if m:
+                results.append((m.group(1), m.group(2), m.group(3)))
+    return results
+
+
+def test_all_entry_points_resolve():
+    """Every console-script declared in pyproject.toml must point to an
+    importable module that exposes the named callable."""
+    entry_points = _parse_entry_points()
+    assert entry_points, "pyproject.toml should declare at least one entry point"
+
+    for name, module_path, attr in entry_points:
+        mod = importlib.import_module(module_path)
+        obj = getattr(mod, attr, None)
+        assert obj is not None, (
+            f"Entry point {name!r} references {module_path}:{attr} "
+            f"but {attr!r} was not found in module {module_path!r}"
+        )
+        assert callable(obj), (
+            f"Entry point {name!r}: {module_path}:{attr} exists but is not callable"
+        )
+
+
+def test_no_dashboard_entry_point():
+    """The phantom ``truememory-dashboard`` entry point must not reappear."""
+    entry_points = _parse_entry_points()
+    names = {name for name, _, _ in entry_points}
+    assert "truememory-dashboard" not in names, (
+        "truememory-dashboard entry point must not exist — "
+        "the dashboard module was never committed (issue #594)"
+    )
+
+
+def test_no_dashboard_optional_extra():
+    """The ``dashboard`` optional-dependency extra must not reappear."""
+    toml_path = pathlib.Path(__file__).resolve().parents[1] / "pyproject.toml"
+    text = toml_path.read_text()
+
+    in_optional = False
+    extras: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == "[project.optional-dependencies]":
+            in_optional = True
+            continue
+        if in_optional:
+            if stripped.startswith("["):
+                break
+            m = re.match(r"^(\w+)\s*=", stripped)
+            if m:
+                extras.append(m.group(1))
+
+    assert "dashboard" not in extras, (
+        "dashboard optional-dependency extra must not exist — "
+        "the dashboard module was never committed (issue #594)"
+    )


### PR DESCRIPTION
## Summary
- Removed the `truememory-dashboard` console-script entry point from `[project.scripts]` — it referenced `truememory.dashboard.cli:main` which never existed in the repo, shipping a broken entry point in every PyPI wheel
- Removed the `dashboard` optional-dependency extra (`fastapi`, `uvicorn`, `pywebview`) since there is no dashboard code to use them
- Removed 10 dead sdist exclude rules for `truememory/dashboard/frontend/` paths

## Test plan
- [x] Added `tests/test_issue_594_packaging.py` with 3 tests:
  - `test_all_entry_points_resolve` — verifies every `[project.scripts]` entry resolves to an importable, callable object
  - `test_no_dashboard_entry_point` — locks out the phantom `truememory-dashboard` script
  - `test_no_dashboard_optional_extra` — locks out the phantom `dashboard` extra
- [x] All 3 new tests pass
- [x] Full suite: 1143 passed, 6 skipped, 2 deselected

Closes #594