### PR TITLE
fix: engine.search supplement-merge crashes — mixed-id sort, id-less KeyError, id=0 RRF collision (#630)

### DIFF
--- a/tests/test_issue_630_search_supplement_merge.py
+++ b/tests/test_issue_630_search_supplement_merge.py
@@ -1,0 +1,174 @@
+"""Regression tests for issue #630 — id-hygiene bugs in engine.search's
+supplement-merge step.
+
+Three confirmed bugs in the path that merges personality / contradiction /
+consolidated-summary supplements into the FTS+vector result list:
+
+* **M-01** — the final ``cleaned.sort`` tie-broke on ``d["id"]``. Consolidation
+  emits ``"summary_N"`` *string* ids (#606) while messages have *int* ids, so any
+  score tie (guaranteed: FTS normalization pins the top hit at exactly 1.0)
+  raised ``TypeError: '<' not supported between 'str' and 'int'``. Same bug in
+  ``agentic_search.clean_results``. Fix: tie-break on ``str(d.get("id", ""))``.
+
+* **M-05** — ``personality.search_personality`` emits rows with *no* ``"id"``
+  key. ``engine.search`` built ``existing_ids`` with bracket access
+  (``{r["id"] for r in results}``); the KeyError was swallowed by a blanket
+  ``except`` so on EVERY personality-intent query ALL contradiction supplements
+  and consolidated summaries were silently discarded. Fix: ``r.get("id")``.
+
+* **M-67** — id-less rows were rewritten to ``id=0`` during cleaning, so #606's
+  id-keyed RRF collapsed multiple distinct id-less rows into one fabricated
+  ``id=0`` document. Fix: preserve ``None`` ids through cleaning.
+
+These tests drive the real ``TrueMemoryEngine.search`` with an in-memory /
+FTS-only engine and stub the supplement functions on the ``truememory.engine``
+module namespace. No model loads.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+
+@pytest.fixture
+def fts_engine(tmp_path, monkeypatch):
+    """Small FTS-only engine: a handful of seeded messages, no vectors, no
+    reranker, salience/surprise boosts disabled so we exercise the bare
+    supplement-merge + clean + sort path."""
+    monkeypatch.delenv("TRUEMEMORY_ALPHA_SURPRISE", raising=False)
+
+    from truememory.engine import TrueMemoryEngine
+    from truememory.storage import create_db
+
+    db_path = tmp_path / "i630.db"
+    conn = create_db(db_path)
+    for i in range(1, 5):
+        conn.execute(
+            "INSERT INTO messages (content, sender, recipient, timestamp, "
+            "category, modality) VALUES (?, 'alice', 'bob', ?, 'session_1', "
+            "'conversation')",
+            (f"alice favorite food number {i}", f"2026-0{i}-01T10:00:00Z"),
+        )
+    conn.commit()
+    conn.close()
+
+    eng = TrueMemoryEngine(db_path)
+    eng.open(rebuild_vectors=False)
+    # Force the bare path: no cross-encoder rerank, no salience filtering.
+    eng._has_reranker = False
+    eng._has_salience = False
+    return eng
+
+
+# Query that _has_personality_intent() recognizes (matches "favorite food").
+_PERSONALITY_QUERY = "what is alice favorite food"
+
+
+def test_summary_string_id_tie_does_not_raise_typeerror(fts_engine, monkeypatch):
+    """M-01: a consolidated summary with a string id ("summary_7") tying at
+    score 1.0 with int-id message rows must NOT raise TypeError, and results
+    must come back sorted."""
+    eng = fts_engine
+    eng._has_consolidation = True
+
+    monkeypatch.setattr("truememory.engine.search_contradictions", lambda *a, **k: [])
+
+    def fake_consolidated(conn, query, limit=3):
+        # String id + score exactly 1.0 to force a tie with the FTS top hit.
+        return [{
+            "id": "summary_7",
+            "content": "alice tends to prefer spicy food",
+            "score": 1.0,
+            "source": "summary",
+        }]
+
+    monkeypatch.setattr("truememory.engine.search_consolidated", fake_consolidated)
+
+    # Must not raise TypeError on the mixed-type tie-break.
+    results = eng.search(_PERSONALITY_QUERY, limit=10)
+    assert isinstance(results, list)
+    # Sorted descending by score.
+    scores = [r["score"] for r in results]
+    assert scores == sorted(scores, reverse=True)
+    # The string-id summary survived the merge.
+    assert any(r.get("id") == "summary_7" for r in results)
+
+
+def test_personality_intent_keeps_supplements(fts_engine, monkeypatch):
+    """M-05: on a personality-intent query, id-less personality rows in the
+    result list must NOT cause the contradiction/summary existing_ids
+    comprehension to KeyError-and-discard the supplements."""
+    eng = fts_engine
+    eng._has_personality = True
+    eng._has_consolidation = True
+
+    # Personality results carry NO "id" key (this is what triggered the bug).
+    def fake_personality(conn, query, limit=5):
+        return [{
+            "content": "alice communication style: casual",
+            "sender": "alice",
+            "recipient": "",
+            "timestamp": "",
+            "source": "profile",
+            "score": 1.0,
+        }]
+
+    def fake_contradictions(conn, query, *a, **k):
+        return [{
+            "id": 9001,
+            "content": "alice now prefers sushi (was pizza)",
+            "current_fact": "alice now prefers sushi",
+            "source": "contradiction",
+        }]
+
+    def fake_consolidated(conn, query, limit=3):
+        return [{
+            "id": "summary_3",
+            "content": "alice summary: enjoys spicy food",
+            "score": 0.5,
+            "source": "summary",
+        }]
+
+    monkeypatch.setattr("truememory.engine.search_personality", fake_personality)
+    monkeypatch.setattr("truememory.engine.search_contradictions", fake_contradictions)
+    monkeypatch.setattr("truememory.engine.search_consolidated", fake_consolidated)
+
+    results = eng.search(_PERSONALITY_QUERY, limit=10)
+    ids = [r.get("id") for r in results]
+    # Both supplements must survive — before the fix they were silently dropped.
+    assert 9001 in ids, "contradiction supplement was discarded (M-05 regression)"
+    assert "summary_3" in ids, "consolidated summary was discarded (M-05 regression)"
+
+
+def test_idless_rows_do_not_collapse_to_id_zero(fts_engine, monkeypatch):
+    """M-67: two distinct id-less supplement rows must remain two distinct
+    rows in the output, not collapse into a single fabricated id=0 document."""
+    eng = fts_engine
+    eng._has_personality = True
+    eng._has_consolidation = True
+
+    def fake_personality(conn, query, limit=5):
+        # Two distinct rows, both WITHOUT an id, distinct content.
+        return [
+            {"content": "alice profile fact ONE", "sender": "alice",
+             "source": "profile", "score": 1.0},
+            {"content": "alice profile fact TWO", "sender": "alice",
+             "source": "profile", "score": 1.0},
+        ]
+
+    monkeypatch.setattr("truememory.engine.search_personality", fake_personality)
+    monkeypatch.setattr("truememory.engine.search_contradictions", lambda *a, **k: [])
+    monkeypatch.setattr("truememory.engine.search_consolidated", lambda *a, **k: [])
+
+    results = eng.search(_PERSONALITY_QUERY, limit=10)
+    one = [r for r in results if r["content"] == "alice profile fact ONE"]
+    two = [r for r in results if r["content"] == "alice profile fact TWO"]
+    assert len(one) == 1, "id-less row ONE missing/collapsed (M-67 regression)"
+    assert len(two) == 1, "id-less row TWO missing/collapsed (M-67 regression)"
+    # Neither was rewritten to a fabricated integer id=0.
+    assert one[0].get("id") != 0
+    assert two[0].get("id") != 0

--- a/truememory/agentic_search.py
+++ b/truememory/agentic_search.py
@@ -255,7 +255,9 @@ def clean_results(
             score = 0.0
 
         cleaned.append({
-            "id": rid if rid else 0,
+            # Preserve None for id-less rows (#630 M-67): rewriting to 0
+            # collapsed distinct supplement rows under id-keyed RRF.
+            "id": rid,
             "content": content,
             "sender": r.get("sender", ""),
             "recipient": r.get("recipient", ""),
@@ -271,7 +273,9 @@ def clean_results(
             seen_ids.add(rid)
         seen_content.add(content_key)
 
-    cleaned.sort(key=lambda d: (-d["score"], d["id"]))
+    # Tie-break on str(id): type-stable across int / "summary_N" / None
+    # supplement ids (#630 M-01).
+    cleaned.sort(key=lambda d: (-d["score"], str(d.get("id", ""))))
 
     if max_per_session > 0 and len(cleaned) > limit:
         diverse: list[dict] = []

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -1837,7 +1837,12 @@ class TrueMemoryEngine:
             try:
                 contradiction_results = search_contradictions(self.conn, query)
                 if contradiction_results:
-                    existing_ids = {r["id"] for r in results}
+                    # Use .get(): supplement rows (personality/profile) may
+                    # lack an "id" key — bracket access raised KeyError that
+                    # the blanket except silently swallowed, discarding ALL
+                    # contradiction supplements on personality queries
+                    # (#630 M-05).
+                    existing_ids = {r.get("id") for r in results if r.get("id")}
                     # Score contradictions competitively so they survive
                     # the top-K slice and reach the reranker (#581).
                     max_existing = max(
@@ -1866,7 +1871,8 @@ class TrueMemoryEngine:
             try:
                 consolidated = search_consolidated(self.conn, query, limit=3)
                 if consolidated:
-                    existing_ids = {r["id"] for r in results}
+                    # .get() guard (#630 M-05): see contradiction block above.
+                    existing_ids = {r.get("id") for r in results if r.get("id")}
                     for sr in consolidated:
                         sr["source"] = sr.get("source", "summary")
                         if sr.get("id") and sr["id"] not in existing_ids:
@@ -1944,7 +1950,10 @@ class TrueMemoryEngine:
                 score = 0.0
 
             cleaned.append({
-                "id": rid if rid else 0,
+                # Preserve None for id-less supplement rows (#630 M-67).
+                # Rewriting to 0 made #606's id-keyed RRF collapse multiple
+                # distinct id-less rows into one fabricated id=0 document.
+                "id": rid,
                 "content": content,
                 "sender": r.get("sender", ""),
                 "recipient": r.get("recipient", ""),
@@ -1960,8 +1969,10 @@ class TrueMemoryEngine:
                 seen_ids.add(rid)
             seen_content.add(content_key)
 
-        # Sort by score descending, then by id for determinism.
-        cleaned.sort(key=lambda d: (-d["score"], d["id"]))
+        # Sort by score descending, then by str(id) for determinism.
+        # str() is type-stable even when ids mix int message ids with
+        # "summary_N" / None supplement ids (#630 M-01).
+        cleaned.sort(key=lambda d: (-d["score"], str(d.get("id", ""))))
         return cleaned[:limit]
 
     # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #630.

Three confirmed id-hygiene bugs in `engine.search`'s supplement-merge step (the path that folds personality / contradiction / consolidated-summary supplements into the FTS+vector result list).

## M-01 (P0) — mixed-id sort TypeError
The final `cleaned.sort` tie-broke on `d["id"]`. Consolidation emits `"summary_N"` **string** ids (#606) while messages have **int** ids, so any score tie raised `TypeError: '<' not supported between 'str' and 'int'`. Ties are guaranteed: FTS normalization pins the top hit at exactly 1.0. Same bug in `agentic_search.clean_results`.
**Fix:** tie-break on `str(d.get("id", ""))` in both sorts, matching the type-stable pattern in `hybrid.py:113`.

## M-05 (P1) — id-less KeyError silently drops supplements
`personality.search_personality` emits rows with **no** `"id"` key. The contradiction and consolidated-summary blocks built `existing_ids` with bracket access (`{r["id"] for r in results}`); the KeyError was swallowed by a blanket `except`, so on **every** personality-intent query ALL contradiction supplements and consolidated summaries were silently discarded.
**Fix:** use `r.get("id")` (filtering None) in both set comprehensions.

## M-67 (P2) — id=0 RRF collision
Id-less rows were rewritten to `id=0` during cleaning, so #606's id-keyed RRF collapsed multiple distinct id-less rows into one fabricated `id=0` document.
**Fix:** preserve `None` ids through cleaning (`engine.py` + `agentic_search.py`).

## Tests
New `tests/test_issue_630_search_supplement_merge.py` — 3 regression tests driving the real `TrueMemoryEngine.search` with an FTS-only in-memory engine, supplement fns stubbed, no model loads:
1. string-id summary tying at score 1.0 with int-id rows does **not** raise TypeError and returns sorted results;
2. personality-intent query still returns its contradiction + consolidated-summary supplements;
3. two distinct id-less supplement rows do not collapse into one.

Each test was verified to **fail** on pre-fix code and **pass** after the fix.

## Verification
- `ruff check truememory/ tests/` — clean.
- new tests: 3 passed; `test_l5_surprise_rerank.py`: 22 passed; `test_issue_581_contradiction_inject.py`: 10 passed (adjacent merge logic).

Touches only `engine.py`, `agentic_search.py`, and the new test file. No merge.