### PR TITLE
perf: watermark-based stale session scanner

### DIFF
--- a/tests/test_issue_560_scanner_watermark.py
+++ b/tests/test_issue_560_scanner_watermark.py
@@ -44,8 +44,10 @@ def scanner_env(monkeypatch, tmp_path):
     backlog.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
 
-    # Patch Path.home() — setenv HOME so Path.home() returns tmp_path
+    # Patch Path.home() — setenv HOME so Path.home() returns tmp_path.
+    # On Windows, Path.home() reads USERPROFILE (not HOME), so set both.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     # Patch _shared references used inside _scan_stale_sessions
     from truememory.ingest.hooks import _shared

--- a/tests/test_issue_560_scanner_watermark.py
+++ b/tests/test_issue_560_scanner_watermark.py
@@ -1,0 +1,270 @@
+"""Tests for watermark-based stale session scanner (issue #560).
+
+The scanner previously did an O(n) walk of every .jsonl file under
+~/.claude/projects/. With the watermark optimization it only checks
+files modified after the last scan timestamp, making it O(new).
+
+Covers:
+  - First scan (no watermark) uses 24-hour fallback
+  - Old files (before watermark) are skipped
+  - New files (after watermark) are scanned and queued
+  - Watermark is updated after each scan
+  - _read_scan_watermark handles empty / corrupt data
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+
+import pytest
+
+from truememory.ingest.hooks import session_start as ss
+
+
+@pytest.fixture
+def scanner_env(monkeypatch, tmp_path):
+    """Set up isolated directories for scanner testing."""
+    # Scan marker
+    marker = tmp_path / "truememory" / ".last_stale_scan"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(ss, "_SCAN_MARKER", marker)
+
+    # Claude projects dir (must match Path.home() / ".claude" / "projects")
+    claude_dir = tmp_path / ".claude" / "projects"
+    claude_dir.mkdir(parents=True)
+
+    # Extracted dir
+    extracted = tmp_path / "truememory" / "extracted"
+    extracted.mkdir(parents=True, exist_ok=True)
+
+    # Backlog dir
+    backlog = tmp_path / "truememory" / "backlog"
+    backlog.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
+
+    # Patch Path.home() — setenv HOME so Path.home() returns tmp_path
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Patch _shared references used inside _scan_stale_sessions
+    from truememory.ingest.hooks import _shared
+    monkeypatch.setattr(_shared, "EXTRACTED_DIR", extracted)
+
+    # Disable fcntl locking for test isolation
+    monkeypatch.setattr(ss, "_HAS_FCNTL", False)
+
+    return {
+        "tmp_path": tmp_path,
+        "marker": marker,
+        "claude_dir": claude_dir,
+        "extracted": extracted,
+        "backlog": backlog,
+    }
+
+
+def _make_transcript(project_dir, session_id=None, mtime=None, size=6000):
+    """Create a fake .jsonl transcript file."""
+    if session_id is None:
+        session_id = str(uuid.uuid4())
+    path = project_dir / f"{session_id}.jsonl"
+    # Write enough content to pass the 5000 byte minimum, with a non-extraction
+    # first user message so it isn't flagged as noise.
+    line = json.dumps({"type": "user", "message": {"content": "Hello world " + "x" * 200}})
+    content = (line + "\n") * (size // len(line) + 1)
+    path.write_text(content[:max(size, len(line) + 1)], encoding="utf-8")
+    if mtime is not None:
+        os.utime(str(path), (mtime, mtime))
+    return session_id, path
+
+
+class TestReadScanWatermark:
+    """Unit tests for _read_scan_watermark."""
+
+    def test_valid_timestamp(self, tmp_path):
+        p = tmp_path / "marker"
+        fd = os.open(str(p), os.O_RDWR | os.O_CREAT)
+        try:
+            ts = time.time() - 3600
+            os.write(fd, str(ts).encode("utf-8"))
+            result = ss._read_scan_watermark(fd)
+            assert abs(result - ts) < 0.01
+        finally:
+            os.close(fd)
+
+    def test_empty_file_returns_zero(self, tmp_path):
+        p = tmp_path / "marker"
+        fd = os.open(str(p), os.O_RDWR | os.O_CREAT)
+        try:
+            result = ss._read_scan_watermark(fd)
+            assert result == 0.0
+        finally:
+            os.close(fd)
+
+    def test_corrupt_content_returns_zero(self, tmp_path):
+        p = tmp_path / "marker"
+        fd = os.open(str(p), os.O_RDWR | os.O_CREAT)
+        try:
+            os.write(fd, b"not-a-number")
+            result = ss._read_scan_watermark(fd)
+            assert result == 0.0
+        finally:
+            os.close(fd)
+
+
+class TestScannerWatermark:
+    """Integration tests for watermark-based stale session scanning."""
+
+    def test_first_scan_no_watermark_uses_24h_fallback(self, scanner_env, monkeypatch):
+        """First scan with no prior watermark should scan files from the last 24h."""
+        env = scanner_env
+        proj = env["claude_dir"] / "test-project"
+        proj.mkdir()
+
+        now = time.time()
+        # File from 12 hours ago — should be scanned (within 24h)
+        sid_recent, _ = _make_transcript(proj, mtime=now - 43200)
+        # File from 48 hours ago — should be skipped (older than 24h)
+        sid_old, _ = _make_transcript(proj, mtime=now - 172800)
+
+        # Patch _queue_to_backlog to track calls
+        queued_sessions = []
+        from truememory.ingest.hooks import stop as stop_mod
+        monkeypatch.setattr(stop_mod, "_queue_to_backlog",
+                            lambda tp, sid, u, d, reason="": queued_sessions.append(sid))
+
+        # Ensure scan interval has passed (no marker exists yet)
+        ss._scan_stale_sessions()
+
+        assert sid_recent in queued_sessions
+        assert sid_old not in queued_sessions
+
+    def test_old_files_before_watermark_skipped(self, scanner_env, monkeypatch):
+        """Files modified before the watermark timestamp should be skipped."""
+        env = scanner_env
+        proj = env["claude_dir"] / "test-project"
+        proj.mkdir()
+
+        now = time.time()
+        watermark_time = now - 1800  # 30 minutes ago
+
+        # Write a watermark from 30 minutes ago
+        env["marker"].write_text(str(watermark_time), encoding="utf-8")
+        # Set mtime old enough to pass the scan interval check
+        os.utime(str(env["marker"]), (now - _scan_interval_plus(), now - _scan_interval_plus()))
+
+        # File modified BEFORE watermark — should be skipped
+        sid_old, _ = _make_transcript(proj, mtime=watermark_time - 600)
+        # File modified AFTER watermark — should be scanned
+        sid_new, _ = _make_transcript(proj, mtime=watermark_time + 300)
+
+        queued_sessions = []
+        from truememory.ingest.hooks import stop as stop_mod
+        monkeypatch.setattr(stop_mod, "_queue_to_backlog",
+                            lambda tp, sid, u, d, reason="": queued_sessions.append(sid))
+
+        ss._scan_stale_sessions()
+
+        assert sid_new in queued_sessions
+        assert sid_old not in queued_sessions
+
+    def test_watermark_updated_after_scan(self, scanner_env, monkeypatch):
+        """After a scan, the marker file should contain the new watermark."""
+        env = scanner_env
+
+        # No marker file yet
+        assert not env["marker"].exists()
+
+        from truememory.ingest.hooks import stop as stop_mod
+        monkeypatch.setattr(stop_mod, "_queue_to_backlog",
+                            lambda tp, sid, u, d, reason="": None)
+
+        before = time.time()
+        ss._scan_stale_sessions()
+        after = time.time()
+
+        assert env["marker"].exists()
+        watermark = float(env["marker"].read_text(encoding="utf-8").strip())
+        assert before <= watermark <= after
+
+    def test_new_files_after_watermark_scanned(self, scanner_env, monkeypatch):
+        """Files modified after the watermark should be checked and queued."""
+        env = scanner_env
+        proj = env["claude_dir"] / "test-project"
+        proj.mkdir()
+
+        now = time.time()
+        watermark_time = now - 1800
+
+        env["marker"].write_text(str(watermark_time), encoding="utf-8")
+        os.utime(str(env["marker"]), (now - _scan_interval_plus(), now - _scan_interval_plus()))
+
+        # Create 3 new files after watermark
+        sids = []
+        for i in range(3):
+            sid, _ = _make_transcript(proj, mtime=watermark_time + 60 * (i + 1))
+            sids.append(sid)
+
+        queued_sessions = []
+        from truememory.ingest.hooks import stop as stop_mod
+        monkeypatch.setattr(stop_mod, "_queue_to_backlog",
+                            lambda tp, sid, u, d, reason="": queued_sessions.append(sid))
+
+        ss._scan_stale_sessions()
+
+        # All 3 should be queued (cap is 3)
+        for sid in sids:
+            assert sid in queued_sessions
+
+    def test_already_extracted_sessions_skipped(self, scanner_env, monkeypatch):
+        """Files with an extraction marker should still be skipped."""
+        env = scanner_env
+        proj = env["claude_dir"] / "test-project"
+        proj.mkdir()
+
+        now = time.time()
+        watermark_time = now - 1800
+
+        env["marker"].write_text(str(watermark_time), encoding="utf-8")
+        os.utime(str(env["marker"]), (now - _scan_interval_plus(), now - _scan_interval_plus()))
+
+        sid, _ = _make_transcript(proj, mtime=now - 60)
+        # Create extraction marker
+        (env["extracted"] / sid).write_text("done", encoding="utf-8")
+
+        queued_sessions = []
+        from truememory.ingest.hooks import stop as stop_mod
+        monkeypatch.setattr(stop_mod, "_queue_to_backlog",
+                            lambda tp, sid, u, d, reason="": queued_sessions.append(sid))
+
+        ss._scan_stale_sessions()
+
+        assert sid not in queued_sessions
+
+    def test_scan_respects_interval(self, scanner_env, monkeypatch):
+        """Scanner should not run if the marker mtime is within the interval."""
+        env = scanner_env
+
+        # Create marker with recent mtime (within interval)
+        now = time.time()
+        env["marker"].write_text(str(now), encoding="utf-8")
+        # mtime is current — within _SCAN_INTERVAL
+
+        proj = env["claude_dir"] / "test-project"
+        proj.mkdir()
+        sid, _ = _make_transcript(proj, mtime=now)
+
+        queued_sessions = []
+        from truememory.ingest.hooks import stop as stop_mod
+        monkeypatch.setattr(stop_mod, "_queue_to_backlog",
+                            lambda tp, sid, u, d, reason="": queued_sessions.append(sid))
+
+        ss._scan_stale_sessions()
+
+        # Should not have scanned (interval not elapsed)
+        assert len(queued_sessions) == 0
+
+
+def _scan_interval_plus():
+    """Return a value larger than _SCAN_INTERVAL for mtime backdating."""
+    return ss._SCAN_INTERVAL + 60

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -324,13 +324,32 @@ def _cleanup_extracted_markers() -> None:
                  removed, _EXTRACTED_MARKER_MAX_AGE // 86400)
 
 
+def _read_scan_watermark(scan_fd: int) -> float:
+    """Read the watermark timestamp stored in the scan marker file.
+
+    Returns the stored timestamp, or 0.0 if the file is empty / corrupt.
+    """
+    try:
+        os.lseek(scan_fd, 0, os.SEEK_SET)
+        raw = os.read(scan_fd, 64)
+        if raw:
+            return float(raw.strip())
+    except (OSError, ValueError):
+        pass
+    return 0.0
+
+
 def _scan_stale_sessions() -> None:
     """Find transcripts from recent sessions that were never extracted.
 
-    Runs at most once per _SCAN_INTERVAL. Scans Claude Code's project
-    directories for session transcripts modified in the last 24 hours
-    that have no corresponding extraction marker. Skips extraction noise
-    transcripts (identified by sentinel tag or legacy prompt prefixes).
+    Runs at most once per _SCAN_INTERVAL.  Uses a watermark-based approach:
+    the marker file stores the timestamp of the last successful scan.
+    Only transcripts modified *after* that watermark are checked, making the
+    scanner O(new) instead of O(all).  On first run (no watermark) it falls
+    back to a 24-hour lookback window.
+
+    Uses ``os.scandir()`` instead of ``Path.iterdir()`` to piggy-back on
+    the DirEntry stat cache and avoid redundant syscalls.
     """
     import time
     import re
@@ -344,26 +363,28 @@ def _scan_stale_sessions() -> None:
         return
 
     try:
+        now = time.time()
         try:
-            # Read the marker content to determine last scan time.  On first
-            # run O_CREAT creates an empty file — we must NOT skip the scan
-            # just because the file now exists with a recent mtime (issue #579).
-            raw = os.read(scan_fd, 64).decode("utf-8", errors="replace").strip()
-            if raw:
-                last_scan = float(raw)
-                if time.time() - last_scan < _SCAN_INTERVAL:
-                    return
+            # Read watermark *before* the interval gate — an empty file
+            # (first run, or O_CREAT just created it) must not short-circuit.
+            watermark = _read_scan_watermark(scan_fd)
+            if watermark > 0 and (now - watermark) < _SCAN_INTERVAL:
+                return
+        except OSError:
+            return
+
+        # Fall back to 24-hour lookback when no previous watermark exists
+        # (first scan or corrupted marker).
+        cutoff = watermark if watermark > 0 else (now - 86400)
+
+        # Write the new watermark (current time) — even if no files are
+        # queued, the mtime update gates the next scan interval.
+        try:
             os.lseek(scan_fd, 0, os.SEEK_SET)
             os.ftruncate(scan_fd, 0)
-            os.write(scan_fd, str(time.time()).encode("utf-8"))
-        except (OSError, ValueError):
-            # ValueError covers corrupted/non-numeric content — scan anyway.
-            try:
-                os.lseek(scan_fd, 0, os.SEEK_SET)
-                os.ftruncate(scan_fd, 0)
-                os.write(scan_fd, str(time.time()).encode("utf-8"))
-            except OSError:
-                pass
+            os.write(scan_fd, str(now).encode("utf-8"))
+        except OSError:
+            return
 
         claude_dir = Path.home() / ".claude" / "projects"
         if not claude_dir.exists():
@@ -373,23 +394,31 @@ def _scan_stale_sessions() -> None:
         from truememory.ingest.hooks.stop import _queue_to_backlog
 
         uuid_re = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
-        cutoff = time.time() - 86400
         queued = 0
         skipped_noise = 0
 
-        for project_dir in claude_dir.iterdir():
-            if not project_dir.is_dir():
+        try:
+            project_entries = os.scandir(str(claude_dir))
+        except OSError:
+            return
+
+        for proj_entry in project_entries:
+            if not proj_entry.is_dir(follow_symlinks=False):
                 continue
-            for transcript in project_dir.iterdir():
-                if transcript.suffix != ".jsonl":
+            try:
+                file_entries = os.scandir(proj_entry.path)
+            except OSError:
+                continue
+            for entry in file_entries:
+                if not entry.name.endswith(".jsonl"):
                     continue
-                if not transcript.is_file():
+                if not entry.is_file(follow_symlinks=False):
                     continue
-                session_id = transcript.stem
+                session_id = entry.name[:-6]  # strip .jsonl
                 if not uuid_re.match(session_id):
                     continue
                 try:
-                    stat = transcript.stat()
+                    stat = entry.stat()
                     if stat.st_mtime < cutoff:
                         continue
                     if stat.st_size < 5000:
@@ -405,6 +434,7 @@ def _scan_stale_sessions() -> None:
                 if marker.exists():
                     continue
 
+                transcript = Path(entry.path)
                 if _is_extraction_transcript(transcript):
                     try:
                         mark_session_extracted(session_id, str(transcript))


### PR DESCRIPTION
## Summary
- **Replaces O(n) brute-force walk** of all `.jsonl` files with a watermark-based approach that only checks files modified since the last scan — making the scanner O(new) instead of O(all)
- **Reads/writes a watermark timestamp** in the existing scan marker file; first scan (no watermark) falls back to the 24-hour lookback window
- **Switches to `os.scandir()`** instead of `Path.iterdir()` to avoid redundant stat syscalls (DirEntry caches mtime/size from the directory read)

Closes #560

## Test plan
- [x] 9 new tests in `tests/test_issue_560_scanner_watermark.py`:
  - `_read_scan_watermark` handles valid, empty, and corrupt data
  - First scan (no watermark) uses 24-hour fallback
  - Old files (before watermark) are skipped
  - New files (after watermark) are scanned and queued
  - Watermark is updated after each scan
  - Already-extracted sessions still skipped
  - Scan interval is still respected
- [x] All 9 new tests pass
- [x] Existing test suite passes (92/93 — 1 pre-existing model-server timeout)