### PR TITLE
fix: per-exchange store DOA — should_encode, depth self-match, request deadline (#634)

### DIFF
--- a/tests/test_issue_634_per_exchange_store.py
+++ b/tests/test_issue_634_per_exchange_store.py
@@ -1,0 +1,240 @@
+"""Tests for issue #634 — per-exchange store DOA.
+
+Three regressions in ``truememory/ingest/hooks/user_prompt_submit.py``:
+
+- M-04 (P0): the store path read ``decision.passed`` but ``EncodingDecision``
+  only has ``should_encode``. The AttributeError was swallowed by a blanket
+  ``except``, so enhanced/max stored ZERO rows. We assert a real row lands.
+- M-17 (P1): ``_check_conversation_depth`` read the last buffer entries
+  INCLUDING the just-buffered current prompt, so "enhanced" always matched
+  itself and behaved identically to "max". We assert enhanced does NOT fire
+  on a shallow/first-prompt exchange that max would store.
+- M-18 (P1): the store path now arms the recall deadline before its model
+  searches and closes the Memory instance. We assert the deadline is set.
+
+All tests mock the model/embedding layer (no real model loads).
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+
+
+# ---------------------------------------------------------------------------
+# Fakes — fully model-free
+# ---------------------------------------------------------------------------
+
+class _FakeDecision:
+    """Mimics EncodingDecision: has should_encode, NOT passed."""
+
+    def __init__(self, should_encode: bool):
+        self.should_encode = should_encode
+
+
+class _FakeGate:
+    def __init__(self, *args, **kwargs):
+        # default: encode everything
+        pass
+
+    def evaluate(self, fact, category=""):
+        return _FakeDecision(True)
+
+
+class _FakeMemory:
+    """Records add() calls; search() returns no dupes by default."""
+
+    instances: list["_FakeMemory"] = []
+
+    def __init__(self, path=None, **kwargs):
+        self.added: list[str] = []
+        self.closed = False
+        self.search_results: list[dict] = []
+        _FakeMemory.instances.append(self)
+
+    def search(self, query, user_id=None, limit=10, **kwargs):
+        return list(self.search_results)
+
+    def add(self, content, user_id=None, **kwargs):
+        self.added.append(content)
+        return {"id": len(self.added), "content": content, "user_id": user_id or ""}
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_instances():
+    _FakeMemory.instances.clear()
+    yield
+    _FakeMemory.instances.clear()
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Patch the model-touching deps in the hook with fakes + record deadline."""
+    import truememory.client as client
+    import truememory.ingest.encoding_gate as eg
+
+    monkeypatch.setattr(client, "Memory", _FakeMemory)
+    monkeypatch.setattr(eg, "EncodingGate", _FakeGate)
+
+    deadline_calls: list = []
+    import truememory.model_client as mc
+    monkeypatch.setattr(mc, "set_request_timeout", lambda v: deadline_calls.append(v))
+
+    return {"deadline_calls": deadline_calls, "FakeMemory": _FakeMemory}
+
+
+# ---------------------------------------------------------------------------
+# M-04: a real row lands at store_intensity="max"
+# ---------------------------------------------------------------------------
+
+class TestStoreActuallyLands:
+    def test_max_stores_a_row(self, patched):
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        ups._try_per_exchange_store(
+            "I prefer dark mode for all my editors and always use TypeScript",
+            "sess-max", "", "", "max",
+        )
+        adds = [c for m in patched["FakeMemory"].instances for c in m.added]
+        assert len(adds) == 1, f"expected exactly one stored row, got {adds}"
+
+    def test_max_respects_should_encode_false(self, patched, monkeypatch):
+        """When the gate says should_encode=False, nothing is stored."""
+        import truememory.ingest.encoding_gate as eg
+
+        class _NoGate:
+            def __init__(self, *a, **k):
+                pass
+
+            def evaluate(self, fact, category=""):
+                return _FakeDecision(False)
+
+        monkeypatch.setattr(eg, "EncodingGate", _NoGate)
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        ups._try_per_exchange_store(
+            "I prefer dark mode for all my editors", "sess-noenc", "", "", "max",
+        )
+        adds = [c for m in patched["FakeMemory"].instances for c in m.added]
+        assert adds == [], "should not store when gate rejects"
+
+    def test_dupe_above_threshold_not_stored(self, patched):
+        """A near-duplicate (score > 0.85) is skipped."""
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        # Pre-load the next FakeMemory with a high-scoring dupe by patching
+        # the class to seed search_results.
+        orig_init = _FakeMemory.__init__
+
+        def seeded_init(self, path=None, **kwargs):
+            orig_init(self, path=path, **kwargs)
+            self.search_results = [{"content": "x", "score": 0.95}]
+
+        _FakeMemory.__init__ = seeded_init
+        try:
+            ups._try_per_exchange_store(
+                "I prefer dark mode for all my editors", "sess-dupe", "", "", "max",
+            )
+        finally:
+            _FakeMemory.__init__ = orig_init
+        adds = [c for m in patched["FakeMemory"].instances for c in m.added]
+        assert adds == [], "near-duplicate should not be stored"
+
+
+# ---------------------------------------------------------------------------
+# M-18: deadline armed + memory closed
+# ---------------------------------------------------------------------------
+
+class TestRequestDeadlineAndClose:
+    def test_deadline_armed_before_store(self, patched):
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        ups._try_per_exchange_store(
+            "I always use TypeScript over JavaScript for new projects",
+            "sess-dl", "", "", "max",
+        )
+        assert patched["deadline_calls"], "store path must arm the recall deadline"
+
+    def test_memory_closed_after_store(self, patched):
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        ups._try_per_exchange_store(
+            "I always use TypeScript over JavaScript for new projects",
+            "sess-close", "", "", "max",
+        )
+        assert patched["FakeMemory"].instances, "a Memory was created"
+        assert all(m.closed for m in patched["FakeMemory"].instances), (
+            "Memory instance must be closed (no leak)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# M-17: enhanced depth gate differs from max (no self-match)
+# ---------------------------------------------------------------------------
+
+class TestEnhancedDistinctFromMax:
+    def _write_buffer(self, tmp_path, session_id, contents):
+        buf_dir = tmp_path / "buffers"
+        buf_dir.mkdir(parents=True, exist_ok=True)
+        safe_id = "".join(c for c in session_id if c.isalnum() or c in "-_")[:64]
+        f = buf_dir / f"{safe_id}.jsonl"
+        with f.open("w", encoding="utf-8") as fh:
+            for c in contents:
+                fh.write(json.dumps({"role": "user", "content": c}) + "\n")
+        return buf_dir
+
+    def test_first_prompt_does_not_self_match(self, tmp_path, monkeypatch):
+        """A first-prompt exchange (only the current prompt in the buffer)
+        must NOT pass the depth gate — previously it matched itself."""
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        prompt = "I prefer dark mode for all my editors and tools"
+        buf_dir = self._write_buffer(tmp_path, "sess-first", [prompt])
+        monkeypatch.setattr(ups, "_PROMPT_COUNTER_DIR", buf_dir)
+        monkeypatch.setenv("TRUEMEMORY_BUFFER_DIR", str(buf_dir))
+        assert ups._check_conversation_depth("sess-first", prompt) is False
+
+    def test_enhanced_skips_shallow_max_would_store(self, patched, tmp_path, monkeypatch):
+        """On a shallow/first-prompt exchange, enhanced stores nothing while
+        max stores a row — proving the two tiers genuinely differ."""
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        prompt = "I prefer dark mode for all my editors and tools"
+
+        # Buffer contains ONLY the current prompt (first-prompt scenario).
+        buf_dir = self._write_buffer(tmp_path, "sess-shallow", [prompt])
+        monkeypatch.setattr(ups, "_PROMPT_COUNTER_DIR", buf_dir)
+        monkeypatch.setenv("TRUEMEMORY_BUFFER_DIR", str(buf_dir))
+
+        ups._try_per_exchange_store(prompt, "sess-shallow", "", "", "enhanced")
+        enhanced_adds = [c for m in patched["FakeMemory"].instances for c in m.added]
+        assert enhanced_adds == [], "enhanced must NOT fire on shallow first prompt"
+
+        patched["FakeMemory"].instances.clear()
+        ups._try_per_exchange_store(prompt, "sess-shallow", "", "", "max")
+        max_adds = [c for m in patched["FakeMemory"].instances for c in m.added]
+        assert len(max_adds) == 1, "max SHOULD store the same shallow prompt"
+
+    def test_enhanced_fires_on_deep_topic(self, patched, tmp_path, monkeypatch):
+        """With prior on-topic history (>=3 shared words), enhanced fires."""
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        prior = [
+            "lets talk about database indexing strategy performance",
+            "the database indexing performance strategy matters here",
+            "I prefer database indexing performance strategy tuning",
+        ]
+        prompt = "I prefer database indexing performance strategy as default"
+        buf_dir = self._write_buffer(tmp_path, "sess-deep", prior + [prompt])
+        monkeypatch.setattr(ups, "_PROMPT_COUNTER_DIR", buf_dir)
+        monkeypatch.setenv("TRUEMEMORY_BUFFER_DIR", str(buf_dir))
+
+        assert ups._check_conversation_depth("sess-deep", prompt) is True
+        ups._try_per_exchange_store(prompt, "sess-deep", "", "", "enhanced")
+        adds = [c for m in patched["FakeMemory"].instances for c in m.added]
+        assert len(adds) == 1, "enhanced should fire when topic depth is real"

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -204,6 +204,13 @@ def _check_conversation_depth(session_id: str, prompt: str, window: int = 5) -> 
     Reads the last `window` buffer entries and checks if the current prompt
     shares significant keywords with them, suggesting a sustained topic
     worth capturing.
+
+    The current prompt has already been appended to the buffer by ``main()``
+    before this runs, so the final buffer entry IS the current prompt. We
+    exclude it (``lines[:-1]``) — otherwise the prompt always overlaps with
+    itself and "enhanced" becomes indistinguishable from "max" (issue #634,
+    M-17). This means a shallow/first-prompt exchange (no prior on-topic
+    history) correctly does NOT fire under "enhanced".
     """
     safe_id = "".join(c for c in session_id if c.isalnum() or c in "-_")[:64] or "unknown"
     buffer_file = _PROMPT_COUNTER_DIR.parent / "buffers" / f"{safe_id}.jsonl"
@@ -218,7 +225,9 @@ def _check_conversation_depth(session_id: str, prompt: str, window: int = 5) -> 
     try:
         recent_words: set[str] = set()
         lines = buffer_file.read_text(encoding="utf-8").strip().splitlines()
-        for line in lines[-window:]:
+        # Exclude the final entry: it is the current prompt (issue #634, M-17).
+        prior_lines = lines[:-1]
+        for line in prior_lines[-window:]:
             try:
                 entry = json.loads(line)
                 content = entry.get("content", "")
@@ -247,33 +256,48 @@ def _try_per_exchange_store(prompt: str, session_id: str, user_id: str, db_path:
     if not _detect_storable_content(prompt):
         return
 
-    # Enhanced: require conversation depth; Max: skip depth check
+    # Enhanced: require conversation depth; Max: skip depth check.
+    # The depth check excludes the current prompt (already buffered by main())
+    # so "enhanced" does not trivially match itself (issue #634, M-17).
     if store_intensity == "enhanced" and not _check_conversation_depth(session_id, prompt):
         return
 
-    # Novelty check: quick search to avoid dupes
+    # Issue #634 (M-18): arm the same model-server deadline the recall paths
+    # use so a slow/contended model server can't hang prompt submission on the
+    # two searches + add below. Without this the store path runs synchronously
+    # with no deadline before any recall path gets to set one.
+    try:
+        from truememory.ingest.hooks._shared import get_recall_deadline
+        from truememory.model_client import set_request_timeout
+        set_request_timeout(get_recall_deadline())
+    except Exception:
+        pass
+
+    # Issue #634 (M-04): the encoding gate returns EncodingDecision with a
+    # `should_encode` attribute (not `passed`). The previous code read
+    # `decision.passed`, which raised AttributeError swallowed by the blanket
+    # except below, so the store path stored ZERO rows. The Memory instance
+    # was also never closed (leak). Both are fixed here.
     try:
         from truememory.client import Memory
-        m = Memory(path=db_path or None)
-        existing = m.search(prompt, user_id=user_id or None, limit=3)
-        if existing:
-            for r in existing:
-                score = r.get("score", 0.0)
-                if score > 0.85:
-                    return  # Too similar to existing memory
-    except Exception:
-        return  # If search fails, skip storing
+        with Memory(path=db_path or None) as m:
+            # Novelty check: quick search to avoid dupes
+            existing = m.search(prompt, user_id=user_id or None, limit=3)
+            if existing:
+                for r in existing:
+                    score = r.get("score", 0.0)
+                    if score > 0.85:
+                        return  # Too similar to existing memory
 
-    # Run through encoding gate
-    try:
-        from truememory.ingest.encoding_gate import EncodingGate
-        gate = EncodingGate(memory=m, user_id=user_id or "")
-        decision = gate.evaluate(prompt)
-        if not decision.passed:
-            return
+            # Run through encoding gate
+            from truememory.ingest.encoding_gate import EncodingGate
+            gate = EncodingGate(memory=m, user_id=user_id or "")
+            decision = gate.evaluate(prompt)
+            if not decision.should_encode:
+                return
 
-        # Store the content
-        m.add(content=prompt, user_id=user_id or None)
+            # Store the content
+            m.add(content=prompt, user_id=user_id or None)
     except Exception:
         pass  # Never crash the hook
 


### PR DESCRIPTION
Fixes #634.

The #628 per-exchange store path was non-functional and slow. Three fixes, all in `truememory/ingest/hooks/user_prompt_submit.py`:

**M-04 (P0) — stored 0 rows.** `_try_per_exchange_store` read `decision.passed`, but `EncodingDecision` only exposes `should_encode`. The AttributeError was swallowed by the blanket `except`, so enhanced/max stored zero rows while still paying full Memory-init + search + gate cost. Now reads `decision.should_encode`.

**M-17 (P1) — enhanced ≡ max.** `main()` buffers the current prompt before `_try_per_exchange_store`, so `_check_conversation_depth` was reading the just-buffered current prompt and always matching itself (overlap with self ≥ 3 words). The depth check now excludes the final buffer entry (`lines[:-1]`), so a shallow/first-prompt exchange no longer self-matches — enhanced is genuinely distinct from max.

**M-18 (P1) — could hang prompt submission.** The store path ran two model-touching searches + `m.add` synchronously with no model-server deadline, before any recall path armed one. It now calls `set_request_timeout(get_recall_deadline())` at the top of the store path (same helper the recall paths use), and wraps `Memory` in a `with` block so the instance is always closed (it previously leaked).

**Tests** (new `tests/test_issue_634_per_exchange_store.py`, model/embedding fully mocked, `HF_HUB_OFFLINE=1`):
- max stores exactly one row when the gate returns should_encode=True; stores nothing when False; skips near-duplicates (score > 0.85).
- store path arms the recall deadline and closes the Memory instance.
- enhanced does NOT fire on a shallow/first-prompt exchange that max WOULD store; first prompt no longer self-matches; enhanced still fires when real topic depth exists.

`ruff check truememory/ tests/` passes. `tests/test_issue_396_memory_intensity.py` + the new file: 39 passed.