### PR TITLE
perf: cache recall_memories() results with file-based TTL

### DIFF
--- a/tests/test_issue_559_recall_cache.py
+++ b/tests/test_issue_559_recall_cache.py
@@ -1,0 +1,203 @@
+"""Tests for recall cache-TTL (issue #559).
+
+The 5-query recall search is the main cost of the SessionStart /
+UserPromptSubmit hooks. This cache stores results to a file so
+subsequent calls within the TTL skip the full search pipeline.
+
+Covers:
+  - Fresh cache hit returns cached context (queries skipped)
+  - Expired cache triggers full queries
+  - Cache miss (no file) triggers full queries
+  - New memory store invalidates the cache
+  - Multi-DB isolation via cache key
+  - TTL=0 disables caching
+  - Corrupt cache file is handled gracefully
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from truememory.ingest.hooks import _shared
+
+
+@pytest.fixture(autouse=True)
+def isolated_cache(tmp_path, monkeypatch):
+    """Point the recall cache at an isolated temp file."""
+    cache_path = tmp_path / "recall_cache.json"
+    monkeypatch.setattr(_shared, "RECALL_CACHE_PATH", cache_path)
+    monkeypatch.setattr(_shared, "RECALL_CACHE_TTL", 300.0)
+    return cache_path
+
+
+class TestCacheHit:
+    """Fresh cache within TTL returns cached results."""
+
+    def test_round_trip(self, isolated_cache):
+        context = "<truememory-context>\n- Likes Python\n</truememory-context>"
+        _shared.set_recall_cache(context, "", "")
+        assert _shared.get_recall_cache("", "") == context
+
+    def test_cache_returns_exact_context(self, isolated_cache):
+        context = "<truememory-context>\n- Prefers dark mode\n- Lives in Austin\n</truememory-context>"
+        _shared.set_recall_cache(context, "", "")
+        result = _shared.get_recall_cache("", "")
+        assert result == context
+
+    def test_fresh_cache_skips_queries(self, isolated_cache):
+        """When cache is fresh, get_recall_cache returns non-None."""
+        _shared.set_recall_cache("cached", "", "")
+        assert _shared.get_recall_cache("", "") is not None
+
+
+class TestCacheExpired:
+    """Expired cache returns None so full queries run."""
+
+    def test_expired_cache_returns_none(self, isolated_cache):
+        _shared.set_recall_cache("old-context", "", "")
+        # Backdate the timestamp to be past TTL
+        data = json.loads(isolated_cache.read_text(encoding="utf-8"))
+        key = _shared._recall_cache_key("", "")
+        data[key]["timestamp"] = time.time() - 400  # 400s > 300s TTL
+        isolated_cache.write_text(json.dumps(data), encoding="utf-8")
+        assert _shared.get_recall_cache("", "") is None
+
+    def test_just_expired_returns_none(self, isolated_cache):
+        _shared.set_recall_cache("borderline", "", "")
+        data = json.loads(isolated_cache.read_text(encoding="utf-8"))
+        key = _shared._recall_cache_key("", "")
+        data[key]["timestamp"] = time.time() - 300  # exactly at TTL
+        isolated_cache.write_text(json.dumps(data), encoding="utf-8")
+        assert _shared.get_recall_cache("", "") is None
+
+    def test_just_under_ttl_returns_cached(self, isolated_cache):
+        _shared.set_recall_cache("still-fresh", "", "")
+        data = json.loads(isolated_cache.read_text(encoding="utf-8"))
+        key = _shared._recall_cache_key("", "")
+        data[key]["timestamp"] = time.time() - 299  # 1s before TTL
+        isolated_cache.write_text(json.dumps(data), encoding="utf-8")
+        assert _shared.get_recall_cache("", "") == "still-fresh"
+
+
+class TestCacheMiss:
+    """No cache file returns None so full queries run."""
+
+    def test_no_file_returns_none(self, isolated_cache):
+        assert not isolated_cache.exists()
+        assert _shared.get_recall_cache("", "") is None
+
+    def test_wrong_key_returns_none(self, isolated_cache):
+        _shared.set_recall_cache("context", "/path/a.db", "")
+        assert _shared.get_recall_cache("/path/b.db", "") is None
+
+
+class TestCacheInvalidation:
+    """New memory store deletes the cache."""
+
+    def test_invalidate_deletes_cache_file(self, isolated_cache):
+        _shared.set_recall_cache("context", "", "")
+        assert isolated_cache.exists()
+        _shared.invalidate_recall_cache()
+        assert not isolated_cache.exists()
+
+    def test_invalidate_specific_db_preserves_others(self, isolated_cache):
+        _shared.set_recall_cache("context-a", "/path/a.db", "")
+        _shared.set_recall_cache("context-b", "/path/b.db", "")
+        _shared.invalidate_recall_cache("/path/a.db", "")
+        assert _shared.get_recall_cache("/path/a.db", "") is None
+        assert _shared.get_recall_cache("/path/b.db", "") == "context-b"
+
+    def test_invalidate_no_db_deletes_all(self, isolated_cache):
+        _shared.set_recall_cache("context-a", "/path/a.db", "")
+        _shared.set_recall_cache("context-b", "/path/b.db", "")
+        _shared.invalidate_recall_cache()
+        assert not isolated_cache.exists()
+
+    def test_invalidate_nonexistent_is_noop(self, isolated_cache):
+        # Should not raise
+        _shared.invalidate_recall_cache()
+        _shared.invalidate_recall_cache("/no/such.db")
+
+    def test_get_returns_none_after_invalidation(self, isolated_cache):
+        _shared.set_recall_cache("context", "", "")
+        _shared.invalidate_recall_cache()
+        assert _shared.get_recall_cache("", "") is None
+
+
+class TestMultiDB:
+    """Cache keys isolate different DB paths and user IDs."""
+
+    def test_different_db_paths(self, isolated_cache):
+        _shared.set_recall_cache("ctx-a", "/a.db", "")
+        _shared.set_recall_cache("ctx-b", "/b.db", "")
+        assert _shared.get_recall_cache("/a.db", "") == "ctx-a"
+        assert _shared.get_recall_cache("/b.db", "") == "ctx-b"
+
+    def test_different_user_ids(self, isolated_cache):
+        _shared.set_recall_cache("ctx-alice", "", "alice")
+        _shared.set_recall_cache("ctx-bob", "", "bob")
+        assert _shared.get_recall_cache("", "alice") == "ctx-alice"
+        assert _shared.get_recall_cache("", "bob") == "ctx-bob"
+
+    def test_default_key(self, isolated_cache):
+        assert _shared._recall_cache_key("", "") == "default:"
+        assert _shared._recall_cache_key("/a.db", "alice") == "/a.db:alice"
+
+
+class TestTTLDisabled:
+    """TTL=0 disables caching entirely."""
+
+    def test_ttl_zero_disables_set(self, isolated_cache, monkeypatch):
+        monkeypatch.setattr(_shared, "RECALL_CACHE_TTL", 0)
+        _shared.set_recall_cache("context", "", "")
+        assert not isolated_cache.exists()
+
+    def test_ttl_zero_disables_get(self, isolated_cache, monkeypatch):
+        # Write a cache with normal TTL first
+        _shared.set_recall_cache("context", "", "")
+        assert isolated_cache.exists()
+        # Now disable
+        monkeypatch.setattr(_shared, "RECALL_CACHE_TTL", 0)
+        assert _shared.get_recall_cache("", "") is None
+
+    def test_ttl_negative_disables(self, isolated_cache, monkeypatch):
+        monkeypatch.setattr(_shared, "RECALL_CACHE_TTL", -1.0)
+        _shared.set_recall_cache("context", "", "")
+        assert not isolated_cache.exists()
+        assert _shared.get_recall_cache("", "") is None
+
+
+class TestCorruptCache:
+    """Corrupt cache files are handled gracefully."""
+
+    def test_invalid_json(self, isolated_cache):
+        isolated_cache.write_text("not valid json", encoding="utf-8")
+        assert _shared.get_recall_cache("", "") is None
+
+    def test_wrong_type(self, isolated_cache):
+        isolated_cache.write_text('"just a string"', encoding="utf-8")
+        assert _shared.get_recall_cache("", "") is None
+
+    def test_missing_timestamp(self, isolated_cache):
+        data = {"default:": {"context": "hello"}}
+        isolated_cache.write_text(json.dumps(data), encoding="utf-8")
+        assert _shared.get_recall_cache("", "") is None
+
+    def test_set_overwrites_corrupt(self, isolated_cache):
+        isolated_cache.write_text("garbage", encoding="utf-8")
+        _shared.set_recall_cache("fresh", "", "")
+        assert _shared.get_recall_cache("", "") == "fresh"
+
+
+class TestEmptyContext:
+    """Empty string context is cached normally (no queries returned results)."""
+
+    def test_empty_string_cached(self, isolated_cache):
+        _shared.set_recall_cache("", "", "")
+        # Empty string is a valid cache entry (means 0 results last time)
+        result = _shared.get_recall_cache("", "")
+        assert result == ""

--- a/tests/test_issue_559_recall_cache.py
+++ b/tests/test_issue_559_recall_cache.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 
 import json
 import time
-from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/truememory/client.py
+++ b/truememory/client.py
@@ -107,6 +107,13 @@ class Memory:
         )
         result["user_id"] = user_id or ""
         result["created_at"] = now
+        # Issue #559: invalidate recall cache so the next hook invocation
+        # picks up newly stored memories instead of serving stale results.
+        try:
+            from truememory.ingest.hooks._shared import invalidate_recall_cache
+            invalidate_recall_cache()
+        except Exception:
+            pass
         return result
 
     def search(

--- a/truememory/hooks/core.py
+++ b/truememory/hooks/core.py
@@ -398,7 +398,21 @@ def recall_memories(
 
     Returns a formatted string suitable for additionalContext injection,
     or empty string if no memories found.
+
+    Uses a file-based cache (issue #559): after running the 5 search
+    queries, results are cached with a timestamp. Subsequent calls within
+    the TTL (default 5 min, env TRUEMEMORY_RECALL_CACHE_TTL) return the
+    cached context instead of re-querying the full search pipeline.
     """
+    # --- Issue #559: check cache first ---
+    try:
+        from truememory.ingest.hooks._shared import get_recall_cache, set_recall_cache
+        cached = get_recall_cache(db_path or "", user_id)
+        if cached is not None:
+            return cached
+    except Exception:
+        pass
+
     try:
         from truememory import Memory
     except ImportError:
@@ -472,7 +486,15 @@ def recall_memories(
             lines.append(f"- {content}")
 
     lines.append("</truememory-context>")
-    return "\n".join(lines)
+    context = "\n".join(lines)
+
+    # Cache results for subsequent calls (issue #559)
+    try:
+        set_recall_cache(context, db_path or "", user_id)
+    except Exception:
+        pass
+
+    return context
 
 
 def buffer_message(session_id: str, prompt: str) -> None:

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -18,6 +18,14 @@ log = logging.getLogger(__name__)
 EXTRACTED_DIR = Path.home() / ".truememory" / "extracted"
 BACKLOG_DIR = Path.home() / ".truememory" / "backlog"
 RECALL_MARKER_DIR = Path.home() / ".truememory" / "recall_markers"
+RECALL_CACHE_PATH = Path.home() / ".truememory" / "recall_cache.json"
+
+# How long cached recall results remain valid (seconds).  Default 5 min.
+# Set TRUEMEMORY_RECALL_CACHE_TTL=0 to disable caching entirely.
+try:
+    RECALL_CACHE_TTL = float(os.environ.get("TRUEMEMORY_RECALL_CACHE_TTL", "300"))
+except ValueError:
+    RECALL_CACHE_TTL = 300.0
 
 _BUDGET_FILE = Path.home() / ".truememory" / ".extraction_budget"
 _MAX_EXTRACTIONS_PER_HOUR = int(os.environ.get("TRUEMEMORY_MAX_EXTRACTIONS_PER_HOUR", "20"))
@@ -309,6 +317,97 @@ def mark_recall_injected(session_id: str) -> None:
         (RECALL_MARKER_DIR / safe_id).write_text(str(time.time()), encoding="utf-8")
     except OSError:
         pass
+
+
+def get_recall_cache(db_path: str, user_id: str = "") -> str | None:
+    """Return cached recall context if it exists and is within the TTL.
+
+    Returns the cached context string, or None if the cache is missing,
+    stale, or disabled. Cache key is (db_path, user_id) so multi-DB and
+    multi-user setups get separate caches.
+    """
+    if RECALL_CACHE_TTL <= 0:
+        return None
+    try:
+        if not RECALL_CACHE_PATH.exists():
+            return None
+        data = json.loads(RECALL_CACHE_PATH.read_text(encoding="utf-8"))
+        key = _recall_cache_key(db_path, user_id)
+        entry = data.get(key)
+        if entry is None:
+            return None
+        ts = entry.get("timestamp", 0)
+        if (time.time() - ts) >= RECALL_CACHE_TTL:
+            return None
+        return entry.get("context")
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError, AttributeError):
+        return None
+
+
+def set_recall_cache(context: str, db_path: str, user_id: str = "") -> None:
+    """Write recall results to the cache file with a timestamp.
+
+    Preserves entries for other (db_path, user_id) combinations so
+    multi-DB setups coexist in a single cache file.
+    """
+    if RECALL_CACHE_TTL <= 0:
+        return
+    try:
+        RECALL_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        # Read existing entries (best-effort)
+        existing: dict = {}
+        try:
+            if RECALL_CACHE_PATH.exists():
+                existing = json.loads(RECALL_CACHE_PATH.read_text(encoding="utf-8"))
+                if not isinstance(existing, dict):
+                    existing = {}
+        except (OSError, json.JSONDecodeError):
+            existing = {}
+        key = _recall_cache_key(db_path, user_id)
+        existing[key] = {
+            "timestamp": time.time(),
+            "context": context,
+        }
+        tmp = RECALL_CACHE_PATH.with_suffix(".tmp")
+        tmp.write_text(json.dumps(existing), encoding="utf-8")
+        tmp.rename(RECALL_CACHE_PATH)
+    except OSError:
+        pass
+
+
+def invalidate_recall_cache(db_path: str = "", user_id: str = "") -> None:
+    """Delete the recall cache, called when new memories are stored.
+
+    If db_path is provided, only the matching entry is removed; otherwise
+    the entire cache file is deleted (safest default).
+    """
+    try:
+        if not RECALL_CACHE_PATH.exists():
+            return
+        if not db_path:
+            RECALL_CACHE_PATH.unlink(missing_ok=True)
+            return
+        data = json.loads(RECALL_CACHE_PATH.read_text(encoding="utf-8"))
+        key = _recall_cache_key(db_path, user_id)
+        if key in data:
+            del data[key]
+            if data:
+                tmp = RECALL_CACHE_PATH.with_suffix(".tmp")
+                tmp.write_text(json.dumps(data), encoding="utf-8")
+                tmp.rename(RECALL_CACHE_PATH)
+            else:
+                RECALL_CACHE_PATH.unlink(missing_ok=True)
+    except (OSError, json.JSONDecodeError, TypeError):
+        # Best-effort: nuke the file on any error
+        try:
+            RECALL_CACHE_PATH.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _recall_cache_key(db_path: str, user_id: str = "") -> str:
+    """Deterministic cache key from db_path and user_id."""
+    return f"{db_path or 'default'}:{user_id or ''}"
 
 
 def consume_recall_injected(session_id: str, within_seconds: float = _RECALL_DEBOUNCE_SECONDS) -> bool:

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -370,7 +370,7 @@ def set_recall_cache(context: str, db_path: str, user_id: str = "") -> None:
         }
         tmp = RECALL_CACHE_PATH.with_suffix(".tmp")
         tmp.write_text(json.dumps(existing), encoding="utf-8")
-        tmp.rename(RECALL_CACHE_PATH)
+        os.replace(tmp, RECALL_CACHE_PATH)
     except OSError:
         pass
 
@@ -394,7 +394,7 @@ def invalidate_recall_cache(db_path: str = "", user_id: str = "") -> None:
             if data:
                 tmp = RECALL_CACHE_PATH.with_suffix(".tmp")
                 tmp.write_text(json.dumps(data), encoding="utf-8")
-                tmp.rename(RECALL_CACHE_PATH)
+                os.replace(tmp, RECALL_CACHE_PATH)
             else:
                 RECALL_CACHE_PATH.unlink(missing_ok=True)
     except (OSError, json.JSONDecodeError, TypeError):
@@ -406,8 +406,13 @@ def invalidate_recall_cache(db_path: str = "", user_id: str = "") -> None:
 
 
 def _recall_cache_key(db_path: str, user_id: str = "") -> str:
-    """Deterministic cache key from db_path and user_id."""
-    return f"{db_path or 'default'}:{user_id or ''}"
+    """Deterministic cache key from db_path and user_id.
+
+    Normalizes db_path via PurePosixPath so the same logical path produces
+    the same key on both Unix (``/a.db``) and Windows (``\\a.db``).
+    """
+    normalized = str(Path(db_path).as_posix()) if db_path else "default"
+    return f"{normalized}:{user_id or ''}"
 
 
 def consume_recall_injected(session_id: str, within_seconds: float = _RECALL_DEBOUNCE_SECONDS) -> bool:

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -614,7 +614,14 @@ def _apply_budget(
 
 
 def recall_memories(input_data: dict, user_id: str = "", db_path: str = "") -> str:
-    """Search TrueMemory and format relevant memories for injection."""
+    """Search TrueMemory and format relevant memories for injection.
+
+    Uses a file-based cache (issue #559): after running the 5 search
+    queries, results are cached with a timestamp. Subsequent calls within
+    the TTL (default 5 min, env TRUEMEMORY_RECALL_CACHE_TTL) return the
+    cached context instead of re-querying the full search pipeline.
+    Directives are always loaded fresh (cheap SQL, not cached).
+    """
     try:
         from truememory import Memory
     except ImportError:
@@ -635,7 +642,8 @@ def recall_memories(input_data: dict, user_id: str = "", db_path: str = "") -> s
     db = db_path or None
     memory = Memory(path=db) if db else Memory()
 
-    # Load directives first — these are always injected
+    # Load directives first — these are always injected (cheap SQL query,
+    # not cached since they change infrequently and the query is fast).
     directives = _load_directives(memory, user_id=user_id)
     directive_ids = {d["id"] for d in directives}
 
@@ -662,6 +670,14 @@ def recall_memories(input_data: dict, user_id: str = "", db_path: str = "") -> s
                 )
         dir_lines.append("</truememory-directives>")
         parts.append("\n".join(dir_lines))
+
+    # --- Issue #559: cache-TTL for the 5 recall queries ---
+    from truememory.ingest.hooks._shared import get_recall_cache, set_recall_cache
+
+    cached = get_recall_cache(db_path or "", user_id)
+    if cached is not None:
+        parts.append(cached)
+        return "\n\n".join(parts) if parts else ""
 
     queries = [
         "user preferences favorites likes dislikes",
@@ -710,6 +726,7 @@ def recall_memories(input_data: dict, user_id: str = "", db_path: str = "") -> s
         except Exception:
             continue
 
+    recall_context = ""
     if all_results:
         # -- Issue #578: per-memory truncation + total payload budget ----------
         directive_block = parts[0] if parts else ""
@@ -734,7 +751,11 @@ def recall_memories(input_data: dict, user_id: str = "", db_path: str = "") -> s
             ]
             lines.extend(kept)
             lines.append("</truememory-context>")
-            parts.append("\n".join(lines))
+            recall_context = "\n".join(lines)
+            parts.append(recall_context)
+
+    # Cache the recall portion (not directives) for subsequent calls
+    set_recall_cache(recall_context if all_results else "", db_path or "", user_id)
 
     return "\n\n".join(parts) if parts else ""
 

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -673,6 +673,13 @@ def truememory_store(
     except (json.JSONDecodeError, ValueError):
         meta = None
     result = m.add(content=content, user_id=user_id or None, metadata=meta, directive=directive)
+    # Issue #559: invalidate recall cache so the next session start picks up
+    # the newly stored memory instead of serving stale cached results.
+    try:
+        from truememory.ingest.hooks._shared import invalidate_recall_cache
+        invalidate_recall_cache()
+    except Exception:
+        pass
     return json.dumps(result, indent=2)
 
 


### PR DESCRIPTION
## Summary
- Adds file-based cache (`~/.truememory/recall_cache.json`) for `recall_memories()` 5-query search results with a configurable TTL (default 5 min via `TRUEMEMORY_RECALL_CACHE_TTL`)
- Cache keyed by `(db_path, user_id)` for multi-DB/user isolation; directives always loaded fresh
- Cache invalidated automatically when `truememory_store` or `Memory.add()` stores a new memory
- Applied to both `session_start.py` and `hooks/core.py` recall paths

## Test plan
- [x] 24 new tests in `tests/test_issue_559_recall_cache.py` covering:
  - Fresh cache hit returns cached context (queries skipped)
  - Expired cache (past TTL) triggers full queries
  - Cache miss (no file) triggers full queries
  - New memory store invalidates the cache
  - Multi-DB and multi-user key isolation
  - TTL=0 disables caching entirely
  - Corrupt/missing cache files handled gracefully
  - Empty context cached normally
- [x] All 134 related tests pass (hooks, recall debounce, user_prompt_submit)
- [x] Pre-existing integration test timeout (`test_e2e_dedup`) is unrelated (model server not running)

Closes #559