### PR TITLE
fix: declare cosine distance on vec0 tables + rebuild migration (#631)

### DIFF
--- a/tests/test_issue_631_cosine_metric.py
+++ b/tests/test_issue_631_cosine_metric.py
@@ -1,0 +1,246 @@
+"""Regression tests for issue #631: vec0 tables must declare cosine distance.
+
+M-03 (P0): all sqlite-vec vec0 tables were created without
+``distance_metric=cosine``, so sqlite-vec used its L2 default. The code then
+computed ``cos_sim = 1 - distance`` and treated it as cosine — numerically
+wrong for non-unit vectors and a wrong transform even for unit vectors.
+
+These tests verify:
+  (a) new vec tables declare cosine (via sqlite_master.sql);
+  (b) reported similarity equals TRUE cosine for unit vectors
+      (orthogonal -> ~0.0, identical -> ~1.0, known-angle -> expected);
+  (c) the rebuild migration upgrades an L2 table to cosine, preserving the
+      same ids and (normalized) vectors;
+  (d) zero / non-finite vectors do not crash the build or migration.
+
+All tests need the sqlite-vec extension; they skip cleanly where it can't
+load. Vectors are constructed by hand — no model loads (HF_HUB_OFFLINE=1).
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from tests.conftest import requires_sqlite_ext
+
+
+def _ser(vec):
+    return struct.pack(f"{len(vec)}f", *vec)
+
+
+def _load_vec(conn):
+    import sqlite_vec
+
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+
+
+def _make_conn():
+    import sqlite3
+
+    conn = sqlite3.connect(":memory:")
+    _load_vec(conn)
+    return conn
+
+
+def _ddl(conn, table):
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name=? AND type='table'",
+        (table,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+@requires_sqlite_ext
+class TestIssue631CosineMetric:
+
+    # ----- (a) new tables declare cosine -----------------------------------
+
+    def test_init_vec_table_declares_cosine(self):
+        from truememory.storage import create_db
+        from truememory.vector_search import init_vec_table, _active_vec_table, _active_sep_table
+
+        conn = create_db(":memory:")
+        _load_vec(conn)
+        init_vec_table(conn)
+
+        vec = _active_vec_table(conn)
+        sep = _active_sep_table(conn)
+        assert "distance_metric=cosine" in _ddl(conn, vec).replace(" ", "")
+        assert "distance_metric=cosine" in _ddl(conn, sep).replace(" ", "")
+
+    def test_column_decl_helper(self):
+        from truememory.vector_search import _vec0_column_decl
+
+        decl = _vec0_column_decl(256)
+        assert "float[256]" in decl
+        assert "distance_metric=cosine" in decl
+
+    # ----- (b) reported similarity is TRUE cosine --------------------------
+
+    def test_reported_similarity_is_true_cosine(self):
+        """For unit vectors, ``1 - distance`` equals true cosine.
+
+        Stored [1,0]; query orthogonal [0,1] -> cos 0.0; query identical
+        [1,0] -> cos 1.0; query at 36.87deg ([0.8,0.6]) -> cos 0.8. Under the
+        OLD L2 default, distance for the orthogonal pair would be sqrt(2)~1.414
+        (so the wrong "cos_sim = 1 - 1.414" clamps to 0.0 by luck) but the
+        36.87deg pair would give L2 ~0.633 -> wrong "cos_sim" 0.367 != 0.8.
+        """
+        from truememory.vector_search import _vec0_column_decl
+
+        conn = _make_conn()
+        conn.execute(
+            f"CREATE VIRTUAL TABLE t USING vec0({_vec0_column_decl(2)})"
+        )
+        conn.execute("INSERT INTO t(rowid, embedding) VALUES (1, ?)", (_ser([1.0, 0.0]),))
+
+        cases = {
+            "orthogonal": ([0.0, 1.0], 0.0),
+            "identical": ([1.0, 0.0], 1.0),
+            "angle_36.87deg": ([0.8, 0.6], 0.8),
+        }
+        for label, (query, expected_cos) in cases.items():
+            dist = conn.execute(
+                "SELECT distance FROM t WHERE embedding MATCH ? AND k=1",
+                (_ser(query),),
+            ).fetchone()[0]
+            cos_sim = 1.0 - dist
+            assert cos_sim == pytest.approx(expected_cos, abs=1e-5), (
+                f"{label}: cosine {cos_sim} != expected {expected_cos}"
+            )
+
+    def test_normalize_for_cosine_unit_and_zero(self):
+        import numpy as np
+        from truememory.vector_search import _normalize_for_cosine
+
+        out = _normalize_for_cosine([3.0, 4.0])
+        assert out is not None
+        assert float(np.linalg.norm(out)) == pytest.approx(1.0, abs=1e-6)
+        assert out.tolist() == pytest.approx([0.6, 0.8], abs=1e-6)
+
+        assert _normalize_for_cosine([0.0, 0.0]) is None
+        assert _normalize_for_cosine([float("nan"), 1.0]) is None
+        assert _normalize_for_cosine([float("inf"), 0.0]) is None
+
+    # ----- (c) migration upgrades L2 -> cosine preserving vectors ----------
+
+    def test_migration_upgrades_l2_to_cosine(self):
+        from truememory.vector_search import migrate_to_cosine_metric, _table_uses_cosine
+
+        conn = _make_conn()
+        # Old-format L2 table with UNNORMALIZED vectors (as Qwen3@256 produces).
+        conn.execute("CREATE VIRTUAL TABLE vec_messages USING vec0(embedding float[2])")
+        conn.execute("INSERT INTO vec_messages(rowid, embedding) VALUES (1, ?)", (_ser([3.0, 4.0]),))
+        conn.execute("INSERT INTO vec_messages(rowid, embedding) VALUES (2, ?)", (_ser([1.0, 0.0]),))
+
+        assert not _table_uses_cosine(conn, "vec_messages")
+        assert migrate_to_cosine_metric(conn) is True
+        assert _table_uses_cosine(conn, "vec_messages")
+
+        # Same ids preserved.
+        ids = [r[0] for r in conn.execute("SELECT rowid FROM vec_messages ORDER BY rowid")]
+        assert ids == [1, 2]
+
+        # Vector [3,4] is now L2-normalized to [0.6, 0.8].
+        blob = conn.execute("SELECT embedding FROM vec_messages WHERE rowid=1").fetchone()[0]
+        assert struct.unpack("2f", blob) == pytest.approx((0.6, 0.8), abs=1e-6)
+
+        # Query returns true cosine: query [1,0] vs stored [0.6,0.8] -> cos 0.6.
+        dist = conn.execute(
+            "SELECT distance FROM vec_messages WHERE embedding MATCH ? AND k=1 ",
+            (_ser([0.6, 0.8]),),
+        ).fetchone()[0]
+        assert (1.0 - dist) == pytest.approx(1.0, abs=1e-5)  # identical to row1 normalized
+
+    def test_migration_is_idempotent(self):
+        from truememory.vector_search import migrate_to_cosine_metric
+
+        conn = _make_conn()
+        conn.execute("CREATE VIRTUAL TABLE vec_messages USING vec0(embedding float[2])")
+        conn.execute("INSERT INTO vec_messages(rowid, embedding) VALUES (1, ?)", (_ser([1.0, 0.0]),))
+        assert migrate_to_cosine_metric(conn) is True
+        assert migrate_to_cosine_metric(conn) is False  # already cosine
+
+    def test_migration_resumes_from_staging(self):
+        """A crash that left a populated staging table is recovered."""
+        from truememory.vector_search import migrate_to_cosine_metric, _table_uses_cosine
+
+        conn = _make_conn()
+        # Old L2 table still present, plus a staging table (simulated crash).
+        conn.execute("CREATE VIRTUAL TABLE vec_messages USING vec0(embedding float[2])")
+        conn.execute("INSERT INTO vec_messages(rowid, embedding) VALUES (1, ?)", (_ser([1.0, 0.0]),))
+        conn.execute("CREATE TABLE vec_messages_cos_stage (rowid INTEGER PRIMARY KEY, embedding BLOB)")
+        conn.execute("INSERT INTO vec_messages_cos_stage VALUES (1, ?)", (_ser([1.0, 0.0]),))
+        conn.execute("INSERT INTO vec_messages_cos_stage VALUES (9, ?)", (_ser([0.0, 1.0]),))
+        conn.commit()
+
+        assert migrate_to_cosine_metric(conn) is True
+        assert _table_uses_cosine(conn, "vec_messages")
+        ids = [r[0] for r in conn.execute("SELECT rowid FROM vec_messages ORDER BY rowid")]
+        assert ids == [1, 9]  # recovered from staging
+        # staging cleaned up
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE name='vec_messages_cos_stage'"
+        ).fetchone() is None
+
+    # ----- (d) zero / NaN vectors do not crash -----------------------------
+
+    def test_migration_drops_zero_vector_without_crash(self):
+        from truememory.vector_search import migrate_to_cosine_metric
+
+        conn = _make_conn()
+        conn.execute("CREATE VIRTUAL TABLE vec_messages USING vec0(embedding float[2])")
+        conn.execute("INSERT INTO vec_messages(rowid, embedding) VALUES (1, ?)", (_ser([1.0, 0.0]),))
+        conn.execute("INSERT INTO vec_messages(rowid, embedding) VALUES (2, ?)", (_ser([0.0, 0.0]),))
+        conn.execute("INSERT INTO vec_messages(rowid, embedding) VALUES (3, ?)", (_ser([0.0, 1.0]),))
+
+        assert migrate_to_cosine_metric(conn) is True
+        ids = [r[0] for r in conn.execute("SELECT rowid FROM vec_messages ORDER BY rowid")]
+        assert ids == [1, 3]  # zero vector dropped
+
+        # No NULL distances poison results.
+        rows = conn.execute(
+            "SELECT rowid, distance FROM vec_messages WHERE embedding MATCH ? AND k=2",
+            (_ser([1.0, 0.0]),),
+        ).fetchall()
+        assert all(d is not None for _, d in rows)
+
+    def test_build_vectors_skips_zero_vector(self):
+        """build_vectors must skip a zero-norm embedding (C2-8)."""
+        from unittest.mock import patch
+        import numpy as np
+        from truememory.storage import create_db
+        from truememory import vector_search as vs
+
+        conn = create_db(":memory:")
+        _load_vec(conn)
+        vs.init_vec_table(conn)
+
+        conn.execute("INSERT INTO messages(id, content) VALUES (1, 'real')")
+        conn.execute("INSERT INTO messages(id, content) VALUES (2, 'zero')")
+        conn.commit()
+
+        dim = vs._embedding_dim
+        good = np.zeros(dim, dtype=np.float32)
+        good[0] = 1.0
+        bad = np.zeros(dim, dtype=np.float32)
+
+        def fake_encode(texts, **kw):
+            out = []
+            for t in texts:
+                out.append(bad if t == "zero" else good)
+            return np.array(out)
+
+        with patch.object(vs, "get_model", return_value=object()), \
+             patch.object(vs, "_encode_with_mps_fallback", side_effect=lambda m, t, **k: fake_encode(t)):
+            inserted = vs.build_vectors(conn)
+
+        # Only the real (non-zero) vector is stored.
+        assert inserted == 1
+        ids = [r[0] for r in conn.execute(
+            f"SELECT rowid FROM {vs._active_vec_table(conn)} ORDER BY rowid"
+        )]
+        assert ids == [1]

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -459,6 +459,63 @@ def serialize_f32(vector) -> bytes:
 
 
 # ---------------------------------------------------------------------------
+# Cosine-metric helpers (issue #631)
+# ---------------------------------------------------------------------------
+
+# sqlite-vec stores vectors with an L2 distance function by default. We declare
+# ``distance_metric=cosine`` on every vec0 table so that ``v.distance`` is a
+# true cosine distance and ``cos_sim = 1 - distance`` is numerically honest.
+#
+# NOTE (sqlite-vec 0.1.9 syntax): ``distance_metric`` is a *column-level*
+# option (space-separated inside the column declaration), NOT a comma-separated
+# table option. ``vec0(embedding float[256] distance_metric=cosine)`` is valid;
+# ``vec0(embedding float[256], distance_metric=cosine)`` raises
+# "Unknown table option".
+_VEC_DISTANCE_METRIC = "cosine"
+
+
+def _vec0_column_decl(dim: int) -> str:
+    """Return the vec0 embedding-column declaration with the cosine metric."""
+    return f"embedding float[{dim}] distance_metric={_VEC_DISTANCE_METRIC}"
+
+
+def _table_uses_cosine(conn: sqlite3.Connection, table_name: str) -> bool:
+    """True if *table_name* exists and its DDL declares the cosine metric.
+
+    Used to detect old-format (L2-default) vec tables that need rebuilding.
+    """
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = ? AND type='table'",
+        (table_name,),
+    ).fetchone()
+    if not row or not row[0]:
+        return False
+    return "distance_metric=cosine" in row[0].replace(" ", "").replace("'", "")
+
+
+def _normalize_for_cosine(emb):
+    """L2-normalize *emb* so cosine distance is meaningful, or return None.
+
+    Cosine distance is only well-defined once vectors are unit-normalized.
+    Edge-tier (potion) vectors already arrive unit-norm, but Base/Pro (Qwen3
+    @ truncate_dim=256, Matryoshka) vectors do NOT — truncating a normalized
+    1024d vector to 256d leaves ``||v|| ~= 0.55``. Normalizing at write time
+    keeps cosine ordering correct across every tier.
+
+    A zero (or non-finite) vector has undefined cosine and would poison the
+    cosine table with NaN distances (sqlite-vec returns ``distance=NULL`` for
+    such rows). Those are skipped by returning ``None`` (C2-8 guard).
+    """
+    arr = np.asarray(emb, dtype=np.float32)
+    if not np.all(np.isfinite(arr)):
+        return None
+    norm = float(np.linalg.norm(arr))
+    if norm < 1e-12:
+        return None
+    return arr / norm
+
+
+# ---------------------------------------------------------------------------
 # Table initialization
 # ---------------------------------------------------------------------------
 
@@ -505,13 +562,17 @@ def init_vec_table(
     dim = _embedding_dim
     conn.execute(
         f"CREATE VIRTUAL TABLE IF NOT EXISTS {vec_name} "
-        f"USING vec0(embedding float[{dim}])"
+        f"USING vec0({_vec0_column_decl(dim)})"
     )
     conn.execute(
         f"CREATE VIRTUAL TABLE IF NOT EXISTS {sep_name} "
-        f"USING vec0(embedding float[{dim}])"
+        f"USING vec0({_vec0_column_decl(dim)})"
     )
     conn.commit()
+
+    # Upgrade any pre-#631 L2-default tables to cosine in place. Idempotent:
+    # a no-op once the active tables already declare distance_metric=cosine.
+    migrate_to_cosine_metric(conn)
 
 
 # ---------------------------------------------------------------------------
@@ -630,12 +691,25 @@ def build_vectors(
 
             embeddings = _encode_with_mps_fallback(model, texts, show_progress_bar=False)
 
-            conn.executemany(
-                f"INSERT INTO {tbl}(rowid, embedding) VALUES (?, ?)",
-                [(mid, serialize_f32(emb)) for mid, emb in zip(ids, embeddings)],
-            )
+            rows_to_insert = []
+            for mid, emb in zip(ids, embeddings):
+                normed = _normalize_for_cosine(emb)
+                if normed is None:
+                    # Zero/NaN vector: undefined cosine — skip so it can't
+                    # poison the cosine table with NULL distances (C2-8).
+                    logger.warning(
+                        "Skipping message %s: zero-norm/non-finite embedding "
+                        "(undefined cosine)", mid,
+                    )
+                    continue
+                rows_to_insert.append((mid, serialize_f32(normed)))
+            if rows_to_insert:
+                conn.executemany(
+                    f"INSERT INTO {tbl}(rowid, embedding) VALUES (?, ?)",
+                    rows_to_insert,
+                )
 
-            total += len(batch)
+            total += len(rows_to_insert)
             batches_since_commit += 1
             del embeddings
             _flush_mps_cache()
@@ -884,12 +958,23 @@ def build_separation_vectors(
 
             embeddings = _encode_with_mps_fallback(model, texts, show_progress_bar=False)
 
-            conn.executemany(
-                f"INSERT INTO {tbl}(rowid, embedding) VALUES (?, ?)",
-                [(mid, serialize_f32(emb)) for mid, emb in zip(ids, embeddings)],
-            )
+            rows_to_insert = []
+            for mid, emb in zip(ids, embeddings):
+                normed = _normalize_for_cosine(emb)
+                if normed is None:
+                    logger.warning(
+                        "Skipping separation vector for message %s: "
+                        "zero-norm/non-finite embedding (undefined cosine)", mid,
+                    )
+                    continue
+                rows_to_insert.append((mid, serialize_f32(normed)))
+            if rows_to_insert:
+                conn.executemany(
+                    f"INSERT INTO {tbl}(rowid, embedding) VALUES (?, ?)",
+                    rows_to_insert,
+                )
 
-            total += len(batch)
+            total += len(rows_to_insert)
             del embeddings
             _flush_mps_cache()
 
@@ -921,10 +1006,19 @@ def embed_single(conn: sqlite3.Connection, message_id: int, content: str) -> Non
     """
     model = get_model()
     embedding = _encode_with_mps_fallback(model, [content])[0]  # shape (dim,)
+    normed = _normalize_for_cosine(embedding)
+    if normed is None:
+        # Zero/NaN vector has undefined cosine — skip rather than poison the
+        # cosine table with NULL distances (C2-8).
+        logger.warning(
+            "Skipping message %d: zero-norm/non-finite embedding "
+            "(undefined cosine)", message_id,
+        )
+        return
     vec_tbl = _active_vec_table(conn)
     conn.execute(
         f"INSERT INTO {vec_tbl}(rowid, embedding) VALUES (?, ?)",
-        (message_id, serialize_f32(embedding)),
+        (message_id, serialize_f32(normed)),
     )
 
     try:
@@ -935,10 +1029,18 @@ def embed_single(conn: sqlite3.Connection, message_id: int, content: str) -> Non
         if row:
             sep_text = _build_sep_text(row[0], row[1], row[2], content)
             sep_embedding = _encode_with_mps_fallback(model, [sep_text])[0]
+            sep_normed = _normalize_for_cosine(sep_embedding)
+            if sep_normed is None:
+                logger.warning(
+                    "Skipping separation vector for message %d: "
+                    "zero-norm/non-finite embedding (undefined cosine)",
+                    message_id,
+                )
+                return
             sep_tbl = _active_sep_table(conn)
             conn.execute(
                 f"INSERT INTO {sep_tbl}(rowid, embedding) VALUES (?, ?)",
-                (message_id, serialize_f32(sep_embedding)),
+                (message_id, serialize_f32(sep_normed)),
             )
     except Exception:
         logger.warning("Failed to create separation vector for message %d", message_id, exc_info=True)
@@ -1031,6 +1133,170 @@ def search_vector_separation(
 
 
 # ---------------------------------------------------------------------------
+# Cosine-metric migration (issue #631)
+# ---------------------------------------------------------------------------
+
+# Every vec0 table that might hold user vectors. Tier-specific names cover the
+# tier-switch cache; the generic names cover legacy / pre-tier-switch DBs.
+_KNOWN_VEC_TABLES = (
+    "vec_messages",
+    "vec_messages_sep",
+    "vec_messages_edge",
+    "vec_messages_sep_edge",
+    "vec_messages_basepro",
+    "vec_messages_sep_basepro",
+)
+
+
+def _rebuild_table_as_cosine(conn: sqlite3.Connection, table_name: str) -> int:
+    """Rebuild one L2-default vec0 table in place as a cosine table.
+
+    Re-inserts the EXISTING stored vectors (L2-normalized so cosine is
+    meaningful) — no re-embedding. Zero-norm / non-finite vectors are dropped
+    so they can't poison the cosine table with NULL distances (C2-8).
+
+    vec0 virtual tables cannot be renamed (``ALTER TABLE RENAME`` leaves their
+    shadow ``*_rowids`` / ``*_chunks`` tables behind), so the rebuild recreates
+    the table under its original name. Crash-safety comes from a *plain* SQLite
+    staging table ``{table}_cos_stage`` that holds the normalized vectors before
+    the vec0 table is dropped: if the process dies mid-rebuild, the next run
+    detects the staging table and finishes the swap rather than losing data.
+
+    Returns the number of vectors carried over.
+    """
+    dim = _detect_existing_vec_dim(conn, table_name)
+    if dim is None:
+        return 0
+
+    stage = f"{table_name}_cos_stage"
+    fmt = f"{dim}f"
+
+    # Phase 1: copy normalized vectors into a durable plain staging table.
+    conn.execute(f"DROP TABLE IF EXISTS {stage}")
+    conn.execute(
+        f"CREATE TABLE {stage} (rowid INTEGER PRIMARY KEY, embedding BLOB)"
+    )
+    rows = conn.execute(
+        f"SELECT rowid, embedding FROM {table_name}"
+    ).fetchall()
+    skipped = 0
+    staged = 0
+    for rowid, blob in rows:
+        if blob is None or len(blob) != dim * 4:
+            skipped += 1
+            continue
+        normed = _normalize_for_cosine(struct.unpack(fmt, blob))
+        if normed is None:
+            skipped += 1
+            continue
+        conn.execute(
+            f"INSERT INTO {stage}(rowid, embedding) VALUES (?, ?)",
+            (rowid, serialize_f32(normed)),
+        )
+        staged += 1
+    conn.commit()  # staging durable before we touch the original
+
+    # Phase 2: replace the vec0 table with a cosine one and refill it.
+    carried = _finish_cosine_swap(conn, table_name, dim)
+
+    if skipped:
+        logger.warning(
+            "Cosine migration for %s dropped %d zero-norm/invalid vector(s)",
+            table_name, skipped,
+        )
+    logger.info(
+        "Rebuilt %s as cosine (%d vectors carried over)", table_name, carried
+    )
+    return carried
+
+
+def _finish_cosine_swap(
+    conn: sqlite3.Connection, table_name: str, dim: int
+) -> int:
+    """Drop the old vec0 table, recreate it as cosine, refill from staging.
+
+    Assumes ``{table_name}_cos_stage`` exists and is populated. Idempotent /
+    resumable: safe to call after a crash that left the staging table behind.
+    """
+    stage = f"{table_name}_cos_stage"
+    conn.execute(f"DROP TABLE IF EXISTS {table_name}")
+    conn.execute(
+        f"CREATE VIRTUAL TABLE {table_name} USING vec0({_vec0_column_decl(dim)})"
+    )
+    carried = 0
+    staged_rows = conn.execute(
+        f"SELECT rowid, embedding FROM {stage}"
+    ).fetchall()
+    if staged_rows:
+        conn.executemany(
+            f"INSERT INTO {table_name}(rowid, embedding) VALUES (?, ?)",
+            staged_rows,
+        )
+        carried = len(staged_rows)
+    conn.execute(f"DROP TABLE IF EXISTS {stage}")
+    return carried
+
+
+def migrate_to_cosine_metric(conn: sqlite3.Connection) -> bool:
+    """Upgrade any old-format (L2-default) vec0 tables to cosine in place.
+
+    Detects tables whose DDL lacks ``distance_metric=cosine`` and rebuilds each
+    one, re-inserting the existing stored vectors (L2-normalized). This is the
+    #631 fix for existing user DBs: the vectors are unchanged, only the table's
+    distance function and per-row norm change so that ``cos_sim = 1 - distance``
+    becomes numerically honest.
+
+    Idempotent: a no-op once every present table already declares cosine.
+    Returns True if at least one table was rebuilt.
+    """
+    # Ensure the extension is loaded (callers from engine.open already load it,
+    # but init_vec_table is the common entry and loads it just above).
+    try:
+        import sqlite_vec
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+    except Exception:
+        # If the extension cannot load, there are no vec0 tables to migrate.
+        return False
+
+    migrated = False
+    for table in _KNOWN_VEC_TABLES:
+        stage = f"{table}_cos_stage"
+        has_stage = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE name = ? AND type='table'",
+            (stage,),
+        ).fetchone()
+        if has_stage:
+            # A prior run was interrupted between staging and swap. The staging
+            # table holds the already-normalized vectors — finish the swap.
+            dim = (
+                _detect_existing_vec_dim(conn, table)
+                or _detect_existing_vec_dim(conn, stage)
+                or _embedding_dim
+            )
+            _finish_cosine_swap(conn, table, dim)
+            conn.commit()
+            migrated = True
+            continue
+
+        exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE name = ? AND type='table'",
+            (table,),
+        ).fetchone()
+        if not exists:
+            continue
+        if _table_uses_cosine(conn, table):
+            continue
+        _rebuild_table_as_cosine(conn, table)
+        migrated = True
+
+    if migrated:
+        conn.commit()
+    return migrated
+
+
+# ---------------------------------------------------------------------------
 # Legacy migration (generic → tier-specific table names)
 # ---------------------------------------------------------------------------
 
@@ -1086,11 +1352,11 @@ def migrate_legacy_vec_tables(conn: sqlite3.Connection) -> bool:
 
     conn.execute(
         f"CREATE VIRTUAL TABLE IF NOT EXISTS {new_vec} "
-        f"USING vec0(embedding float[{dim}])"
+        f"USING vec0({_vec0_column_decl(dim)})"
     )
     conn.execute(
         f"CREATE VIRTUAL TABLE IF NOT EXISTS {new_sep} "
-        f"USING vec0(embedding float[{dim}])"
+        f"USING vec0({_vec0_column_decl(dim)})"
     )
 
     conn.execute(f"INSERT INTO {new_vec} SELECT * FROM vec_messages")


### PR DESCRIPTION
Fixes #631.

## The bug (M-03, P0)
All `vec0` tables were created without `distance_metric=cosine`, so sqlite-vec used its **L2 default**. The code then computed `cos_sim = 1 - distance` (`vector_search.py:793`) and treated it as cosine. That transform is numerically wrong: a wrong mapping even for unit vectors, and outright wrong for non-unit vectors. Ranking survived (L2 is rank-monotonic for unit vectors), which is why benchmarks never caught it, but reported similarity scores were dishonest.

## STEP 0 — Normalization finding (verified empirically, HF_HUB_OFFLINE)
Embeddings are produced by `model.encode(...)` **without** `normalize_embeddings=True`, so whether stored vectors are unit-norm depends on the model:

- **Edge (Model2Vec `potion-base-8M`):** already unit-normalized — measured `‖v‖ = 1.0`.
- **Base / Pro (`Qwen3-Embedding-0.6B`, `truncate_dim=256`, Matryoshka):** **NOT unit-normalized** — measured `‖v‖ ≈ 0.55`. The model's `2_Normalize` module normalizes the full 1024-d vector, then SentenceTransformer truncates to 256-d, which destroys unit norm.

Implication: for Edge, switching to cosine does **not** change ranking (only makes absolute scores honest). For Base/Pro, flipping the metric on un-normalized vectors **would** change ranking. Per the issue's guidance, the minimal correct path is to **normalize vectors at write time** (and in the migration) so cosine is meaningful and ordering is preserved across every tier. Query vectors are left as-is: sqlite-vec's cosine distance is per-vector scale-invariant (verified: a 5×-scaled query yields the same distance), so only the stored side needs normalizing.

## The fix (`truememory/vector_search.py` only)
1. **Declare cosine** on every `vec0` table (search + separation; fresh tables in `init_vec_table` and the legacy-rename path) via `_vec0_column_decl(dim)`.
   - sqlite-vec **0.1.9 syntax note:** `distance_metric` is a **column-level** option (space-separated *inside* the column declaration): `vec0(embedding float[256] distance_metric=cosine)`. The comma-separated table-option form `vec0(embedding float[256], distance_metric=cosine)` raises `Unknown table option` on 0.1.9.
2. **Normalize at write time** in `build_vectors`, `build_separation_vectors`, and `embed_single` via `_normalize_for_cosine()`.
3. **Migration** `migrate_to_cosine_metric()`: detects old L2 tables by inspecting their DDL (`SELECT sql FROM sqlite_master` → check for `distance_metric=cosine`) and rebuilds each as cosine, **re-inserting the existing stored vectors (normalized) — no re-embedding**. Crash-safety: normalized vectors are first copied into a durable *plain* SQLite staging table; only then is the `vec0` table dropped and recreated (vec0 tables can't be `ALTER ... RENAME`d — that strips their shadow tables). If interrupted mid-swap, the next run detects the staging table and finishes. Hooked from `init_vec_table` (idempotent), so **no `engine.py` change was needed**.
4. **Zero/NaN guard (C2-8):** a zero vector has undefined cosine and makes sqlite-vec return `distance=NULL`. `_normalize_for_cosine()` returns `None` for zero-norm/non-finite vectors; the write paths skip them and the migration drops them.

## Tests — `tests/test_issue_631_cosine_metric.py` (gated on `requires_sqlite_ext`)
- (a) new vec tables declare cosine (asserted via `sqlite_master.sql`);
- (b) for unit vectors, `1 - distance` equals **true** cosine (orthogonal → 0.0, identical → 1.0, 36.87° pair → 0.8 — contrasting the old wrong value);
- (c) migration upgrades an L2 table to cosine, preserving ids and normalizing vectors ([3,4] → [0.6,0.8]); idempotent; resumes from a leftover staging table;
- (d) zero vectors don't crash the migration or `build_vectors` and don't produce NULL distances.

## Test results
Locally (sqlite-vec **does** load here): **9/9 new tests pass**; `test_issue_483_vec_migration`, `test_issue_590_build_vectors_batch`, `test_issue_460_warm_search`, `test_issue_465_qwen3_nan_async`, `test_issue_459_mps_oom` all green. End-to-end (mocked model) confirms the engine's active table is cosine and `search_vector_raw` self-match returns 1.0. `ruff check truememory/ tests/` passes. The 2 `test_upgrade_path.py` failures are a **pre-existing** py3.14 env-only `UnicodeDecodeError` (fail identically on the base branch). Where sqlite-vec can't load, the new tests skip cleanly via the repo's `requires_sqlite_ext` marker (CI on ubuntu runs them).

## Scope
Does **not** touch dedup logic or the 0.92 threshold (#632). Note: once scores are true-cosine, dedup at 0.92 will begin catching real paraphrases — intended.