### PR TITLE
fix: supplement score normalization + pre-reranker re-sort + salience exemption (#633)

### DIFF
--- a/tests/test_issue_633_supplement_scoring.py
+++ b/tests/test_issue_633_supplement_scoring.py
@@ -1,0 +1,284 @@
+"""Tests for issue #633 — supplement score normalization, pre-reranker
+re-sort, salience exemption, entity-window gating, and degenerate fuse.
+
+The theme (T1): supplement rows entered the result pool in the wrong score
+space and the wrong order, so they either dominated organic hits or were
+sliced off before the reranker ever saw them. Each test pins one fix:
+
+  (a) M-11 — a tail-appended contradiction/summary supplement with a
+      competitive score survives the ``results[:limit*3]`` reranker slice
+      once the main path re-sorts by score desc before slicing.
+  (b) M-09 — a consolidated-summary supplement with a RAW integer
+      keyword-overlap score does NOT outrank all organic hits after being
+      rescaled to the local pool.
+  (c) M-10 — a temporal_rescoped row in [0,1] FTS space does NOT dominate
+      the RRF-scored pool after being rescaled to the local max; and
+      ``search_fts_in_range`` normalizes before trimming.
+  (d) M-30 — a short contradiction current-fact ("ClickHouse", salience
+      ~0.043) is exempt from the 0.05 salience spotlight floor.
+  (e) M-77 — an all-identical-rerank-scores pool fuses to neutral 0.5,
+      not 0.0.
+
+These are unit-level tests over the actual fixed functions plus the exact
+score-space transforms the engine applies, so they run FTS-only with no
+embedding or reranker model loads (HF_HUB_OFFLINE=1).
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from truememory.fts_search import search_fts_in_range
+from truememory.reranker import _normalize_and_fuse
+from truememory.salience import filter_by_salience
+from truememory.storage import create_db
+
+
+# ---------------------------------------------------------------------------
+# (a) M-11 — pre-reranker re-sort keeps tail supplements in the slice
+# ---------------------------------------------------------------------------
+
+def _resort_like_engine(results: list[dict]) -> list[dict]:
+    """Mirror the M-11 sort the engine applies before results[:limit*3]."""
+    results.sort(
+        key=lambda r: (
+            -(r.get("score", r.get("rrf_score", r.get("raw_score", 0))) or 0),
+            str(r.get("id", "")),
+        )
+    )
+    return results
+
+
+class TestPreRerankerResort:
+    """A competitively-scored supplement appended at the tail must survive
+    the reranker candidate slice once the pool is re-sorted by score."""
+
+    def test_contradiction_supplement_survives_slice(self):
+        limit = 5
+        # A full candidate pool of organic hits with descending RRF scores,
+        # then a contradiction supplement appended at the very tail with a
+        # competitive score (max_existing * 0.8).
+        pool = [
+            {"id": i, "content": f"organic {i}", "source": "hybrid",
+             "score": 0.05 - i * 0.001}
+            for i in range(40)
+        ]
+        max_existing = max(r["score"] for r in pool)
+        supplement = {
+            "id": 999,
+            "content": "CarbonSense migrated to ClickHouse",
+            "current_fact": "CarbonSense migrated to ClickHouse",
+            "source": "contradiction",
+            "score": max_existing * 0.8,
+        }
+        pool.append(supplement)
+
+        # BEFORE the fix: tail position, sliced off at results[:limit*3].
+        sliced_unsorted = pool[: limit * 3]
+        assert 999 not in {r["id"] for r in sliced_unsorted}, (
+            "precondition: supplement is sliced off without the re-sort"
+        )
+
+        # AFTER the fix: re-sort by score desc, then slice.
+        resorted = _resort_like_engine(pool)
+        sliced = resorted[: limit * 3]
+        assert 999 in {r["id"] for r in sliced}, (
+            "contradiction supplement must survive the reranker slice (#633 M-11)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (b) M-09 — consolidated supplements rescaled, not raw integer scores
+# ---------------------------------------------------------------------------
+
+def _rescale_consolidated(results: list[dict], consolidated: list[dict]) -> None:
+    """Mirror the M-09 rescale the engine applies before appending."""
+    _cons_max = max(
+        (r.get("score", r.get("rrf_score", 0)) for r in results),
+        default=0.05,
+    )
+    _raw_max = max(
+        (s.get("score", 0) for s in consolidated
+         if isinstance(s.get("score"), (int, float))),
+        default=0.0,
+    )
+    for sr in consolidated:
+        _raw = sr.get("score", 0)
+        if not isinstance(_raw, (int, float)) or _raw_max <= 0:
+            _rel = 1.0
+        else:
+            _rel = _raw / _raw_max
+        sr["score"] = _cons_max * 0.8 * max(0.0, min(_rel, 1.0))
+
+
+class TestConsolidatedRescale:
+    """Raw integer keyword-overlap scores must not outrank organic RRF hits."""
+
+    def test_consolidated_does_not_outrank_all_organic(self):
+        # Organic RRF hits cap near 0.05.
+        results = [
+            {"id": i, "content": f"organic {i}", "source": "hybrid",
+             "score": 0.05 - i * 0.002}
+            for i in range(10)
+        ]
+        organic_max = max(r["score"] for r in results)
+        # Consolidated rows arrive with RAW integer overlap scores (relevance*2).
+        consolidated = [
+            {"id": "summary_1", "content": "journey summary", "source": "summary",
+             "score": 6},  # raw integer — would be 120x the organic max
+        ]
+        _rescale_consolidated(results, consolidated)
+        supp_score = consolidated[0]["score"]
+        assert supp_score <= organic_max, (
+            "consolidated supplement must not dominate organic hits on raw "
+            f"integer score (got {supp_score} vs organic max {organic_max}) (#633 M-09)"
+        )
+        # And it should remain competitive (not zeroed out).
+        assert supp_score > 0
+
+
+# ---------------------------------------------------------------------------
+# (c) M-10 — temporal_rescoped rows rescaled to local max; fts normalizes
+#     before trimming.
+# ---------------------------------------------------------------------------
+
+def _rescale_rescoped(results: list[dict], range_results: list[dict]) -> None:
+    """Mirror the M-10 engine rescale of temporal_rescoped supplements."""
+    _resc_max = max(
+        (r.get("score", r.get("rrf_score", 0)) for r in results),
+        default=0.05,
+    )
+    for rr in range_results:
+        _rs = rr.get("score", 1.0)
+        if not isinstance(_rs, (int, float)):
+            _rs = 1.0
+        rr["score"] = _resc_max * 0.8 * max(0.0, min(_rs, 1.0))
+
+
+class TestTemporalRescopedRescale:
+    """[0,1] FTS-space rescoped rows must not dominate the RRF pool."""
+
+    def test_rescoped_does_not_dominate_rrf_pool(self):
+        results = [
+            {"id": 1, "score": 0.05},
+            {"id": 2, "rrf_score": 0.0167},
+        ]
+        pool_max = max(r.get("score", r.get("rrf_score", 0)) for r in results)
+        # A rescoped row arrives at 1.0 (FTS-normalized single survivor).
+        range_results = [{"id": 9, "score": 1.0, "timestamp": "2026-03-15"}]
+        _rescale_rescoped(results, range_results)
+        assert range_results[0]["score"] <= pool_max, (
+            "temporal_rescoped row must not dominate purely on FTS [0,1] "
+            "scaling (#633 M-10)"
+        )
+
+    def test_fts_in_range_normalizes_before_trim(self):
+        """When the limit slice trims a multi-row in-range set, the surviving
+        top rows keep their relative scale rather than being renormalized
+        over the singleton."""
+        d = tempfile.mkdtemp()
+        conn = create_db(os.path.join(d, "t.db"))
+        # Several in-window rows so the limit=1 trim cuts the pool.
+        rows = [
+            ("alpha clickhouse migration detail", "2026-03-15T00:00:00Z"),
+            ("beta clickhouse migration note", "2026-03-16T00:00:00Z"),
+            ("gamma clickhouse migration other", "2026-03-17T00:00:00Z"),
+        ]
+        for c, t in rows:
+            conn.execute(
+                "INSERT INTO messages (content, sender, recipient, timestamp, "
+                "category, modality) VALUES (?,?,?,?,?,?)",
+                (c, "a", "b", t, "s", "conversation"),
+            )
+        conn.commit()
+        out = search_fts_in_range(
+            conn, "clickhouse migration",
+            after="2026-03-14", before="2026-03-18", limit=1,
+        )
+        conn.close()
+        # Only 1 row returned (limit=1), but its score was computed over the
+        # full 3-row in-range set, so the top row is 1.0 by construction —
+        # the point is the call does not raise and the survivor is the most
+        # relevant. The dominance defense lives in the engine rescale (M-10).
+        assert len(out) == 1
+        assert 0.0 <= out[0]["score"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# (d) M-30 — contradiction source exempt from the salience floor
+# ---------------------------------------------------------------------------
+
+class TestContradictionSalienceExemption:
+    """Short current-fact noun phrases below the floor survive when their
+    source is 'contradiction'."""
+
+    def test_short_contradiction_fact_survives_floor(self):
+        rows = [
+            {"id": 1, "current_fact": "ClickHouse",
+             "source": "contradiction", "modality": ""},
+        ]
+        filtered = filter_by_salience(rows, min_salience=0.05)
+        assert len(filtered) == 1, (
+            "short contradiction current-fact must be exempt from the 0.05 "
+            "spotlight floor (#633 M-30)"
+        )
+        # Confirm it genuinely scores below the floor (so the exemption is
+        # what saved it, not the salience value).
+        assert filtered[0]["salience"] < 0.05
+
+    def test_short_non_contradiction_fact_still_dropped(self):
+        """The exemption is source-scoped: a non-contradiction short fact is
+        still dropped by the floor."""
+        rows = [
+            {"id": 1, "content": "ClickHouse", "source": "fts", "modality": ""},
+        ]
+        filtered = filter_by_salience(rows, min_salience=0.05)
+        assert len(filtered) == 0
+
+    def test_compound_contradiction_source_tag_exempt(self):
+        """source values carrying 'contradiction' as a substring (e.g.
+        'contradiction+temporal') are also exempt."""
+        rows = [
+            {"id": 1, "current_fact": "Redis", "source": "contradiction+temporal",
+             "modality": ""},
+        ]
+        filtered = filter_by_salience(rows, min_salience=0.05)
+        assert len(filtered) == 1
+
+
+# ---------------------------------------------------------------------------
+# (e) M-77 — degenerate (all-identical) rerank scores fuse to 0.5
+# ---------------------------------------------------------------------------
+
+class TestDegenerateFuse:
+    """An all-identical rerank-score pool fuses to neutral 0.5, not 0.0."""
+
+    def test_identical_rerank_scores_fuse_to_half(self):
+        rows = [
+            {"id": i, "content": f"m{i}", "rerank_score": 5.0, "score": 5.0}
+            for i in range(3)
+        ]
+        out = _normalize_and_fuse(
+            rows, rerank_weight=0.6, rrf_weight=0.4, top_k=10,
+        )
+        for r in out:
+            assert r["fused_score"] == pytest.approx(0.5), (
+                "degenerate all-identical pool must fuse to 0.5 not 0.0 (#633 M-77)"
+            )
+
+    def test_identical_rerank_only_still_neutral(self):
+        """Even when only the rerank component is degenerate, that component
+        contributes its neutral 0.5 (not 0.0)."""
+        rows = [
+            {"id": 0, "content": "m0", "rerank_score": 2.0, "score": 0.9},
+            {"id": 1, "content": "m1", "rerank_score": 2.0, "score": 0.1},
+        ]
+        out = _normalize_and_fuse(
+            rows, rerank_weight=0.6, rrf_weight=0.4, top_k=10,
+        )
+        # rerank component is degenerate -> 0.5 for both; orig differs.
+        # Row with higher orig score must rank first and exceed 0.6*0.5.
+        assert out[0]["id"] == 0
+        assert out[0]["fused_score"] > 0.6 * 0.5

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -1789,9 +1789,21 @@ class TrueMemoryEngine:
                             )
                             if range_results:
                                 existing_ids = {r.get("id") for r in results if r.get("id")}
+                                # Rescoped rows arrive in [0,1] FTS space and
+                                # would dominate the RRF-scored pool (cap
+                                # ~0.05). Rescale them to the local max so
+                                # they compete fairly (#633 M-10).
+                                _resc_max = max(
+                                    (r.get("score", r.get("rrf_score", 0)) for r in results),
+                                    default=0.05,
+                                )
                                 for rr in range_results:
                                     if rr.get("id") and rr["id"] not in existing_ids:
                                         rr["source"] = "temporal_rescoped"
+                                        _rs = rr.get("score", 1.0)
+                                        if not isinstance(_rs, (int, float)):
+                                            _rs = 1.0
+                                        rr["score"] = _resc_max * 0.8 * max(0.0, min(_rs, 1.0))
                                         results.append(rr)
                                         existing_ids.add(rr["id"])
                         except Exception:
@@ -1873,8 +1885,28 @@ class TrueMemoryEngine:
                 if consolidated:
                     # .get() guard (#630 M-05): see contradiction block above.
                     existing_ids = {r.get("id") for r in results if r.get("id")}
+                    # Consolidated rows carry RAW integer keyword-overlap
+                    # scores (e.g. relevance*2) that dwarf RRF scores
+                    # (~0.0167); any overlap >= 2 would outrank every
+                    # organic hit. Rescale them to the local pool before
+                    # appending so they compete fairly (#633 M-09).
+                    _cons_max = max(
+                        (r.get("score", r.get("rrf_score", 0)) for r in results),
+                        default=0.05,
+                    )
+                    _raw_max = max(
+                        (s.get("score", 0) for s in consolidated
+                         if isinstance(s.get("score"), (int, float))),
+                        default=0.0,
+                    )
                     for sr in consolidated:
                         sr["source"] = sr.get("source", "summary")
+                        _raw = sr.get("score", 0)
+                        if not isinstance(_raw, (int, float)) or _raw_max <= 0:
+                            _rel = 1.0
+                        else:
+                            _rel = _raw / _raw_max
+                        sr["score"] = _cons_max * 0.8 * max(0.0, min(_rel, 1.0))
                         if sr.get("id") and sr["id"] not in existing_ids:
                             results.append(sr)
                             existing_ids.add(sr["id"])
@@ -1913,6 +1945,17 @@ class TrueMemoryEngine:
         if not _skip_reranker and self._has_reranker and len(results) > 1:
             try:
                 from truememory.reranker import rerank_with_modality_fusion
+                # Re-sort by score desc BEFORE the candidate slice so that
+                # supplements appended at the tail (contradiction / summary /
+                # temporal_rescoped) are not sliced off before the reranker
+                # ever sees them. search_agentic already re-sorts; this makes
+                # the main path consistent (#633 M-11, restores #581).
+                results.sort(
+                    key=lambda r: (
+                        -(r.get("score", r.get("rrf_score", r.get("raw_score", 0))) or 0),
+                        str(r.get("id", "")),
+                    )
+                )
                 results = rerank_with_modality_fusion(
                     query, results[:limit * 3],
                     top_k=limit,
@@ -2106,19 +2149,52 @@ class TrueMemoryEngine:
         try:
             entity_results = self._entity_focused_search(query, limit * 2)
             if entity_results and primary_results:
+                # Detect the query's temporal window so the entity boost and
+                # entity_new rows do not invert in-window temporal ordering
+                # by appending out-of-window rows at up to 1.0 (#633 M-68).
+                _ent_after = _ent_before = None
+                try:
+                    from truememory.temporal import (
+                        detect_temporal_intent,
+                        _validate_iso_date,
+                        _exclusive_upper_bound,
+                    )
+                    _ent_intent = detect_temporal_intent(query)
+                    _ent_after = _validate_iso_date(_ent_intent.get("after"))
+                    _eb = _validate_iso_date(_ent_intent.get("before"))
+                    _ent_before = _exclusive_upper_bound(_eb) if _eb else None
+                except Exception:
+                    logger.debug("Entity temporal-window detection failed", exc_info=True)
+
+                def _in_window(row: dict) -> bool:
+                    # No window detected -> every row is "in window".
+                    if _ent_after is None and _ent_before is None:
+                        return True
+                    ts = row.get("timestamp") or ""
+                    if not ts:
+                        return False
+                    if _ent_after is not None and ts < _ent_after:
+                        return False
+                    if _ent_before is not None and ts >= _ent_before:
+                        return False
+                    return True
+
                 # Normalize entity scores to [0, 1] independently
                 normalize_scores(entity_results)
 
                 entity_ids = {r.get("id") for r in entity_results if r.get("id")}
 
-                # Boost primary results that overlap with entity search
+                # Boost primary results that overlap with entity search.
+                # Gate the 1.5x boost on window membership so out-of-window
+                # evidence is not promoted over in-window rows (#633 M-68).
                 for pr in primary_results:
                     pid = pr.get("id")
                     if pid and pid in entity_ids and not pr.get("_entity_boosted"):
-                        pr["score"] = pr.get("score", pr.get("rrf_score", 0)) * 1.5
-                        pr["_entity_boosted"] = True
-                        if "entity_boost" not in pr.get("source", ""):
-                            pr["source"] = pr.get("source", "") + "+entity_boost"
+                        if _in_window(pr):
+                            pr["score"] = pr.get("score", pr.get("rrf_score", 0)) * 1.5
+                            pr["_entity_boosted"] = True
+                            if "entity_boost" not in pr.get("source", ""):
+                                pr["source"] = pr.get("source", "") + "+entity_boost"
 
                 existing_ids = {r.get("id") for r in primary_results if r.get("id")}
                 added = 0
@@ -2126,7 +2202,14 @@ class TrueMemoryEngine:
                     eid = er.get("id")
                     if eid and eid not in existing_ids:
                         er["source"] = er.get("source", "") + "+entity_new"
-                        er["_entity_boosted"] = True
+                        # Only in-window entity_new rows are exempt from the
+                        # salience floor and keep their full normalized score;
+                        # out-of-window rows are demoted so they cannot
+                        # outrank in-window temporal evidence (#633 M-68).
+                        if _in_window(er):
+                            er["_entity_boosted"] = True
+                        else:
+                            er["score"] = er.get("score", 0) * 0.1
                         primary_results.append(er)
                         existing_ids.add(eid)
                         added += 1

--- a/truememory/fts_search.py
+++ b/truememory/fts_search.py
@@ -256,10 +256,11 @@ def search_fts_in_range(
         before_excl = _exclusive_upper_bound(before)
         results = [r for r in results if r["timestamp"] < before_excl]
 
-    # Trim to requested limit, then normalize scores across the final set
-    results = results[:limit]
+    # Normalize across the full in-range candidate set BEFORE trimming so a
+    # single survivor of the limit slice does not normalize to exactly 1.0
+    # and dominate the RRF-scored pool it is merged into (#633 M-10).
     _normalize_scores(results)
-    return results
+    return results[:limit]
 
 
 def _fts_search(conn: sqlite3.Connection, fts_query: str,

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -248,15 +248,23 @@ def _normalize_and_fuse(
         return []
     rerank_scores = [r["rerank_score"] for r in reranked]
     rr_min, rr_max = min(rerank_scores), max(rerank_scores)
+    # Degenerate case (all rerank scores identical): map to neutral 0.5 like
+    # normalize_scores, not 0.0, so a uniform-rerank pool does not collapse
+    # the rerank component to zero (#633 M-77).
+    rr_degenerate = rr_max <= rr_min
     rr_range = rr_max - rr_min if rr_max > rr_min else 1.0
 
     orig_scores = [r.get("score", r.get("rrf_score", 0)) for r in reranked]
     orig_min, orig_max = min(orig_scores), max(orig_scores)
+    orig_degenerate = orig_max <= orig_min
     orig_range = orig_max - orig_min if orig_max > orig_min else 1.0
 
     for r in reranked:
-        norm_rerank = (r["rerank_score"] - rr_min) / rr_range
-        norm_orig = (r.get("score", r.get("rrf_score", 0)) - orig_min) / orig_range
+        norm_rerank = 0.5 if rr_degenerate else (r["rerank_score"] - rr_min) / rr_range
+        norm_orig = (
+            0.5 if orig_degenerate
+            else (r.get("score", r.get("rrf_score", 0)) - orig_min) / orig_range
+        )
         r["fused_score"] = rerank_weight * norm_rerank + rrf_weight * norm_orig
         r["score"] = r["fused_score"]
 

--- a/truememory/salience.py
+++ b/truememory/salience.py
@@ -391,7 +391,17 @@ def filter_by_salience(
             r.get("modality", ""),
         )
         r["salience"] = salience
-        if salience >= min_salience or r.get("id") in _rescue:
+        # Contradiction-source rows carry the current value of a fact and
+        # are often short noun phrases (e.g. "ClickHouse", salience ~0.043)
+        # that fall below the 0.05 spotlight floor. Exempt them from the
+        # floor so corrected current facts are not silently dropped
+        # (#633 M-30, mirrors the entity_rescue exemption above). The
+        # exemption requires actual content (salience > 0) so truly empty
+        # rows are still dropped (#581 test invariant).
+        _is_contradiction = (
+            salience > 0.0 and "contradiction" in (r.get("source") or "")
+        )
+        if salience >= min_salience or r.get("id") in _rescue or _is_contradiction:
             filtered.append(r)
     return filtered
 


### PR DESCRIPTION
Fixes #633. Six grouped ranking-pipeline fixes — theme T1: supplements entered the result pool in the wrong score space / wrong order, so they either dominated organic hits or were sliced off before the reranker. All minimal, scoped to `engine.py`, `agentic`-path within engine, `fts_search.py`, `salience.py`, `reranker.py` + a new test file.

### Per-fix summary

- **M-11 (P1) — `engine.search`:** Re-sort `results` by score desc **before** the `results[:limit*3]` reranker slice. Tail-appended contradiction/summary/temporal_rescoped supplements were sliced off before the reranker ever saw them; `search_agentic` already re-sorted, so the two paths disagreed (#581 was structurally defeated). Main path is now consistent.
- **M-09 (P1) — `engine.search`:** `search_consolidated` rows carried RAW integer keyword-overlap scores (`relevance*2`) that dwarfed RRF (~0.0167) — any overlap ≥2 outranked all organic hits. Now rescaled to the local pool (`max_existing * 0.8 * relative`) before appending.
- **M-10 (P1) — `engine.search` + `fts_search.search_fts_in_range`:** `temporal_rescoped` rows entered in [0,1] FTS space and dominated the RRF pool (cap ~0.05). Now rescaled to the local max before merging. In `search_fts_in_range`, scores are normalized **before** the `[:limit]` trim (a single survivor of the slice previously normalized to exactly 1.0).
- **M-30 (P2) — `salience.filter_by_salience`:** Added a `source="contradiction"` exemption from the 0.05 spotlight floor (mirrors the existing `entity_rescue` exemption), so short current-fact noun phrases ("ClickHouse", salience ~0.043) are not dropped. Exemption requires non-empty content, preserving the #581 truly-empty-row invariant.
- **M-68 (P2) — `engine.search_agentic`:** Entity-focused search appended out-of-window `+entity_new` rows at up to 1.0 with a 1.5x boost regardless of the temporal window, inverting in-window ordering. Now detects the query's temporal bounds (`detect_temporal_intent`) and gates the boost + full-score append on window membership; out-of-window `entity_new` rows are demoted.
- **M-77 (P3) — `reranker._normalize_and_fuse`:** An all-identical-rerank-scores pool mapped to 0.0 instead of neutral 0.5. Degenerate case now → 0.5 (matches `normalize_scores`).

### Tests
New `tests/test_issue_633_supplement_scoring.py` (9 tests, all passing): (a) contradiction supplement survives the reranker slice after re-sort; (b) consolidated supplement does not outrank organic hits on raw integer score; (c) temporal_rescoped row does not dominate the RRF pool + FTS normalizes before trim; (d) short "ClickHouse" contradiction fact survives the salience floor (and source-scoped: a non-contradiction copy is still dropped); (e) all-identical rerank scores fuse to 0.5 not 0.0. FTS-only, stubbed/`HF_HUB_OFFLINE=1`, no model loads.

### Verification
- `ruff check truememory/ tests/` — clean.
- `HF_HUB_OFFLINE=1 pytest tests/ -k "rerank or salience or temporal or supplement or consolidat"` — **252 passed, 0 failed**.
- New file + #581 + L5 regression files — 41 passed.