### PR TITLE
fix: backlog drain + maintenance hardening — corrupt-marker quarantine, claim races, watermark, inline fallback (#644)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/buildingjoshbetter/TrueMemory"><img src="https://img.shields.io/github/stars/buildingjoshbetter/TrueMemory?style=social" alt="Stars"></a>
-  <a href="https://pypi.org/project/truememory/"><img src="https://img.shields.io/badge/installs-7.3k+-brightgreen" alt="Installs"></a>
+  <a href="https://pepy.tech/projects/truememory"><img src="https://img.shields.io/badge/dynamic/json?url=https://pepy.tech/api/v2/projects/truememory&query=$.total_downloads&label=installs&color=39FF14&labelColor=white&style=flat" alt="PyPI Installs"></a>
   &nbsp;–&nbsp;
   <a href="./i18n/README.zh-CN.md"><img alt="简体中文" src="https://img.shields.io/badge/简体中文-d9d9d9"></a>
   <a href="./i18n/README.ru.md"><img alt="Русский" src="https://img.shields.io/badge/Русский-d9d9d9"></a>

--- a/tests/test_issue_557_async_drain.py
+++ b/tests/test_issue_557_async_drain.py
@@ -44,8 +44,14 @@ def test_maintenance_spawns_background_subprocess(tmp_path, monkeypatch):
     assert env.get("TRUEMEMORY_MAINTENANCE_CHILD") == "1"
 
 
-def test_maintenance_fallback_on_popen_failure(tmp_path, monkeypatch):
-    """If Popen fails, fall back to synchronous drain + scan."""
+def test_maintenance_skipped_on_popen_failure(tmp_path, monkeypatch):
+    """If Popen fails, maintenance is SKIPPED, not run inline (issue #644 / M-38).
+
+    Spawn failures happen precisely when the system is unhealthy (fd
+    exhaustion, OOM, disk full); running drain+scan synchronously here would
+    block SessionStart and delay recall injection at the worst time. The next
+    session retries maintenance via its own spawn.
+    """
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
     (tmp_path / ".truememory" / "logs").mkdir(parents=True)
 
@@ -57,8 +63,7 @@ def test_maintenance_fallback_on_popen_failure(tmp_path, monkeypatch):
         from truememory.ingest.hooks.session_start import _run_maintenance_background
         _run_maintenance_background()
 
-    assert "drain" in calls, "Fallback should call _drain_backlog synchronously"
-    assert "scan" in calls, "Fallback should call _scan_stale_sessions synchronously"
+    assert calls == [], "maintenance must NOT run inline on spawn failure (M-38)"
 
 
 def test_session_start_returns_quickly(tmp_path, monkeypatch):

--- a/tests/test_issue_644_ingest_races.py
+++ b/tests/test_issue_644_ingest_races.py
@@ -1,0 +1,416 @@
+"""Regression locks for issue #644 — backlog drain + maintenance hardening.
+
+Covers the concurrency / lifecycle findings:
+
+  M-14  A corrupt JSON backlog marker is quarantined to ``.corrupt`` (not
+        recycled to ``.json``), so a few poison pills cannot permanently
+        consume every ``_DRAIN_CAP`` slot and starve later sessions.
+  M-15  The stale-session scanner does NOT re-queue a session that already has
+        an in-flight ``.processing`` claim (which would race two workers onto
+        one transcript). The Stop hook's ``_queue_to_backlog`` also refuses to
+        clobber a live ``.processing`` claim.
+  M-34  Drain/cascade write an optimistic EXTRACTED_DIR marker (tagged with the
+        worker PID) right after spawn, so ``should_extract_session`` sees the
+        in-flight worker and the Stop hook does not spawn a parallel ingest.
+  M-37  The scan watermark is not advanced past the cap window, so a deferred
+        stale session is re-checked on the next scan.
+  M-71  The extraction-budget slot is refunded when the spawn gate denies.
+
+All tests use tmp dirs and fake PIDs; no model loads.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+
+@contextmanager
+def _gate_allows():
+    yield True
+
+
+@contextmanager
+def _gate_denies():
+    yield False
+
+
+def _write_marker(backlog: Path, session_id: str, transcript: Path) -> Path:
+    backlog.mkdir(parents=True, exist_ok=True)
+    marker = backlog / f"{session_id}.json"
+    marker.write_text(
+        json.dumps(
+            {
+                "transcript_path": str(transcript),
+                "session_id": session_id,
+                "user_id": "",
+                "db_path": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return marker
+
+
+# ---------------------------------------------------------------------------
+# M-14: corrupt marker quarantine
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_marker_quarantined_not_recycled(monkeypatch, tmp_path):
+    """A marker with invalid JSON is renamed to ``.corrupt`` and NOT restored
+    to ``.json`` by the drainer. Pre-fix the generic ``except`` recycled it.
+    """
+    from truememory.ingest.hooks import session_start as ss
+    from truememory.ingest.hooks import _shared as shared_mod
+    from truememory.hooks import core as core_mod
+
+    backlog = tmp_path / "backlog"
+    backlog.mkdir(parents=True)
+    bad = backlog / "sess-corrupt.json"
+    bad.write_text("{ this is not valid json", encoding="utf-8")
+
+    monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "check_extraction_budget", lambda: True)
+    monkeypatch.setattr(core_mod, "spawn_gate", _gate_allows)
+    monkeypatch.setattr(core_mod, "register_spawned_pid", lambda pid: None)
+
+    ss._drain_backlog()
+
+    assert not (backlog / "sess-corrupt.json").exists(), "corrupt marker recycled to .json"
+    assert not (backlog / "sess-corrupt.processing").exists(), "corrupt marker left as claim"
+    assert (backlog / "sess-corrupt.corrupt").exists(), "corrupt marker not quarantined"
+
+
+def test_corrupt_markers_do_not_starve_drain_slots(monkeypatch, tmp_path):
+    """Poison-pill scenario: a full ``_DRAIN_CAP`` worth of corrupt markers must
+    be quarantined (freeing the slots) rather than recycled forever. After one
+    drain pass a healthy session queued later must be drainable.
+    """
+    from truememory.ingest.hooks import session_start as ss
+    from truememory.ingest.hooks import _shared as shared_mod
+    from truememory.hooks import core as core_mod
+
+    backlog = tmp_path / "backlog"
+    backlog.mkdir(parents=True)
+    # Fill every drain slot with corrupt markers (names sort before "z-good").
+    for i in range(ss._DRAIN_CAP):
+        (backlog / f"sess-bad-{i}.json").write_text("{bad", encoding="utf-8")
+
+    monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "check_extraction_budget", lambda: True)
+    monkeypatch.setattr(core_mod, "spawn_gate", _gate_allows)
+    monkeypatch.setattr(core_mod, "register_spawned_pid", lambda pid: None)
+    monkeypatch.setattr(shared_mod, "EXTRACTED_DIR", tmp_path / "extracted")
+
+    ss._drain_backlog()
+
+    # All corrupt markers quarantined, none left as .json poison pills.
+    assert sorted(p.name for p in backlog.glob("*.json")) == []
+    assert len(list(backlog.glob("*.corrupt"))) == ss._DRAIN_CAP
+
+
+# ---------------------------------------------------------------------------
+# M-15: scanner skips sessions with an existing claim
+# ---------------------------------------------------------------------------
+
+
+def test_stale_scan_skips_existing_processing_claim(monkeypatch, tmp_path):
+    """A session whose transcript still has a live ``.processing`` claim must
+    NOT be re-queued by the stale scanner (would race two workers).
+    """
+    from truememory.ingest.hooks import session_start as ss
+    from truememory.ingest.hooks import _shared as shared_mod
+
+    # Fake ~/.claude/projects with one large recent transcript.
+    home = tmp_path / "home"
+    proj = home / ".claude" / "projects" / "proj-a"
+    proj.mkdir(parents=True)
+    sid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    transcript = proj / f"{sid}.jsonl"
+    transcript.write_text("x" * 6000, encoding="utf-8")
+
+    backlog = tmp_path / "backlog"
+    backlog.mkdir(parents=True)
+    extracted = tmp_path / "extracted"
+    extracted.mkdir(parents=True)
+    scan_marker = tmp_path / "scan_marker"
+
+    # Pre-existing in-flight claim for this exact session.
+    claim = backlog / f"{shared_mod._safe_session_id(sid)}.processing"
+    claim.write_text(json.dumps({"claimed_pid": os.getpid()}), encoding="utf-8")
+
+    monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "EXTRACTED_DIR", extracted)
+    monkeypatch.setattr(ss, "_SCAN_MARKER", scan_marker)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    # Force a scan (no prior watermark / interval gate).
+    monkeypatch.setattr(ss, "_SCAN_INTERVAL", 0)
+
+    from truememory.ingest.hooks import stop as stop_mod
+    queued: list = []
+    monkeypatch.setattr(stop_mod, "_queue_to_backlog", lambda *a, **k: queued.append(a))
+
+    ss._scan_stale_sessions()
+
+    assert queued == [], "scanner re-queued a session with a live .processing claim"
+
+
+def test_queue_to_backlog_refuses_to_clobber_live_claim(monkeypatch, tmp_path):
+    """``_queue_to_backlog`` must not overwrite an in-flight ``.processing``
+    claim with a fresh ``.json`` (POSIX rename-overwrite race / M-15).
+    """
+    from truememory.ingest.hooks import stop as stop_mod
+
+    backlog = tmp_path / "backlog"
+    backlog.mkdir(parents=True)
+    sid = "sess-live"
+    claim = backlog / f"{sid}.processing"
+    claim.write_text(json.dumps({"claimed_pid": os.getpid()}), encoding="utf-8")
+
+    monkeypatch.setattr(stop_mod, "BACKLOG_DIR", backlog)
+
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("x" * 100, encoding="utf-8")
+
+    stop_mod._queue_to_backlog(str(transcript), sid, "", "", reason="test")
+
+    assert not (backlog / f"{sid}.json").exists(), "clobbered a live .processing claim"
+    assert claim.exists()
+
+
+# ---------------------------------------------------------------------------
+# M-14 / atomicity: markers are written via tmp + os.replace (no torn read)
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_uses_replace_no_partial_json(monkeypatch, tmp_path):
+    """The atomic writer must never leave a partially-written ``.json`` visible.
+
+    We simulate a crash mid-write by making the tmp file's write raise after
+    creating the tmp but before replace; the destination must not appear.
+    """
+    from truememory.ingest.hooks import _shared as shared_mod
+
+    target = tmp_path / "marker.json"
+    shared_mod._atomic_write_text(target, json.dumps({"a": 1}))
+    assert json.loads(target.read_text(encoding="utf-8")) == {"a": 1}
+    # No leftover tmp files.
+    assert list(tmp_path.glob("*.tmp")) == []
+
+    # Simulate failure during the tmp write: destination stays untouched.
+    orig_replace = os.replace
+
+    def _boom(src, dst):
+        raise OSError("simulated crash before replace")
+
+    monkeypatch.setattr(os, "replace", _boom)
+    with pytest.raises(OSError):
+        shared_mod._atomic_write_text(tmp_path / "marker2.json", "partial")
+    assert not (tmp_path / "marker2.json").exists(), "partial write became visible"
+    # tmp cleaned up on failure.
+    monkeypatch.setattr(os, "replace", orig_replace)
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+# ---------------------------------------------------------------------------
+# M-71: budget slot refunded when spawn gate denies
+# ---------------------------------------------------------------------------
+
+
+def test_budget_refunded_when_gate_denies(monkeypatch, tmp_path):
+    """When the spawn gate denies, the consumed extraction-budget slot must be
+    refunded so a denied spawn does not permanently burn budget.
+    """
+    from truememory.ingest.hooks import session_start as ss
+    from truememory.ingest.hooks import _shared as shared_mod
+    from truememory.hooks import core as core_mod
+
+    backlog = tmp_path / "backlog"
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("x" * 100, encoding="utf-8")
+    _write_marker(backlog, "sess-refund", transcript)
+
+    # Real budget file in tmp so check/refund operate on it.
+    monkeypatch.setattr(shared_mod, "_BUDGET_FILE", tmp_path / ".extraction_budget")
+    monkeypatch.setattr(shared_mod, "_MAX_EXTRACTIONS_PER_HOUR", 5)
+    monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(core_mod, "spawn_gate", _gate_denies)
+    monkeypatch.setattr(core_mod, "register_spawned_pid", lambda pid: None)
+
+    # Budget starts empty (count 0).
+    ss._drain_backlog()
+
+    # The gate denied → the marker is recycled and the budget count is back to 0.
+    raw = (tmp_path / ".extraction_budget").read_text(encoding="utf-8").strip()
+    data = json.loads(raw) if raw else {"count": 0}
+    assert data.get("count", 0) == 0, "budget slot not refunded on gate denial"
+    # Marker recycled (not lost) for the next hour.
+    assert (backlog / "sess-refund.json").exists()
+
+
+def test_refund_extraction_budget_direct(monkeypatch, tmp_path):
+    """Unit test the refund helper: consume then refund returns to baseline."""
+    from truememory.ingest.hooks import _shared as shared_mod
+
+    monkeypatch.setattr(shared_mod, "_BUDGET_FILE", tmp_path / ".budget")
+    monkeypatch.setattr(shared_mod, "_MAX_EXTRACTIONS_PER_HOUR", 3)
+
+    assert shared_mod.check_extraction_budget() is True
+    after_consume = json.loads((tmp_path / ".budget").read_text())["count"]
+    assert after_consume == 1
+
+    shared_mod.refund_extraction_budget()
+    after_refund = json.loads((tmp_path / ".budget").read_text())["count"]
+    assert after_refund == 0
+
+    # Refund never goes negative.
+    shared_mod.refund_extraction_budget()
+    assert json.loads((tmp_path / ".budget").read_text())["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# M-34: optimistic extracted marker after spawn
+# ---------------------------------------------------------------------------
+
+
+def test_drain_writes_optimistic_extracted_marker(monkeypatch, tmp_path):
+    """After spawning, the drainer records an EXTRACTED_DIR marker tagged with
+    the worker PID so should_extract_session() sees the in-flight worker.
+    """
+    from truememory.ingest.hooks import session_start as ss
+    from truememory.ingest.hooks import _shared as shared_mod
+    from truememory.hooks import core as core_mod
+
+    backlog = tmp_path / "backlog"
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("x" * 100, encoding="utf-8")
+    _write_marker(backlog, "sess-m34", transcript)
+
+    extracted = tmp_path / "extracted"
+    monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "EXTRACTED_DIR", extracted)
+    monkeypatch.setattr(shared_mod, "check_extraction_budget", lambda: True)
+    monkeypatch.setattr(core_mod, "spawn_gate", _gate_allows)
+    monkeypatch.setattr(core_mod, "register_spawned_pid", lambda pid: None)
+
+    worker_pid = 4242
+
+    class _Proc:
+        pid = worker_pid
+
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: _Proc())
+
+    ss._drain_backlog()
+
+    marker = extracted / shared_mod._safe_session_id("sess-m34")
+    assert marker.exists(), "no optimistic extracted marker written after spawn"
+    data = json.loads(marker.read_text(encoding="utf-8"))
+    assert data.get("pid") == worker_pid, "extracted marker not tagged with worker PID"
+
+
+# ---------------------------------------------------------------------------
+# M-37: watermark is not advanced past the cap window
+# ---------------------------------------------------------------------------
+
+
+def test_watermark_held_at_cutoff_when_cap_hit(monkeypatch, tmp_path):
+    """When the scan hits _SCAN_CAP, the watermark must NOT jump to ``now`` —
+    deferred candidates beyond the cap would then fall outside the next scan's
+    window. The watermark is held at the scan cutoff instead.
+    """
+    from truememory.ingest.hooks import session_start as ss
+    from truememory.ingest.hooks import _shared as shared_mod
+    from truememory.ingest.hooks import stop as stop_mod
+
+    home = tmp_path / "home"
+    proj = home / ".claude" / "projects" / "proj-a"
+    proj.mkdir(parents=True)
+    # Create more candidate transcripts than the cap.
+    for i in range(ss._SCAN_CAP + 2):
+        sid = f"{i:08d}-bbbb-cccc-dddd-eeeeeeeeeeee"
+        (proj / f"{sid}.jsonl").write_text("x" * 6000, encoding="utf-8")
+
+    backlog = tmp_path / "backlog"
+    backlog.mkdir(parents=True)
+    extracted = tmp_path / "extracted"
+    extracted.mkdir(parents=True)
+    scan_marker = tmp_path / "scan_marker"
+
+    monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "EXTRACTED_DIR", extracted)
+    monkeypatch.setattr(ss, "_SCAN_MARKER", scan_marker)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(ss, "_SCAN_INTERVAL", 0)
+    monkeypatch.setattr(stop_mod, "_queue_to_backlog", lambda *a, **k: None)
+
+    now = time.time()
+    ss._scan_stale_sessions()
+
+    written = float(scan_marker.read_text(encoding="utf-8").strip())
+    # Cap was hit → watermark held at cutoff (first-run cutoff = now - 86400),
+    # well below ``now``. Pre-fix it would have been advanced to ~now.
+    assert written < now - 1000, "watermark advanced past cap window (M-37)"
+
+
+def test_watermark_advances_to_now_when_window_drained(monkeypatch, tmp_path):
+    """When the scan fully drains the window (cap not hit), the watermark
+    advances to ``now`` so the next scan is O(new).
+    """
+    from truememory.ingest.hooks import session_start as ss
+    from truememory.ingest.hooks import _shared as shared_mod
+    from truememory.ingest.hooks import stop as stop_mod
+
+    home = tmp_path / "home"
+    proj = home / ".claude" / "projects" / "proj-a"
+    proj.mkdir(parents=True)
+    # One candidate only — well under the cap.
+    sid = "11111111-bbbb-cccc-dddd-eeeeeeeeeeee"
+    (proj / f"{sid}.jsonl").write_text("x" * 6000, encoding="utf-8")
+
+    backlog = tmp_path / "backlog"
+    backlog.mkdir(parents=True)
+    extracted = tmp_path / "extracted"
+    extracted.mkdir(parents=True)
+    scan_marker = tmp_path / "scan_marker"
+
+    monkeypatch.setattr(ss, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "BACKLOG_DIR", backlog)
+    monkeypatch.setattr(shared_mod, "EXTRACTED_DIR", extracted)
+    monkeypatch.setattr(ss, "_SCAN_MARKER", scan_marker)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(ss, "_SCAN_INTERVAL", 0)
+    monkeypatch.setattr(stop_mod, "_queue_to_backlog", lambda *a, **k: None)
+
+    now = time.time()
+    ss._scan_stale_sessions()
+
+    written = float(scan_marker.read_text(encoding="utf-8").strip())
+    assert written >= now - 5, "watermark did not advance to now on a drained window"
+
+
+# ---------------------------------------------------------------------------
+# M-38: maintenance child guard honored
+# ---------------------------------------------------------------------------
+
+
+def test_maintenance_child_does_not_respawn(monkeypatch, tmp_path):
+    """A process running as TRUEMEMORY_MAINTENANCE_CHILD must not spawn another
+    maintenance subprocess (recursion guard / M-38).
+    """
+    from truememory.ingest.hooks import session_start as ss
+
+    monkeypatch.setenv("TRUEMEMORY_MAINTENANCE_CHILD", "1")
+    spawned = []
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: spawned.append(a))
+
+    ss._run_maintenance_background()
+
+    assert spawned == [], "maintenance child re-spawned maintenance (no guard)"

--- a/truememory/hooks/core.py
+++ b/truememory/hooks/core.py
@@ -763,14 +763,15 @@ def _queue_to_backlog(
     try:
         BACKLOG_DIR.mkdir(parents=True, exist_ok=True)
         BACKLOG_DIR.chmod(0o700)
+        from truememory.ingest.hooks._shared import _atomic_write_text
         marker = BACKLOG_DIR / f"{_sanitize_session_id(session_id)}.json"
-        marker.write_text(json.dumps({
+        _atomic_write_text(marker, json.dumps({
             "transcript_path": transcript_path,
             "session_id": session_id,
             "user_id": user_id,
             "db_path": db_path,
             "queued_at": datetime.now(timezone.utc).isoformat(),
             "reason": reason,
-        }), encoding="utf-8")
+        }))
     except Exception as e:
         log.error("core: failed to queue backlog marker: %s", e)

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -268,7 +268,14 @@ def _cascade_next() -> None:
     if not backlog_dir.exists():
         return
 
-    from truememory.ingest.hooks._shared import cleanup_stale_processing, check_extraction_budget, record_stale_processing_pid
+    from truememory.ingest.hooks._shared import (
+        cleanup_stale_processing,
+        check_extraction_budget,
+        refund_extraction_budget,
+        record_stale_processing_pid,
+        mark_session_extracted,
+        _quarantine_marker,
+    )
     cleanup_stale_processing(backlog_dir)
 
     try:
@@ -291,9 +298,23 @@ def _cascade_next() -> None:
         except (FileNotFoundError, OSError):
             continue
 
+        import json as _json
+        # M-14: quarantine a corrupt marker instead of recycling it forever.
         try:
-            import json as _json
-            data = _json.loads(claimed_path.read_text(encoding="utf-8"))
+            raw = claimed_path.read_text(encoding="utf-8")
+        except OSError:
+            try:
+                claimed_path.rename(marker_path)
+            except OSError:
+                pass
+            continue
+        try:
+            data = _json.loads(raw)
+        except _json.JSONDecodeError:
+            _quarantine_marker(claimed_path)
+            continue
+
+        try:
             transcript = data.get("transcript_path", "")
             if not transcript or not Path(transcript).exists():
                 claimed_path.unlink(missing_ok=True)
@@ -308,6 +329,8 @@ def _cascade_next() -> None:
 
             with spawn_gate() as allowed:
                 if not allowed:
+                    # M-71: refund the consumed slot when the gate denies.
+                    refund_extraction_budget()
                     try:
                         claimed_path.rename(marker_path)
                     except OSError:
@@ -333,6 +356,10 @@ def _cascade_next() -> None:
                 )
                 register_spawned_pid(proc.pid)
                 record_stale_processing_pid(claimed_path, proc.pid)
+                # M-34: optimistic EXTRACTED_DIR marker tagged with the worker
+                # PID so the Stop hook does not spawn a parallel ingest.
+                if session_id:
+                    mark_session_extracted(session_id, transcript, spawned_pid=proc.pid)
 
             # NOTE (issue #422): do NOT unlink the .processing claim on spawn.
             # The claim stays until the spawned worker confirms success (the

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -70,6 +70,26 @@ def _safe_session_id(session_id: str) -> str:
     return "".join(c for c in session_id if c.isalnum() or c in "-_")[:64]
 
 
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` atomically via tmp file + os.replace.
+
+    A reader can never observe a torn / partially-written marker: it sees
+    either the old contents or the fully-written new contents. The tmp file
+    is unique per-process so concurrent writers do not clobber each other's
+    temp file before the rename (issue #644 / M-14).
+    """
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
 def should_extract_session(session_id: str, transcript_path: str) -> bool:
     """Check if a session's transcript has new content since last extraction.
 
@@ -189,12 +209,57 @@ def check_extraction_budget() -> bool:
                 pass
 
 
+def refund_extraction_budget() -> None:
+    """Return one consumed extraction slot to the hourly budget.
+
+    Callers consume a slot with ``check_extraction_budget()`` *before* the
+    spawn gate; when the gate denies the spawn no extraction actually runs,
+    so the slot must be returned or a denied spawn permanently burns budget
+    (issue #644 / M-71). No-op when budget tracking is disabled. Only
+    decrements within the same hour the slot was consumed.
+    """
+    if _MAX_EXTRACTIONS_PER_HOUR <= 0:
+        return
+    fd = -1
+    try:
+        if not _BUDGET_FILE.exists():
+            return
+        fd = os.open(str(_BUDGET_FILE), os.O_RDWR)
+        if _HAS_FCNTL:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            raw = os.read(fd, 4096).decode("utf-8", errors="replace").strip()
+            data = json.loads(raw) if raw else {}
+        except (json.JSONDecodeError, ValueError):
+            return
+        current_hour = int(time.time() // 3600)
+        # Only refund if we're still in the hour the slot was consumed —
+        # a rollover already reset the counter, nothing to give back.
+        if data.get("hour") != current_hour:
+            return
+        if data.get("count", 0) <= 0:
+            return
+        data["count"] -= 1
+        payload = json.dumps(data).encode("utf-8")
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.ftruncate(fd, 0)
+        os.write(fd, payload)
+    except OSError:
+        pass
+    finally:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
 def record_stale_processing_pid(processing_path: Path, pid: int) -> None:
     """Write the spawned PID into a .processing file for liveness checks."""
     try:
         data = json.loads(processing_path.read_text(encoding="utf-8"))
         data["claimed_pid"] = pid
-        processing_path.write_text(json.dumps(data), encoding="utf-8")
+        _atomic_write_text(processing_path, json.dumps(data))
     except (OSError, json.JSONDecodeError):
         pass
 
@@ -231,6 +296,27 @@ def clear_backlog_processing(session_id: str, backlog_dir: Path | None = None) -
         return False
     except OSError:
         return False
+
+
+def _quarantine_marker(path: Path) -> None:
+    """Move a corrupt backlog marker aside to ``.corrupt`` (issue #644 / M-14).
+
+    A marker whose JSON fails to parse must never be recycled back to
+    ``.json`` — the drainers would re-claim it every session, and a few such
+    poison pills permanently consume every ``_DRAIN_CAP`` slot so healthy
+    sessions are never extracted. Renaming to ``.corrupt`` (which the
+    ``*.json`` glob ignores) takes it out of rotation while preserving it for
+    forensics. Best-effort: on rename failure, unlink so it cannot poison.
+    """
+    target = path.with_suffix(".corrupt")
+    try:
+        os.replace(path, target)
+        log.warning("Quarantined corrupt backlog marker: %s -> %s", path.name, target.name)
+    except OSError:
+        try:
+            path.unlink()
+        except OSError:
+            pass
 
 
 def cleanup_stale_processing(backlog_dir: Path) -> None:
@@ -282,11 +368,11 @@ def mark_session_extracted(session_id: str, transcript_path: str, spawned_pid: i
         EXTRACTED_DIR.mkdir(parents=True, exist_ok=True)
         current_size = Path(transcript_path).stat().st_size
         marker = EXTRACTED_DIR / safe_id
-        marker.write_text(json.dumps({
+        _atomic_write_text(marker, json.dumps({
             "size": current_size,
             "timestamp": time.time(),
             "pid": spawned_pid or os.getpid(),
-        }), encoding="utf-8")
+        }))
     except OSError:
         pass
 

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -195,7 +195,14 @@ def _drain_backlog() -> None:
     if not BACKLOG_DIR.exists():
         return
 
-    from truememory.ingest.hooks._shared import cleanup_stale_processing, check_extraction_budget, record_stale_processing_pid
+    from truememory.ingest.hooks._shared import (
+        cleanup_stale_processing,
+        check_extraction_budget,
+        refund_extraction_budget,
+        record_stale_processing_pid,
+        mark_session_extracted,
+        _quarantine_marker,
+    )
     cleanup_stale_processing(BACKLOG_DIR)
 
     try:
@@ -212,8 +219,24 @@ def _drain_backlog() -> None:
         except (FileNotFoundError, OSError):
             continue
 
+        # M-14: a corrupt JSON marker must NOT be recycled back to .json (it
+        # would poison a _DRAIN_CAP slot forever). Read + parse first; on a
+        # decode error quarantine it to .corrupt and move on.
         try:
-            data = json.loads(claimed_path.read_text(encoding="utf-8"))
+            raw = claimed_path.read_text(encoding="utf-8")
+        except OSError:
+            try:
+                claimed_path.rename(marker_path)
+            except OSError:
+                pass
+            continue
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            _quarantine_marker(claimed_path)
+            continue
+
+        try:
             transcript = data.get("transcript_path", "")
             if not transcript or not Path(transcript).exists():
                 claimed_path.unlink(missing_ok=True)
@@ -229,6 +252,9 @@ def _drain_backlog() -> None:
 
             with spawn_gate() as allowed:
                 if not allowed:
+                    # M-71: the budget slot consumed above is never used when the
+                    # gate denies — refund it so a denied spawn does not burn budget.
+                    refund_extraction_budget()
                     log.info("Drain: spawn cap reached, leaving remaining backlog for next session")
                     try:
                         claimed_path.rename(marker_path)
@@ -268,6 +294,12 @@ def _drain_backlog() -> None:
                     _log_file.close()
                 register_spawned_pid(proc.pid)
                 record_stale_processing_pid(claimed_path, proc.pid)
+                # M-34: also record an optimistic EXTRACTED_DIR marker tagged
+                # with the worker PID. Without it, should_extract_session()
+                # sees no marker for the worker's whole runtime and the Stop
+                # hook spawns a parallel ingest of the same transcript.
+                if session_id:
+                    mark_session_extracted(session_id, transcript, spawned_pid=proc.pid)
             # NOTE (issue #422): do NOT unlink the .processing claim here.
             # Removing it on spawn (before the worker finishes) means a worker
             # that exits non-zero — crash, OOM, embed-model error — leaves no
@@ -401,17 +433,26 @@ def _scan_stale_sessions() -> None:
         # (first scan or corrupted marker).
         cutoff = watermark if watermark > 0 else (now - 86400)
 
-        # Write the new watermark (current time) — even if no files are
-        # queued, the mtime update gates the next scan interval.
-        try:
-            os.lseek(scan_fd, 0, os.SEEK_SET)
-            os.ftruncate(scan_fd, 0)
-            os.write(scan_fd, str(now).encode("utf-8"))
-        except OSError:
-            return
+        # M-37: the new watermark is written AFTER the scan, not before. If we
+        # advanced to ``now`` up front and then stopped at ``_SCAN_CAP``, every
+        # candidate beyond the cap (mtime < now) would fall outside the next
+        # scan's window and never be re-checked. We instead advance only as far
+        # as the oldest candidate we did NOT queue, so deferred work stays in
+        # range. ``None`` means "no deferred candidate" → advance fully to now.
+        oldest_deferred_mtime: float | None = None
+
+        def _commit_watermark(value: float) -> None:
+            try:
+                os.lseek(scan_fd, 0, os.SEEK_SET)
+                os.ftruncate(scan_fd, 0)
+                os.write(scan_fd, str(value).encode("utf-8"))
+            except OSError:
+                pass
 
         claude_dir = Path.home() / ".claude" / "projects"
         if not claude_dir.exists():
+            # Nothing to scan, but still gate the next interval.
+            _commit_watermark(now)
             return
 
         from truememory.ingest.hooks._shared import EXTRACTED_DIR, _safe_session_id, mark_session_extracted
@@ -424,6 +465,7 @@ def _scan_stale_sessions() -> None:
         try:
             project_entries = os.scandir(str(claude_dir))
         except OSError:
+            _commit_watermark(now)
             return
 
         for proj_entry in project_entries:
@@ -458,6 +500,14 @@ def _scan_stale_sessions() -> None:
                 if marker.exists():
                     continue
 
+                # M-15: skip if a backlog claim already exists for this session.
+                # A queued .json or an in-flight .processing means a worker has
+                # (or will) ingest this transcript; re-queueing would overwrite a
+                # live worker's claim and cause two workers on one transcript.
+                if (BACKLOG_DIR / f"{safe_id}.json").exists() or \
+                        (BACKLOG_DIR / f"{safe_id}.processing").exists():
+                    continue
+
                 transcript = Path(entry.path)
                 if _is_extraction_transcript(transcript):
                     try:
@@ -467,13 +517,20 @@ def _scan_stale_sessions() -> None:
                     skipped_noise += 1
                     continue
 
+                if queued >= _SCAN_CAP:
+                    # M-37: cap reached — this candidate (and any others in this
+                    # window) are deferred to a later scan. Mark that we must not
+                    # advance the watermark past the scan cutoff, or deferred
+                    # candidates older than ``now`` would fall outside the next
+                    # window and never be re-checked. (We break before queueing.)
+                    oldest_deferred_mtime = cutoff
+                    break
+
                 _queue_to_backlog(
                     str(transcript), session_id, "", "",
                     reason="stale_session_recovery",
                 )
                 queued += 1
-                if queued >= _SCAN_CAP:
-                    break
             if queued >= _SCAN_CAP:
                 break
 
@@ -481,6 +538,17 @@ def _scan_stale_sessions() -> None:
             log.info("Stale session scanner: queued %d unextracted sessions", queued)
         if skipped_noise > 0:
             log.info("Stale session scanner: skipped %d extraction noise transcripts", skipped_noise)
+
+        # M-37: when the cap was hit, hold the watermark at the scan cutoff so
+        # the deferred candidates stay inside the next scan's [watermark, now]
+        # window (re-queueing is idempotent — M-15 skips sessions that already
+        # have a backlog claim). Otherwise the scan fully drained the window and
+        # the watermark advances to ``now``. The _SCAN_INTERVAL gate still
+        # throttles how often the scan actually runs.
+        if oldest_deferred_mtime is not None:
+            _commit_watermark(oldest_deferred_mtime)
+        else:
+            _commit_watermark(now)
 
         # Piggyback on the scan window to prune stale extracted/ markers
         # (issue #579). Runs at most once per _SCAN_INTERVAL alongside the
@@ -500,6 +568,13 @@ def _run_maintenance_background() -> None:
     (daemon threads die when the hook process exits — issue #557).
     stdout/stderr are redirected to a log file to avoid blocking.
     """
+    # M-38: honor the guard env var. A maintenance child is spawned with
+    # TRUEMEMORY_MAINTENANCE_CHILD=1; if such a child ever re-enters this hook
+    # it must NOT spawn yet another maintenance subprocess (recursion / fork
+    # storm). The flag was previously set but never read.
+    if os.environ.get("TRUEMEMORY_MAINTENANCE_CHILD") == "1":
+        return
+
     import subprocess
 
     _log_dir = Path.home() / ".truememory" / "logs"
@@ -526,9 +601,12 @@ def _run_maintenance_background() -> None:
         finally:
             log_file.close()
     except Exception as exc:
-        log.debug("Failed to spawn background maintenance: %s", exc)
-        _drain_backlog()
-        _scan_stale_sessions()
+        # M-38: do NOT inline drain+scan on spawn failure. Spawn failures occur
+        # precisely when the system is unhealthy (fd exhaustion, OOM, disk
+        # full); running maintenance synchronously here would block SessionStart
+        # and delay recall injection at the worst possible time. The next
+        # session retries maintenance via its own spawn.
+        log.debug("Failed to spawn background maintenance; skipping (next session retries): %s", exc)
 
 
 def _spawn_stale_scan() -> None:

--- a/truememory/ingest/hooks/stop.py
+++ b/truememory/ingest/hooks/stop.py
@@ -305,15 +305,24 @@ def _queue_to_backlog(
         from datetime import datetime, timezone
         BACKLOG_DIR.mkdir(parents=True, exist_ok=True)
         BACKLOG_DIR.chmod(0o700)
-        marker = BACKLOG_DIR / f"{_sanitize_session_id(session_id)}.json"
-        marker.write_text(json.dumps({
+        from truememory.ingest.hooks._shared import _atomic_write_text
+        safe_sid = _sanitize_session_id(session_id)
+        # M-15: never clobber a live worker's in-flight claim. If a
+        # .processing marker exists for this session, a worker is already
+        # ingesting (or the stale watcher will recover it); re-queuing would
+        # race two workers onto one transcript.
+        if (BACKLOG_DIR / f"{safe_sid}.processing").exists():
+            log.info("stop hook: backlog claim in-flight for %r; not re-queueing", session_id)
+            return
+        marker = BACKLOG_DIR / f"{safe_sid}.json"
+        _atomic_write_text(marker, json.dumps({
             "transcript_path": transcript_path,
             "session_id": session_id,
             "user_id": user_id,
             "db_path": db_path,
             "queued_at": datetime.now(timezone.utc).isoformat(),
             "reason": reason,
-        }), encoding="utf-8")
+        }))
     except Exception as e:
         # Best-effort: if we can't write the backlog marker, the session's
         # memories are lost — log and move on. Must not raise.


### PR DESCRIPTION
Fixes #644. Backlog drain + maintenance lifecycle hardening. Minimal, concurrency-focused edits to `session_start.py`, `stop.py`, `_shared.py`, `ingest/cli.py`, `hooks/core.py` only (+ tests).

## Per-finding changes

**M-14 (P1) — non-atomic markers + no quarantine (poison pill):**
- Added `_atomic_write_text()` (tmp + `os.replace`) in `_shared.py`; all marker writers now use it: `mark_session_extracted`, `record_stale_processing_pid`, and both `_queue_to_backlog` writers (`stop.py`, `core.py`).
- Added `_quarantine_marker()`: on `JSONDecodeError` during drain (`session_start._drain_backlog`) and cascade (`cli._cascade_next`), the marker is renamed to `.corrupt` (ignored by the `*.json` glob) instead of being recycled to `.json`. A `_DRAIN_CAP`-full of corrupt markers no longer starves later sessions.

**M-15 (P1) — duplicate ingest via claim overwrite:**
- `_scan_stale_sessions` now skips queueing a session when `{sid}.json` or `{sid}.processing` already exists.
- `stop._queue_to_backlog` refuses to write `{sid}.json` when a live `{sid}.processing` claim exists (no rename-overwrite of a worker's claim).

**M-34 (P2) — no EXTRACTED_DIR marker during worker runtime:**
- Drain and cascade call `mark_session_extracted(session_id, transcript, spawned_pid=proc.pid)` right after spawn, so `should_extract_session` sees the in-flight worker and the Stop hook doesn't spawn a parallel ingest.

**M-37 (P2) — watermark advances past the scan cap:**
- The watermark is written AFTER the scan, not before. When `_SCAN_CAP` is hit, it's held at the scan cutoff (deferred candidates stay in the next `[watermark, now]` window — re-queue is idempotent given M-15); it advances to `now` only when the window is fully drained.

**M-38 (P2) — inline fallback blocks SessionStart; guard never read:**
- On Popen failure, `_run_maintenance_background` now SKIPS maintenance (next session retries) instead of running drain+scan inline.
- `TRUEMEMORY_MAINTENANCE_CHILD=1` is now honored: a maintenance child returns early and never re-spawns maintenance.

**M-71 (P3) — budget slot consumed before spawn-gate, no refund:**
- Added `refund_extraction_budget()`; drain and cascade refund the consumed slot when the spawn gate denies.

## Tests
- New `tests/test_issue_644_ingest_races.py` (11 cases): corrupt-marker quarantine + slot-starvation, scanner skips live `.processing` claim, `_queue_to_backlog` no-clobber, atomic write / no torn `.json`, budget refund on gate denial (+ direct helper unit test), optimistic extracted marker, watermark held-at-cutoff vs advance-to-now, maintenance-child no-respawn.
- Updated `tests/test_issue_557_async_drain.py::test_maintenance_skipped_on_popen_failure` to assert the new M-38 skip-on-failure contract.
- `ruff check truememory/ tests/` clean.
- Targeted suite (`HF_HUB_OFFLINE=1`, py3.14): 130 passed in the `-k "backlog or drain or stale or watermark or claim or marker or spawn"` filter; full `tests/ingest/` 281 passed, 1 skipped. The only failure is the pre-existing env-only `test_stop_hook_safety::test_spawn_cap_blocks_when_at_cap` (fails identically on the base commit — budget-exhaustion artifact, unrelated to this change).

## Caveats
- M-15's `_queue_to_backlog` no-clobber uses an `exists()` check rather than a hard `O_EXCL` create on the `.json` (a same-session re-queue should still refresh its own `.json`); the live-claim race that caused the duplicate ingest is closed because the `.processing` claim is never overwritten.
- Did not touch `dedup.py`/`encoding_gate.py`/`pipeline.py`/`consolidation.py` (parallel agent owns those).