### PR TITLE
Persist memory.add()

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -37,6 +37,41 @@ def test_get_by_id(mem):
     assert fetched["content"] == "Test memory"
 
 
+def test_metadata_round_trips_through_crud_and_search(mem):
+    metadata = {"session_id": "sess-123", "source": "unit-test", "nested": {"n": 1}}
+    added = mem.add("Alice prefers metadata-aware memories", user_id="alice", metadata=metadata)
+
+    assert added["metadata"] == metadata
+
+    fetched = mem.get(added["id"])
+    assert fetched is not None
+    assert fetched["metadata"] == metadata
+
+    all_mems = mem.get_all(user_id="alice")
+    assert all_mems[0]["metadata"] == metadata
+
+    results = mem.search("aware", user_id="alice")
+    assert results
+    assert results[0]["metadata"] == metadata
+
+
+def test_metadata_defaults_to_empty_dict(mem):
+    added = mem.add("No metadata here", user_id="alice")
+    assert added["metadata"] == {}
+    fetched = mem.get(added["id"])
+    assert fetched["metadata"] == {}
+
+
+def test_metadata_must_be_dict(mem):
+    with pytest.raises(TypeError, match="metadata must be a dict or None"):
+        mem.add("Bad metadata", metadata=["not", "a", "dict"])
+
+
+def test_metadata_must_be_json_serializable(mem):
+    with pytest.raises(TypeError, match="metadata must be JSON-serializable"):
+        mem.add("Bad metadata", metadata={"bad": object()})
+
+
 def test_delete(mem):
     added = mem.add("To be deleted", user_id="alice")
     mem.delete(added["id"])

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -13,6 +13,7 @@ from truememory.storage import (
     get_message,
     get_message_count,
     bulk_replace_messages,
+    update_message,
     DEFAULT_BUSY_TIMEOUT_MS,
 )
 
@@ -71,6 +72,34 @@ class TestCreateDb:
         assert "idx_messages_sender" in indexes
         assert "idx_messages_timestamp" in indexes
 
+    def test_legacy_messages_table_adds_metadata_column(self, tmp_path):
+        path = tmp_path / "legacy.db"
+        conn = sqlite3.connect(path)
+        conn.execute(
+            "CREATE TABLE messages ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "content TEXT NOT NULL, "
+            "sender TEXT DEFAULT '', "
+            "recipient TEXT DEFAULT '', "
+            "timestamp TEXT DEFAULT '', "
+            "category TEXT DEFAULT '', "
+            "modality TEXT DEFAULT '', "
+            "directive INTEGER DEFAULT 0"
+            ")"
+        )
+        conn.execute("INSERT INTO messages (content, sender) VALUES (?, ?)", ("legacy", "alice"))
+        conn.commit()
+        conn.close()
+
+        migrated = create_db(path)
+        try:
+            cols = {row[1] for row in migrated.execute("PRAGMA table_info(messages)").fetchall()}
+            assert "metadata" in cols
+            row = get_message(migrated, 1)
+            assert row["metadata"] == {}
+        finally:
+            migrated.close()
+
 
 class TestInsertMessage:
     def test_basic_insert_and_retrieve(self, db):
@@ -108,6 +137,30 @@ class TestInsertMessage:
         assert row["content"] == "Robert'); DROP TABLE messages;--"
         assert get_message_count(db) >= 1
 
+    def test_metadata_round_trip(self, db):
+        metadata = {"session_id": "sess-1", "source": "test"}
+        new_id = insert_message(db, {"content": "with metadata", "metadata": metadata})
+        db.commit()
+        row = get_message(db, new_id)
+        assert row["metadata"] == metadata
+
+    def test_metadata_must_be_dict(self, db):
+        with pytest.raises(TypeError, match="metadata must be a dict or None"):
+            insert_message(db, {"content": "bad metadata", "metadata": ["bad"]})
+
+    def test_metadata_must_be_json_serializable(self, db):
+        with pytest.raises(TypeError, match="metadata must be JSON-serializable"):
+            insert_message(db, {"content": "bad metadata", "metadata": {"bad": object()}})
+
+
+class TestUpdateMessage:
+    def test_update_metadata(self, db):
+        new_id = insert_message(db, {"content": "update metadata"})
+        db.commit()
+        assert update_message(db, new_id, metadata={"stage": "updated"}) is True
+        row = get_message(db, new_id)
+        assert row["metadata"] == {"stage": "updated"}
+
 
 class TestDeleteMessage:
     def test_delete_existing(self, db):
@@ -136,12 +189,17 @@ class TestBulkReplace:
         insert_message(db, {"content": "old message"})
         db.commit()
         messages = [
-            {"content": "new msg 1", "sender": "a"},
+            {"content": "new msg 1", "sender": "a", "metadata": {"batch": 1}},
             {"content": "new msg 2", "sender": "b"},
         ]
         count = bulk_replace_messages(db, messages)
         assert count == 2
         assert get_message_count(db) == 2
+        first_id = db.execute(
+            "SELECT id FROM messages WHERE content = ?", ("new msg 1",)
+        ).fetchone()[0]
+        first = get_message(db, first_id)
+        assert first["metadata"] == {"batch": 1}
 
     def test_fts_synced_after_replace(self, db):
         messages = [{"content": "bulk_unique_token_abc"}]

--- a/truememory/agentic_search.py
+++ b/truememory/agentic_search.py
@@ -263,6 +263,7 @@ def clean_results(
             "category": r.get("category", ""),
             "modality": r.get("modality", ""),
             "directive": r.get("directive", False),
+            "metadata": r.get("metadata", {}),
             "score": score,
             "source": r.get("source", "agentic"),
         })

--- a/truememory/client.py
+++ b/truememory/client.py
@@ -70,7 +70,7 @@ class Memory:
         Args:
             content:  The text to remember.
             user_id:  Owner of this memory (optional).
-            metadata: Reserved for future use.
+            metadata: Optional JSON-serializable metadata stored with the memory.
 
         Returns:
             Dict with ``id``, ``content``, ``user_id``, ``created_at``.
@@ -103,10 +103,12 @@ class Memory:
             content=content,
             sender=user_id or "",
             timestamp=now,
+            metadata=metadata,
             directive=directive,
         )
         result["user_id"] = user_id or ""
         result["created_at"] = now
+        result["metadata"] = metadata or {}
         # Issue #559: invalidate recall cache so the next hook invocation
         # picks up newly stored memories instead of serving stale results.
         try:

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -581,7 +581,7 @@ class TrueMemoryEngine:
             recipient: Who it was said to.
             timestamp: ISO-8601 timestamp string.
             category:  Optional grouping label.
-            metadata:  Reserved for future use.
+            metadata:  Optional JSON-serializable metadata stored with the memory.
 
         Returns:
             Dict with ``id`` and the stored fields.
@@ -622,6 +622,7 @@ class TrueMemoryEngine:
                 "category": category,
                 "modality": "",
                 "directive": directive,
+                "metadata": metadata,
             }
             new_id = insert_message(self.conn, msg)
 
@@ -673,6 +674,7 @@ class TrueMemoryEngine:
             "timestamp": timestamp,
             "category": category,
             "directive": directive,
+            "metadata": metadata or {},
         }
 
     def _maybe_auto_consolidate(self) -> None:
@@ -1952,6 +1954,7 @@ class TrueMemoryEngine:
                 "category": r.get("category", ""),
                 "modality": r.get("modality", ""),
                 "directive": r.get("directive", False),
+                "metadata": r.get("metadata", {}),
                 "score": score,
                 "source": r.get("source", source_label),
             })
@@ -2331,6 +2334,7 @@ class TrueMemoryEngine:
                 "category": r.get("category", ""),
                 "modality": r.get("modality", ""),
                 "directive": r.get("directive", False),
+                "metadata": r.get("metadata", {}),
                 "score": r.get("score", 0),
                 "source": "fts",
             })

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -1114,16 +1114,17 @@ class TrueMemoryEngine:
             List of memory dicts.
         """
         self._ensure_connection()
-        from truememory.storage import _SELECT_COLS, _row_to_dict
+        from truememory.storage import _row_to_dict, select_message_cols
+        select_cols = select_message_cols(self.conn)
 
         if user_id:
             rows = self.conn.execute(
-                f"SELECT {_SELECT_COLS} FROM messages WHERE sender = ? ORDER BY id DESC LIMIT ? OFFSET ?",
+                f"SELECT {select_cols} FROM messages WHERE sender = ? ORDER BY id DESC LIMIT ? OFFSET ?",
                 (user_id, limit, offset),
             ).fetchall()
         else:
             rows = self.conn.execute(
-                f"SELECT {_SELECT_COLS} FROM messages ORDER BY id DESC LIMIT ? OFFSET ?",
+                f"SELECT {select_cols} FROM messages ORDER BY id DESC LIMIT ? OFFSET ?",
                 (limit, offset),
             ).fetchall()
 

--- a/truememory/fts_search.py
+++ b/truememory/fts_search.py
@@ -17,7 +17,11 @@ Key design decisions:
 
 import sqlite3
 
-from truememory.storage import _deserialize_metadata
+from truememory.storage import (
+    _deserialize_metadata,
+    directive_filter_sql,
+    select_message_cols,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -89,14 +93,13 @@ def _rows_to_results(rows: list[tuple]) -> list[dict]:
     ]
 
 
-_FTS_SELECT = """
-    SELECT
-        m.id, m.content, m.sender, m.recipient, m.timestamp,
-        m.category, m.modality, m.directive, m.metadata,
-        messages_fts.rank AS bm25_score
-    FROM messages_fts
-    JOIN messages m ON m.id = messages_fts.rowid
-"""
+def _fts_select(conn: sqlite3.Connection) -> str:
+    return (
+        f"SELECT {select_message_cols(conn, alias='m')}, "
+        "messages_fts.rank AS bm25_score "
+        "FROM messages_fts "
+        "JOIN messages m ON m.id = messages_fts.rowid"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -131,8 +134,8 @@ def search_fts(
     if not query or not query.strip():
         return []
 
-    directive_filter = "" if include_directives else " AND (m.directive = 0 OR m.directive IS NULL)"
-    sql = f"{_FTS_SELECT} WHERE messages_fts MATCH ?{directive_filter} ORDER BY messages_fts.rank LIMIT ?"
+    directive_filter = directive_filter_sql(conn, alias="m", include_directives=include_directives)
+    sql = f"{_fts_select(conn)} WHERE messages_fts MATCH ?{directive_filter} ORDER BY messages_fts.rank LIMIT ?"
     safe = _build_safe_query(query)
     if not safe:
         return []
@@ -172,9 +175,9 @@ def search_fts_by_sender(
     if not query or not query.strip():
         return []
 
-    directive_filter = "" if include_directives else " AND (m.directive = 0 OR m.directive IS NULL)"
+    directive_filter = directive_filter_sql(conn, alias="m", include_directives=include_directives)
     sql = (
-        f"{_FTS_SELECT}"
+        f"{_fts_select(conn)}"
         f" WHERE messages_fts MATCH ? AND m.sender = ?{directive_filter}"
         " ORDER BY messages_fts.rank LIMIT ?"
     )
@@ -227,9 +230,9 @@ def search_fts_in_range(
     # enough results.
     candidate_limit = min(max(limit * 10, 100), 1000)
 
-    directive_filter = "" if include_directives else " AND (m.directive = 0 OR m.directive IS NULL)"
+    directive_filter = directive_filter_sql(conn, alias="m", include_directives=include_directives)
     sql = (
-        f"{_FTS_SELECT}"
+        f"{_fts_select(conn)}"
         f" WHERE messages_fts MATCH ?{directive_filter}"
         " ORDER BY messages_fts.rank LIMIT ?"
     )
@@ -269,12 +272,9 @@ def _fts_search(conn: sqlite3.Connection, fts_query: str,
                 limit: int = 20,
                 include_directives: bool = False) -> list[dict]:
     """Run an FTS5 search and return result dicts."""
-    directive_filter = "" if include_directives else " AND (m.directive = 0 OR m.directive IS NULL)"
+    directive_filter = directive_filter_sql(conn, alias="m", include_directives=include_directives)
     sql = (
-        "SELECT m.id, m.content, m.sender, m.recipient, m.timestamp, "
-        "       m.category, m.modality, messages_fts.rank AS score "
-        "FROM messages_fts "
-        "JOIN messages m ON m.id = messages_fts.rowid "
+        f"{_fts_select(conn)} "
         f"WHERE messages_fts MATCH ?{directive_filter} "
         "ORDER BY messages_fts.rank LIMIT ?"
     )
@@ -287,7 +287,8 @@ def _fts_search(conn: sqlite3.Connection, fts_query: str,
         {
             "id": r[0], "content": r[1], "sender": r[2],
             "recipient": r[3], "timestamp": r[4],
-            "category": r[5], "modality": r[6], "score": r[7],
+            "category": r[5], "modality": r[6], "directive": bool(r[7]),
+            "metadata": _deserialize_metadata(r[8]), "score": r[9],
         }
         for r in rows
     ]

--- a/truememory/fts_search.py
+++ b/truememory/fts_search.py
@@ -17,6 +17,8 @@ Key design decisions:
 
 import sqlite3
 
+from truememory.storage import _deserialize_metadata
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -79,7 +81,8 @@ def _rows_to_results(rows: list[tuple]) -> list[dict]:
             "category": row[5],
             "modality": row[6],
             "directive": bool(row[7]),
-            "raw_score": row[8],
+            "metadata": _deserialize_metadata(row[8]),
+            "raw_score": row[9],
             "score": 0.0,  # placeholder, filled by _normalize_scores
         }
         for row in rows
@@ -89,7 +92,7 @@ def _rows_to_results(rows: list[tuple]) -> list[dict]:
 _FTS_SELECT = """
     SELECT
         m.id, m.content, m.sender, m.recipient, m.timestamp,
-        m.category, m.modality, m.directive,
+        m.category, m.modality, m.directive, m.metadata,
         messages_fts.rank AS bm25_score
     FROM messages_fts
     JOIN messages m ON m.id = messages_fts.rowid

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -575,6 +575,56 @@ def _row_to_dict(row: tuple) -> dict:
 
 
 _SELECT_COLS = "id, content, sender, recipient, timestamp, category, modality, directive, metadata"
+_OPTIONAL_SELECT_DEFAULTS = {
+    "sender": "''",
+    "recipient": "''",
+    "timestamp": "''",
+    "category": "''",
+    "modality": "''",
+    "directive": "0",
+    "metadata": "'{}'",
+}
+
+
+def _message_columns(conn: sqlite3.Connection) -> set[str]:
+    """Return column names for messages, or an empty set on bad schemas."""
+    try:
+        return {row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()}
+    except sqlite3.OperationalError:
+        return set()
+
+
+def select_message_cols(conn: sqlite3.Connection, alias: str = "") -> str:
+    """Build the stable message SELECT list, defaulting missing optional columns.
+
+    Some tests and old user databases create a minimal ``messages`` table by
+    hand. Query code should still return the same dict shape rather than
+    failing on newly-added optional columns such as ``metadata``.
+    """
+    existing = _message_columns(conn)
+    prefix = f"{alias}." if alias else ""
+    cols = []
+    for name in (
+        "id", "content", "sender", "recipient", "timestamp",
+        "category", "modality", "directive", "metadata",
+    ):
+        if name in existing or name not in _OPTIONAL_SELECT_DEFAULTS:
+            cols.append(f"{prefix}{name}")
+        else:
+            cols.append(f"{_OPTIONAL_SELECT_DEFAULTS[name]} AS {name}")
+    return ", ".join(cols)
+
+
+def directive_filter_sql(
+    conn: sqlite3.Connection,
+    alias: str = "",
+    include_directives: bool = False,
+) -> str:
+    """Return a WHERE fragment that excludes directives when possible."""
+    if include_directives or "directive" not in _message_columns(conn):
+        return ""
+    prefix = f"{alias}." if alias else ""
+    return f" AND ({prefix}directive = 0 OR {prefix}directive IS NULL)"
 
 
 def get_message(conn: sqlite3.Connection, msg_id: int) -> dict | None:
@@ -589,7 +639,7 @@ def get_message(conn: sqlite3.Connection, msg_id: int) -> dict | None:
         Message dict, or ``None`` if not found.
     """
     row = conn.execute(
-        f"SELECT {_SELECT_COLS} FROM messages WHERE id = ?", (msg_id,)
+        f"SELECT {select_message_cols(conn)} FROM messages WHERE id = ?", (msg_id,)
     ).fetchone()
     return _row_to_dict(row) if row else None
 
@@ -606,7 +656,7 @@ def get_messages_by_sender(conn: sqlite3.Connection, sender: str) -> list[dict]:
         List of message dicts.
     """
     rows = conn.execute(
-        f"SELECT {_SELECT_COLS} FROM messages WHERE sender = ? ORDER BY timestamp",
+        f"SELECT {select_message_cols(conn)} FROM messages WHERE sender = ? ORDER BY timestamp",
         (sender,),
     ).fetchall()
     return [_row_to_dict(r) for r in rows]
@@ -643,7 +693,7 @@ def get_messages_in_range(
 
     where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
     rows = conn.execute(
-        f"SELECT {_SELECT_COLS} FROM messages{where} ORDER BY timestamp",
+        f"SELECT {select_message_cols(conn)} FROM messages{where} ORDER BY timestamp",
         params,
     ).fetchall()
     return [_row_to_dict(r) for r in rows]

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -39,7 +39,8 @@ CREATE TABLE IF NOT EXISTS messages (
     episode_id INTEGER DEFAULT NULL,
     emotional_valence REAL DEFAULT 0.0,
     embedding_separation BLOB DEFAULT NULL,
-    directive INTEGER DEFAULT 0
+    directive INTEGER DEFAULT 0,
+    metadata TEXT DEFAULT '{}'
 );
 
 -- FTS5 virtual table for full-text search
@@ -262,6 +263,7 @@ _EXPECTED_COLUMNS = {
     "emotional_valence": "REAL DEFAULT 0.0",
     "embedding_separation": "BLOB DEFAULT NULL",
     "directive": "INTEGER DEFAULT 0",
+    "metadata": "TEXT DEFAULT '{}'",
 }
 
 
@@ -427,7 +429,7 @@ def bulk_replace_messages(conn: sqlite3.Connection, messages: list[dict]) -> int
 
     Each dict in *messages* should have at minimum a ``content`` key.
     Optional keys: ``sender``, ``recipient``, ``timestamp``, ``category``,
-    ``modality``.
+    ``modality``, ``metadata``.
 
     Args:
         conn:     Open database connection (from :func:`create_db`).
@@ -454,8 +456,8 @@ def bulk_replace_messages(conn: sqlite3.Connection, messages: list[dict]) -> int
 
     conn.executemany(
         """INSERT INTO messages
-           (content, sender, recipient, timestamp, category, modality, directive)
-           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+           (content, sender, recipient, timestamp, category, modality, directive, metadata)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
         [
             (
                 msg["content"],
@@ -465,6 +467,7 @@ def bulk_replace_messages(conn: sqlite3.Connection, messages: list[dict]) -> int
                 msg.get("category", ""),
                 msg.get("modality", ""),
                 1 if msg.get("directive") else 0,
+                _serialize_metadata(msg.get("metadata")),
             )
             for msg in messages
         ],
@@ -524,6 +527,33 @@ def load_messages_from_file(conn: sqlite3.Connection, json_path: str | Path) -> 
 # Message retrieval (CRUD reads)
 # ---------------------------------------------------------------------------
 
+def _serialize_metadata(metadata: dict | None) -> str:
+    """Serialize user metadata for the messages.metadata JSON column."""
+    if metadata is None:
+        metadata = {}
+    if not isinstance(metadata, dict):
+        raise TypeError(f"metadata must be a dict or None, got {type(metadata).__name__}")
+    try:
+        return json.dumps(metadata, sort_keys=True, separators=(",", ":"))
+    except TypeError as exc:
+        raise TypeError("metadata must be JSON-serializable") from exc
+
+
+def _deserialize_metadata(raw: object) -> dict:
+    """Parse messages.metadata, degrading corrupt legacy values to {}."""
+    if raw in (None, ""):
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str):
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def _row_to_dict(row: tuple) -> dict:
     """Convert a raw row tuple to a message dict."""
     d = {
@@ -537,10 +567,14 @@ def _row_to_dict(row: tuple) -> dict:
     }
     if len(row) > 7:
         d["directive"] = bool(row[7])
+    if len(row) > 8:
+        d["metadata"] = _deserialize_metadata(row[8])
+    else:
+        d["metadata"] = {}
     return d
 
 
-_SELECT_COLS = "id, content, sender, recipient, timestamp, category, modality, directive"
+_SELECT_COLS = "id, content, sender, recipient, timestamp, category, modality, directive, metadata"
 
 
 def get_message(conn: sqlite3.Connection, msg_id: int) -> dict | None:
@@ -652,7 +686,7 @@ def insert_message(conn: sqlite3.Connection, msg: dict) -> int:
         conn: Open database connection (from :func:`create_db`).
         msg:  Message dict.  Must have ``content``; optional keys:
               ``sender``, ``recipient``, ``timestamp``, ``category``,
-              ``modality``.
+              ``modality``, ``metadata``.
 
     Returns:
         The new row's integer ID.
@@ -662,8 +696,8 @@ def insert_message(conn: sqlite3.Connection, msg: dict) -> int:
         raise ValueError("content cannot be empty or whitespace-only")
     cursor = conn.execute(
         """INSERT INTO messages
-           (content, sender, recipient, timestamp, category, modality, directive)
-           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+           (content, sender, recipient, timestamp, category, modality, directive, metadata)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             msg["content"],
             msg.get("sender", ""),
@@ -672,6 +706,7 @@ def insert_message(conn: sqlite3.Connection, msg: dict) -> int:
             msg.get("category", ""),
             msg.get("modality", ""),
             1 if msg.get("directive") else 0,
+            _serialize_metadata(msg.get("metadata")),
         ),
     )
     return cursor.lastrowid
@@ -743,7 +778,7 @@ def update_message(conn: sqlite3.Connection, msg_id: int, **fields) -> bool:
 
     Only the provided keyword arguments are changed.  Valid field names:
     ``content``, ``sender``, ``recipient``, ``timestamp``, ``category``,
-    ``modality``.
+    ``modality``, ``metadata``.
 
     The AFTER UPDATE trigger on ``messages`` automatically keeps the
     FTS5 index in sync.
@@ -756,10 +791,12 @@ def update_message(conn: sqlite3.Connection, msg_id: int, **fields) -> bool:
     Returns:
         True if the row was updated, False if ID not found.
     """
-    allowed = {"content", "sender", "recipient", "timestamp", "category", "modality", "directive"}
+    allowed = {"content", "sender", "recipient", "timestamp", "category", "modality", "directive", "metadata"}
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return False
+    if "metadata" in updates:
+        updates["metadata"] = _serialize_metadata(updates["metadata"])
 
     set_clause = ", ".join(f"{k} = ?" for k in updates)
     values = list(updates.values()) + [msg_id]

--- a/truememory/temporal.py
+++ b/truememory/temporal.py
@@ -27,7 +27,7 @@ import re
 import sqlite3
 from datetime import datetime, timedelta
 
-from truememory.storage import _row_to_dict, _SELECT_COLS
+from truememory.storage import _row_to_dict, select_message_cols
 
 
 # ---------------------------------------------------------------------------
@@ -641,7 +641,7 @@ def get_timeline(
         params.extend([entity_lower, entity_lower])
 
     where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
-    sql = f"SELECT {_SELECT_COLS} FROM messages{where} ORDER BY timestamp"
+    sql = f"SELECT {select_message_cols(conn)} FROM messages{where} ORDER BY timestamp"
 
     rows = conn.execute(sql, params).fetchall()
     return [_row_to_dict(r) for r in rows]

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -49,7 +49,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from truememory.storage import _deserialize_metadata
+from truememory.storage import _deserialize_metadata, select_message_cols
 
 if TYPE_CHECKING:
     pass
@@ -711,8 +711,7 @@ def search_vector(
     rows = conn.execute(
         f"""
         SELECT v.rowid, v.distance,
-               m.content, m.sender, m.recipient,
-               m.timestamp, m.category, m.modality, m.directive, m.metadata
+               {select_message_cols(conn, alias='m')}
         FROM (
             SELECT rowid, distance
             FROM {tbl}
@@ -727,7 +726,7 @@ def search_vector(
     results: list[dict] = []
     for row in rows:
         # Exclude directives by default
-        if not include_directives and row[8]:
+        if not include_directives and row[9]:
             continue
 
         distance = row[1]
@@ -736,14 +735,14 @@ def search_vector(
         results.append(
             {
                 "id": row[0],
-                "content": row[2],
-                "sender": row[3],
-                "recipient": row[4],
-                "timestamp": row[5],
-                "category": row[6],
-                "modality": row[7],
-                "directive": bool(row[8]),
-                "metadata": _deserialize_metadata(row[9]),
+                "content": row[3],
+                "sender": row[4],
+                "recipient": row[5],
+                "timestamp": row[6],
+                "category": row[7],
+                "modality": row[8],
+                "directive": bool(row[9]),
+                "metadata": _deserialize_metadata(row[10]),
                 "score": round(score, 6),
             }
         )
@@ -774,8 +773,7 @@ def search_vector_raw(
     rows = conn.execute(
         f"""
         SELECT v.rowid, v.distance,
-               m.content, m.sender, m.recipient,
-               m.timestamp, m.category, m.modality, m.directive, m.metadata
+               {select_message_cols(conn, alias='m')}
         FROM (
             SELECT rowid, distance
             FROM {tbl}
@@ -789,7 +787,7 @@ def search_vector_raw(
 
     results: list[dict] = []
     for row in rows:
-        if not include_directives and row[8]:
+        if not include_directives and row[9]:
             continue
 
         distance = row[1]
@@ -798,14 +796,14 @@ def search_vector_raw(
         results.append(
             {
                 "id": row[0],
-                "content": row[2],
-                "sender": row[3],
-                "recipient": row[4],
-                "timestamp": row[5],
-                "category": row[6],
-                "modality": row[7],
-                "directive": bool(row[8]),
-                "metadata": _deserialize_metadata(row[9]),
+                "content": row[3],
+                "sender": row[4],
+                "recipient": row[5],
+                "timestamp": row[6],
+                "category": row[7],
+                "modality": row[8],
+                "directive": bool(row[9]),
+                "metadata": _deserialize_metadata(row[10]),
                 "score": round(cos_sim, 6),
             }
         )
@@ -999,8 +997,7 @@ def search_vector_separation(
     rows = conn.execute(
         f"""
         SELECT v.rowid, v.distance,
-               m.content, m.sender, m.recipient,
-               m.timestamp, m.category, m.modality, m.directive, m.metadata
+               {select_message_cols(conn, alias='m')}
         FROM (
             SELECT rowid, distance
             FROM {sep_tbl}
@@ -1014,21 +1011,21 @@ def search_vector_separation(
 
     results: list[dict] = []
     for row in rows:
-        if not include_directives and row[8]:
+        if not include_directives and row[9]:
             continue
 
         distance = row[1]
         score = 1.0 / (1.0 + distance)
         results.append({
             "id": row[0],
-            "content": row[2],
-            "sender": row[3],
-            "recipient": row[4],
-            "timestamp": row[5],
-            "category": row[6],
-            "modality": row[7],
-            "directive": bool(row[8]),
-            "metadata": _deserialize_metadata(row[9]),
+            "content": row[3],
+            "sender": row[4],
+            "recipient": row[5],
+            "timestamp": row[6],
+            "category": row[7],
+            "modality": row[8],
+            "directive": bool(row[9]),
+            "metadata": _deserialize_metadata(row[10]),
             "score": round(score, 6),
         })
 

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -49,6 +49,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from truememory.storage import _deserialize_metadata
+
 if TYPE_CHECKING:
     pass
 
@@ -710,7 +712,7 @@ def search_vector(
         f"""
         SELECT v.rowid, v.distance,
                m.content, m.sender, m.recipient,
-               m.timestamp, m.category, m.modality, m.directive
+               m.timestamp, m.category, m.modality, m.directive, m.metadata
         FROM (
             SELECT rowid, distance
             FROM {tbl}
@@ -741,6 +743,7 @@ def search_vector(
                 "category": row[6],
                 "modality": row[7],
                 "directive": bool(row[8]),
+                "metadata": _deserialize_metadata(row[9]),
                 "score": round(score, 6),
             }
         )
@@ -772,7 +775,7 @@ def search_vector_raw(
         f"""
         SELECT v.rowid, v.distance,
                m.content, m.sender, m.recipient,
-               m.timestamp, m.category, m.modality, m.directive
+               m.timestamp, m.category, m.modality, m.directive, m.metadata
         FROM (
             SELECT rowid, distance
             FROM {tbl}
@@ -802,6 +805,7 @@ def search_vector_raw(
                 "category": row[6],
                 "modality": row[7],
                 "directive": bool(row[8]),
+                "metadata": _deserialize_metadata(row[9]),
                 "score": round(cos_sim, 6),
             }
         )
@@ -996,7 +1000,7 @@ def search_vector_separation(
         f"""
         SELECT v.rowid, v.distance,
                m.content, m.sender, m.recipient,
-               m.timestamp, m.category, m.modality, m.directive
+               m.timestamp, m.category, m.modality, m.directive, m.metadata
         FROM (
             SELECT rowid, distance
             FROM {sep_tbl}
@@ -1024,6 +1028,7 @@ def search_vector_separation(
             "category": row[6],
             "modality": row[7],
             "directive": bool(row[8]),
+            "metadata": _deserialize_metadata(row[9]),
             "score": round(score, 6),
         })
 


### PR DESCRIPTION
## Summary

- Add a JSON-backed messages.metadata column with an additive legacy database migration.
- Persist Memory.add(..., metadata=...) instead of dropping the existing API argument.
- Return metadata from CRUD, FTS, vector, separation-vector, and agentic search result paths.
- Validate metadata as a JSON-serializable dictionary.
- Add focused tests covering:
  - Metadata round-trip persistence
  - Default values
  - Validation behavior
  - Metadata updates
  - Bulk replacement
  - Legacy database migration compatibility

## Why

Memory.add() already accepted a metadata argument, and the MCP truememory_store tool already exposed metadata as a JSON string. However, the value was never persisted and was effectively discarded.

As a result, callers often had to encode session, source, or application context directly into memory content to preserve it.

This PR implements persistence and retrieval of metadata while keeping the existing public API unchanged.

## Testing

### Unit Tests

bash uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/test_memory.py tests/test_storage.py -q 

Result: 38 tests passed

### Linting

bash uv --cache-dir /tmp/uv-cache run --extra dev ruff check \     truememory/storage.py \     truememory/client.py \     truememory/engine.py \     truememory/fts_search.py \     truememory/vector_search.py \     truememory/agentic_search.py \     tests/test_memory.py \     tests/test_storage.py 

Result: Passed

### Compilation Check

bash python3 -m py_compile \     truememory/storage.py \     truememory/client.py \     truememory/engine.py \     truememory/fts_search.py \     truememory/vector_search.py \     truememory/agentic_search.py \     tests/test_memory.py \     tests/test_storage.py 

Result: Passed