### PR TITLE
fix: score-space contract — stop comparing relative scores to absolute cosine thresholds (#632)

### DIFF
--- a/tests/test_issue_632_score_space.py
+++ b/tests/test_issue_632_score_space.py
@@ -1,0 +1,248 @@
+"""Tests for issue #632: score-space contract.
+
+`Memory.search_vectors()` falls back to the full `search()` pipeline whose
+scores are RELATIVELY normalized (FTS top hit pinned to 1.0; reranker fused
+scores min-max pinned). Several consumers wrongly compared those relative
+scores against ABSOLUTE cosine thresholds:
+
+  - dedup.py:        SKIP when score > 0.92
+  - user_prompt_submit.py: novelty SKIP when score > 0.85
+  - encoding_gate.py: pays the full reranker pipeline per fact
+
+Net bug: when the embedder is dead (FTS-only / degraded mode), any incoming
+fact sharing ONE keyword with a stored memory gets a relative score near 1.0
+and is silently dropped as a "duplicate".
+
+The fix tags each result with ``score_space`` (``"cosine"`` vs
+``"relative"``). Consumers apply absolute cosine thresholds ONLY to
+cosine-space scores; otherwise they fall back to the scale-free word-overlap
+heuristic.
+
+These tests use plain mock memories — no embeddings, no model loads.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from truememory.ingest.dedup import DedupAction, check_duplicate
+
+
+def _make_memory(results: list[dict]) -> MagicMock:
+    mem = MagicMock()
+    mem.search_vectors.return_value = results
+    return mem
+
+
+# ── (a) Core regression: relative score must NOT drop a non-duplicate ─────
+
+def test_relative_score_does_not_drop_keyword_overlap_nonduplicate():
+    """FTS-only mode: a relative score of 1.0 on a fact that shares only one
+    keyword (and is NOT a true duplicate) must NOT be SKIPped."""
+    memory = _make_memory([
+        {
+            "id": 1,
+            "content": "User lives in Austin",
+            # In FTS-only mode the top hit is pinned to 1.0 regardless of
+            # true similarity — sharing the keyword "user" is enough.
+            "score": 1.0,
+            "score_space": "relative",
+            "directive": False,
+        },
+    ])
+    decision = check_duplicate(
+        "User works at a startup",  # shares "user" only; distinct fact
+        memory,
+        config=None,  # no LLM -> heuristic fallback path
+    )
+    assert decision.action == DedupAction.ADD, (
+        f"Relative 1.0 score must not trigger SKIP on a non-duplicate; "
+        f"got {decision.action}: {decision.reason}"
+    )
+
+
+def test_relative_score_high_but_real_paraphrase_still_word_overlap_deduped():
+    """Even in relative-score mode, a true rephrased duplicate (high word
+    overlap) is still caught by the scale-free heuristic."""
+    memory = _make_memory([
+        {
+            "id": 7,
+            "content": "User prefers dark mode in all apps",
+            "score": 1.0,
+            "score_space": "relative",
+            "directive": False,
+        },
+    ])
+    decision = check_duplicate(
+        "User prefers dark mode in all apps",  # identical -> substring SKIP
+        memory,
+        config=None,
+    )
+    assert decision.action == DedupAction.SKIP, (
+        f"Identical content must still dedup via the heuristic; "
+        f"got {decision.action}: {decision.reason}"
+    )
+
+
+# ── (b) Genuine cosine-space near-duplicate IS still deduped ──────────────
+
+def test_cosine_space_near_duplicate_is_skipped():
+    """A true cosine-space score > 0.92 is a real near-duplicate -> SKIP."""
+    memory = _make_memory([
+        {
+            "id": 2,
+            "content": "User lives in Austin, Texas",
+            "score": 0.97,
+            "score_space": "cosine",
+            "directive": False,
+        },
+    ])
+    decision = check_duplicate(
+        "User resides in Austin TX",
+        memory,
+        config=None,
+    )
+    assert decision.action == DedupAction.SKIP, (
+        f"Cosine-space 0.97 must SKIP as near-exact match; "
+        f"got {decision.action}: {decision.reason}"
+    )
+
+
+def test_missing_score_space_defaults_to_cosine_back_compat():
+    """Back-compat: results with no score_space tag (e.g. from a raw vector
+    path that pre-dates the tag) are treated as cosine-space."""
+    memory = _make_memory([
+        {
+            "id": 3,
+            "content": "User lives in Austin, Texas",
+            "score": 0.97,
+            # no score_space key
+            "directive": False,
+        },
+    ])
+    decision = check_duplicate(
+        "User resides in Austin TX",
+        memory,
+        config=None,
+    )
+    assert decision.action == DedupAction.SKIP
+
+
+def test_cosine_space_low_similarity_added():
+    """Cosine-space but low score -> distinct fact -> ADD."""
+    memory = _make_memory([
+        {
+            "id": 4,
+            "content": "User likes hiking",
+            "score": 0.10,
+            "score_space": "cosine",
+            "directive": False,
+        },
+    ])
+    decision = check_duplicate(
+        "User drives a Tesla",
+        memory,
+        config=None,
+    )
+    assert decision.action == DedupAction.ADD
+
+
+# ── (c) Novelty check in degraded mode uses word-overlap, not relative 1.0 ─
+
+def test_novelty_check_word_overlap_helper():
+    """The novelty fallback helper is scale-free word overlap."""
+    from truememory.ingest.hooks.user_prompt_submit import _word_overlap
+
+    # Identical -> 1.0
+    assert _word_overlap("user likes dogs", "user likes dogs") == 1.0
+    # One shared keyword out of many -> well below the 0.85 cutoff
+    assert _word_overlap("user works at a startup", "user lives in austin") < 0.85
+    # Empty -> 0.0
+    assert _word_overlap("", "") == 0.0
+
+
+def test_novelty_relative_one_keyword_overlap_not_dropped():
+    """Simulate the novelty loop: a relative-space hit with score 1.0 but
+    only one shared keyword must NOT be treated as a duplicate."""
+    from truememory.ingest.hooks.user_prompt_submit import _word_overlap
+
+    prompt = "User just adopted a golden retriever puppy named Biscuit"
+    hit = {
+        "content": "User lives in Austin",
+        "score": 1.0,
+        "score_space": "relative",
+    }
+    # Replicates the guarded novelty decision in _try_per_exchange_store.
+    is_cosine = hit.get("score_space", "relative") == "cosine"
+    dropped = (
+        (is_cosine and hit["score"] > 0.85)
+        or (not is_cosine and _word_overlap(prompt, hit["content"]) > 0.85)
+    )
+    assert dropped is False, "relative 1.0 with weak overlap must not drop the prompt"
+
+
+def test_novelty_relative_true_duplicate_dropped():
+    """A genuine duplicate in relative mode IS dropped via word overlap."""
+    from truememory.ingest.hooks.user_prompt_submit import _word_overlap
+
+    prompt = "User prefers dark mode in all apps"
+    hit = {
+        "content": "User prefers dark mode in all apps",
+        "score": 1.0,
+        "score_space": "relative",
+    }
+    is_cosine = hit.get("score_space", "relative") == "cosine"
+    dropped = (
+        (is_cosine and hit["score"] > 0.85)
+        or (not is_cosine and _word_overlap(prompt, hit["content"]) > 0.85)
+    )
+    assert dropped is True
+
+
+# ── client.py score_space tagging ─────────────────────────────────────────
+
+def test_search_vectors_tags_cosine_when_raw_available():
+    """When the raw vector path returns results, they are tagged cosine."""
+    from truememory.client import Memory
+
+    m = Memory.__new__(Memory)  # bypass __init__/DB
+    m._engine = MagicMock()
+    m._engine.search_vectors_raw.return_value = [
+        {"id": 1, "content": "x", "score": 0.9},
+    ]
+    out = m.search_vectors("q", limit=3)
+    assert out[0]["score_space"] == "cosine"
+
+
+def test_search_vectors_falls_back_to_relative_when_no_vectors():
+    """When raw vectors are unavailable, the search() fallback is tagged
+    relative, never cosine."""
+    from truememory.client import Memory
+
+    m = Memory.__new__(Memory)
+    m._engine = MagicMock()
+    m._engine.search_vectors_raw.return_value = None
+    m._engine.search.return_value = [
+        {"id": 1, "content": "x", "score": 1.0, "sender": ""},
+    ]
+    out = m.search_vectors("q", limit=3)
+    assert out[0]["score_space"] == "relative"
+
+
+def test_search_tags_relative():
+    """The full search() pipeline always yields relative-space scores."""
+    from truememory.client import Memory
+
+    m = Memory.__new__(Memory)
+    m._engine = MagicMock()
+    m._engine.search.return_value = [
+        {"id": 1, "content": "x", "score": 1.0, "sender": ""},
+    ]
+    out = m.search("q", limit=3)
+    assert out[0]["score_space"] == "relative"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_issue_632_score_space.py
+++ b/tests/test_issue_632_score_space.py
@@ -175,7 +175,7 @@ def test_novelty_relative_one_keyword_overlap_not_dropped():
         "score_space": "relative",
     }
     # Replicates the guarded novelty decision in _try_per_exchange_store.
-    is_cosine = hit.get("score_space", "relative") == "cosine"
+    is_cosine = hit.get("score_space", "cosine") != "relative"
     dropped = (
         (is_cosine and hit["score"] > 0.85)
         or (not is_cosine and _word_overlap(prompt, hit["content"]) > 0.85)
@@ -193,12 +193,28 @@ def test_novelty_relative_true_duplicate_dropped():
         "score": 1.0,
         "score_space": "relative",
     }
-    is_cosine = hit.get("score_space", "relative") == "cosine"
+    is_cosine = hit.get("score_space", "cosine") != "relative"
     dropped = (
         (is_cosine and hit["score"] > 0.85)
         or (not is_cosine and _word_overlap(prompt, hit["content"]) > 0.85)
     )
     assert dropped is True
+
+
+def test_novelty_untagged_cosine_score_dropped():
+    """Back-compat (mirrors #634): an untagged high score is treated as
+    cosine and a near-duplicate above 0.85 IS dropped, even when its content
+    shares no words with the prompt (so word-overlap could not catch it)."""
+    from truememory.ingest.hooks.user_prompt_submit import _word_overlap
+
+    prompt = "I prefer dark mode for all my editors"
+    hit = {"content": "x", "score": 0.95}  # no score_space tag
+    is_cosine = hit.get("score_space", "cosine") != "relative"
+    dropped = (
+        (is_cosine and hit["score"] > 0.85)
+        or (not is_cosine and _word_overlap(prompt, hit["content"]) > 0.85)
+    )
+    assert dropped is True, "untagged 0.95 score must be treated as cosine and dropped"
 
 
 # ── client.py score_space tagging ─────────────────────────────────────────

--- a/truememory/client.py
+++ b/truememory/client.py
@@ -122,6 +122,7 @@ class Memory:
         user_id: str | None = None,
         limit: int = 10,
         include_directives: bool = False,
+        _skip_reranker: bool = False,
     ) -> list[dict]:
         """Search memories using the full 6-layer pipeline.
 
@@ -130,6 +131,10 @@ class Memory:
             user_id: Filter results to this user (optional).
             limit:   Max results.
             include_directives: If True, include directive rows in results.
+            _skip_reranker: Internal — skip cross-encoder reranking. Used by
+                callers (encoding gate novelty, dedup fallback) that only
+                need candidate content / raw scores, not a reranked ordering,
+                so they don't pay the cross-encoder per fact (issue #632).
 
         Returns:
             List of result dicts sorted by relevance.
@@ -137,6 +142,7 @@ class Memory:
         results = self._engine.search(
             query, limit=limit * 3 if user_id else limit,
             include_directives=include_directives,
+            _skip_reranker=_skip_reranker,
         )
 
         if user_id:
@@ -144,6 +150,13 @@ class Memory:
 
         for r in results:
             r["user_id"] = r.get("sender", "")
+            # Score-space contract (issue #632): the full search() pipeline
+            # produces RELATIVELY normalized scores (FTS top hit pinned to
+            # 1.0; reranker fused scores min-max pinned). These are NOT
+            # absolute cosine similarities and must never be compared to
+            # absolute cosine thresholds (dedup 0.92, novelty 0.85). Tag
+            # them so consumers can tell the difference.
+            r.setdefault("score_space", "relative")
 
         return results[:limit]
 
@@ -163,11 +176,22 @@ class Memory:
         cos_sim = max(0, 1 - d). This gives the gate a score that can
         be directly subtracted from 1.0 to get novelty.
 
+        Each result is tagged with ``score_space`` (issue #632):
+        ``"cosine"`` when the pure-vector path produced the score (an
+        absolute cosine similarity safe to compare against absolute
+        thresholds), or ``"relative"`` when vectors were unavailable and
+        we fell back to the full ``search()`` pipeline (FTS-only /
+        reranked scores that are relatively normalized and must NOT be
+        compared to absolute cosine cutoffs).
+
         Falls back to regular search() if vector search is unavailable.
         """
         result = self._engine.search_vectors_raw(query, limit=limit)
         if result is None:
+            # No vectors available — relative/fused scores only.
             return self.search(query, limit=limit)
+        for r in result:
+            r["score_space"] = "cosine"
         return result
 
     def search_deep(

--- a/truememory/ingest/dedup.py
+++ b/truememory/ingest/dedup.py
@@ -163,13 +163,21 @@ def check_duplicate(
     top_score = top.get("score", 0)
     top_content = top.get("content", "")
     top_id = top.get("id")
+    # Score-space contract (issue #632): the absolute 0.92 cosine cutoff is
+    # only meaningful when the score is a TRUE cosine similarity. When the
+    # embedder is dead or in FTS-only mode, search_vectors() falls back to
+    # the full pipeline whose scores are relatively normalized (FTS top hit
+    # pinned to 1.0; reranker fused scores min-max pinned). Comparing those
+    # to 0.92 drops any fact sharing one keyword with a stored memory as a
+    # bogus "duplicate". Only trust the number when it is cosine-space.
+    top_is_cosine = top.get("score_space", "cosine") == "cosine"
 
     # Very high similarity — likely near-exact duplicate.
     # BUT: if the new fact contains update markers (issue #576), it may be
     # a genuine fact change that just happens to embed close to the old
     # version.  Route those to LLM arbitration (if available) or the
     # heuristic path rather than silently dropping them.
-    if top_score > 0.92:
+    if top_is_cosine and top_score > 0.92:
         if _has_update_markers(fact):
             log.debug(
                 "High-similarity candidate (%.2f) has update markers — "
@@ -186,6 +194,15 @@ def check_duplicate(
             existing_content=top_content,
             reason=f"near-exact match ({top_score:.2f})",
         )
+
+    # Relative/fused score (FTS-only / degraded / reranked): the number is
+    # NOT a cosine similarity, so we cannot trust it for a SKIP/UPDATE
+    # decision. Defer to the LLM if available, otherwise fall back to the
+    # scale-free word-overlap heuristic instead of the (meaningless) score.
+    if not top_is_cosine:
+        if config:
+            return _llm_dedup(fact, top_content, top_id, config)
+        return _heuristic_dedup(fact, top_content, top_id, similarity=0.0)
 
     # When LLM dedup is available, send the top candidate to the LLM
     # regardless of absolute similarity score — the LLM is the canonical

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -367,7 +367,12 @@ class EncodingGate:
             except Exception:
                 pass
         if results is None:
-            results = self._search(fact, limit=10)
+            # search_vectors() fell back to the full pipeline (no vectors).
+            # Skip the cross-encoder reranker — the gate only reads the
+            # nearest memory's CONTENT (compression novelty + PE re-embed),
+            # never the retrieval score, so paying the reranker per fact is
+            # wasted work (issue #632).
+            results = self._search(fact, limit=10, skip_reranker=True)
 
         # Exclude directives — they are standing instructions, not facts,
         # and should not cause incoming memories to be rejected as redundant.
@@ -550,13 +555,24 @@ class EncodingGate:
     # Helpers
     # ------------------------------------------------------------------
 
-    def _search(self, query: str, limit: int = 5) -> list[dict]:
-        """Search existing memories, scoped to user if set."""
+    def _search(self, query: str, limit: int = 5, skip_reranker: bool = False) -> list[dict]:
+        """Search existing memories, scoped to user if set.
+
+        ``skip_reranker`` (issue #632) asks the underlying Memory.search to
+        skip the cross-encoder reranker. Passed through best-effort: if the
+        backing object doesn't accept the kwarg (e.g. a test double), we
+        retry without it rather than failing the gate.
+        """
+        kwargs: dict = {"limit": limit}
+        if self.user_id:
+            kwargs["user_id"] = self.user_id
         try:
-            if self.user_id:
-                return self.memory.search(query, user_id=self.user_id, limit=limit)
-            else:
-                return self.memory.search(query, limit=limit)
+            if skip_reranker:
+                try:
+                    return self.memory.search(query, _skip_reranker=True, **kwargs)
+                except TypeError:
+                    pass  # backing search() lacks the kwarg — fall through
+            return self.memory.search(query, **kwargs)
         except Exception as e:
             log.warning("Memory search failed during encoding gate: %s", e)
             return []

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -297,23 +297,31 @@ def _try_per_exchange_store(prompt: str, session_id: str, user_id: str, db_path:
         from truememory.client import Memory
         with Memory(path=db_path or None) as m:
             # Novelty check: quick search to avoid dupes.
-            # Score-space contract (issue #632): m.search() returns
+            # Score-space contract (issue #632): a score is only a true
+            # absolute cosine similarity when its result is tagged
+            # score_space="cosine". The full search() pipeline can return
             # RELATIVELY normalized scores (FTS top hit pinned to 1.0;
-            # reranker fused scores min-max pinned), NOT absolute cosine
-            # similarity. Comparing them to the absolute 0.85 cutoff drops
-            # any prompt sharing one keyword with a stored memory as a
-            # bogus "duplicate" — exactly when the embedder is dead. Only
-            # trust the number when it is cosine-space; otherwise fall back
-            # to the scale-free word-overlap heuristic.
+            # reranker fused scores min-max pinned) — comparing those to the
+            # absolute 0.85 cutoff drops any prompt sharing one keyword with
+            # a stored memory as a bogus "duplicate", exactly when the
+            # embedder is dead.
+            #
+            # Apply the 0.85 cosine cutoff ONLY to cosine-space scores.
+            # Missing tag defaults to cosine for back-compat (matches
+            # dedup.py): raw vector hits and callers that predate the tag
+            # are genuine cosine. When the tag is explicitly "relative" the
+            # number is untrustworthy, so fall back to the scale-free
+            # word-overlap heuristic instead. (#631 makes the vector path
+            # emit true cosine, so this stays correct as it lands.)
             existing = m.search(prompt, user_id=user_id or None, limit=3)
             if existing:
                 for r in existing:
                     score = r.get("score", 0.0)
-                    if r.get("score_space", "relative") == "cosine":
+                    if r.get("score_space", "cosine") != "relative":
                         if score > 0.85:
-                            return  # Too similar to existing memory
+                            return  # Too similar to existing memory (cosine)
                     elif _word_overlap(prompt, r.get("content", "")) > 0.85:
-                        return  # Scale-free near-duplicate
+                        return  # Scale-free near-duplicate (relative score)
 
             # Run through encoding gate
             from truememory.ingest.encoding_gate import EncodingGate

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -50,6 +50,21 @@ RETENTION_DAYS = int(os.environ.get("TRUEMEMORY_BUFFER_RETENTION_DAYS", "7"))
 MAX_BUFFER_SIZE = int(os.environ.get("TRUEMEMORY_BUFFER_MAX_BYTES", str(10 * 1024 * 1024)))
 
 
+def _word_overlap(a: str, b: str) -> float:
+    """Scale-free Jaccard similarity on word sets (issue #632).
+
+    Used as the novelty fallback when retrieval scores are relative/fused
+    (FTS-only / degraded embedder) rather than absolute cosine similarity,
+    so the 0.85 cutoff cannot be trusted as a true cosine value.
+    """
+    words_a = set(re.findall(r"\w+", a.lower()))
+    words_b = set(re.findall(r"\w+", b.lower()))
+    union = words_a | words_b
+    if not union:
+        return 0.0
+    return len(words_a & words_b) / len(union)
+
+
 def _parse_args() -> argparse.Namespace:
     """Parse command-line overrides the installer threads through.
 
@@ -281,13 +296,24 @@ def _try_per_exchange_store(prompt: str, session_id: str, user_id: str, db_path:
     try:
         from truememory.client import Memory
         with Memory(path=db_path or None) as m:
-            # Novelty check: quick search to avoid dupes
+            # Novelty check: quick search to avoid dupes.
+            # Score-space contract (issue #632): m.search() returns
+            # RELATIVELY normalized scores (FTS top hit pinned to 1.0;
+            # reranker fused scores min-max pinned), NOT absolute cosine
+            # similarity. Comparing them to the absolute 0.85 cutoff drops
+            # any prompt sharing one keyword with a stored memory as a
+            # bogus "duplicate" — exactly when the embedder is dead. Only
+            # trust the number when it is cosine-space; otherwise fall back
+            # to the scale-free word-overlap heuristic.
             existing = m.search(prompt, user_id=user_id or None, limit=3)
             if existing:
                 for r in existing:
                     score = r.get("score", 0.0)
-                    if score > 0.85:
-                        return  # Too similar to existing memory
+                    if r.get("score_space", "relative") == "cosine":
+                        if score > 0.85:
+                            return  # Too similar to existing memory
+                    elif _word_overlap(prompt, r.get("content", "")) > 0.85:
+                        return  # Scale-free near-duplicate
 
             # Run through encoding gate
             from truememory.ingest.encoding_gate import EncodingGate


### PR DESCRIPTION
Fixes #632.

## Mechanism
Tag every retrieval result with a `score_space` indicator (`"cosine"` vs `"relative"`) at the `client.py` boundary, so consumers can tell whether a `score` is a true absolute cosine similarity or a relatively normalized / fused score. Absolute cosine thresholds are then applied ONLY to cosine-space scores; when only relative/fused scores are available (FTS-only / dead embedder / reranked) consumers fall back to the existing scale-free word-overlap heuristic instead of trusting the number.

## The bug
`Memory.search_vectors()` falls back to the full `search()` pipeline whose scores are relatively normalized (FTS top hit pinned to 1.0; reranker fused scores min-max pinned). But several consumers treated that output as absolute cosine similarity. Net: when the embedder is dead (exactly the case #604 degrades the gate open) or in FTS-only mode, any incoming fact sharing one keyword with a stored memory got a relative score ~1.0 and was dropped as a bogus "duplicate". Inverse failure in RRF mode (scores ~0.016 -> never dedups).

## Changes per file
- **`truememory/client.py`** — `search_vectors()` tags the raw-vector path (`search_vectors_raw`) as `score_space="cosine"` and the no-vectors fallback (full `search()`) as `"relative"`. `search()` tags all results `"relative"`. Added `search(_skip_reranker=)` passthrough to the engine.
- **`truememory/ingest/dedup.py`** — the `> 0.92` SKIP now fires only when `score_space == "cosine"` (missing tag defaults to cosine for back-compat). Relative/fused top hits defer to the LLM if configured, else fall back to `_heuristic_dedup` (substring + word-overlap Jaccard) instead of the meaningless score.
- **`truememory/ingest/hooks/user_prompt_submit.py`** — novelty SKIP applies the `0.85` cutoff only to cosine-space hits; otherwise uses a new scale-free `_word_overlap` helper. (`m.search()` is always relative-space, so this path now always uses word-overlap.)
- **`truememory/ingest/encoding_gate.py`** — the novelty-search fallback (when `search_vectors` has no vectors) now passes `_skip_reranker` via `_search(skip_reranker=True)`, so the gate doesn't pay the cross-encoder per fact. It only reads the nearest memory's content (compression novelty + PE re-embed), never the retrieval score. Best-effort kwarg (retries without it for test doubles).

## Tests
New `tests/test_issue_632_score_space.py` (11 tests, no model loads, mock memories):
- (a) relative-score mode: a fact sharing one keyword but not a true duplicate is NOT dropped by dedup (core regression); novelty likewise not dropped.
- (b) genuine cosine-space near-duplicate (>0.92) IS still deduped; missing-tag back-compat defaults to cosine.
- (c) novelty in degraded mode falls back to word-overlap, dropping true duplicates but keeping weak-overlap prompts.
- client.py tagging: cosine when raw available, relative on fallback, relative for search().

## Test results
- `tests/test_issue_632_score_space.py`: 11 passed.
- `pytest tests/ -k "dedup or encoding_gate or novelty"`: 111 passed.
- `test_issue_587_dedup_directive`, `test_issue_585_encoding_gate_pe`, `test_encoding_gate_compression_novelty`: 34 passed (no regression).
- `ruff check truememory/ tests/`: clean.

## Caveats / coordination
- Coordinates with #631 (making the vector path produce true cosine): once #631 lands, cosine-space scores are trustworthy end-to-end; this PR ensures relative scores are never compared to absolute cutoffs in the meantime, and the `score_space` tag is the contract both sides honor.
- `score_space` is tagged at the client boundary (constraint: do not touch `vector_search.py`/`engine.py`). A future cleanup could push the tag into `search_vector_raw` itself.
- Missing `score_space` defaults to cosine for back-compat (existing raw-vector callers).