### PR TITLE
fix: dedup × gate coherence — shared markers, category plumbing, lock + txn hygiene (#649)

### DIFF
--- a/tests/test_issue_649_dedup_gate_hygiene.py
+++ b/tests/test_issue_649_dedup_gate_hygiene.py
@@ -1,0 +1,293 @@
+"""Tests for issue #649 — dedup × gate coherence + lock/txn hygiene.
+
+Three findings:
+
+* M-13: the encoding gate's contradiction vocabulary and dedup's update
+  vocabulary diverged, so a correction ("Correction: X", "that's
+  incorrect", ...) passed the gate but was then SKIPped by dedup as a
+  near-duplicate before LLM arbitration. Fixed by a SHARED marker module
+  (``truememory.ingest.markers``) used by both, plus threading
+  ``fact.category`` into ``check_duplicate``.
+
+* M-31: the ingest dedup-store lock TTL-stole the lock even when the
+  holder PID was alive, splitting the lock across inodes → two holders.
+  Fixed: TTL only applies when the holder PID is dead; a live holder is
+  never stale.
+
+* M-32: ``detect_contradictions`` / ``build_structured_facts`` committed
+  the CALLER's open transaction before their own ``BEGIN IMMEDIATE``,
+  persisting writes the caller might roll back. Fixed: refuse to run with a
+  caller transaction open (raise) and re-read inside the write txn.
+
+FTS-only / in-memory, no model loads.
+"""
+
+import os
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+
+import truememory.ingest.markers as markers
+import truememory.ingest.dedup as dedup
+import truememory.ingest.encoding_gate as gate_mod
+import truememory.ingest.pipeline as pipeline
+import truememory.consolidation as consolidation
+from truememory.ingest.dedup import DedupAction, check_duplicate
+
+
+# ── M-13: shared markers + correction routing ────────────────────────────
+
+def _make_memory(results: list[dict]) -> MagicMock:
+    mem = MagicMock()
+    mem.search_vectors.return_value = results
+    return mem
+
+
+def test_gate_and_dedup_share_one_marker_source():
+    """The gate and dedup must consume the SAME marker vocabulary (#649)."""
+    # Gate's contradiction markers ARE the shared module's UPDATE_MARKERS.
+    assert gate_mod._CONTRADICTION_MARKERS is markers.UPDATE_MARKERS
+    # Both stages use the same predicate function object.
+    assert gate_mod._has_update_markers is markers.has_update_markers
+    assert dedup._has_update_markers is markers.has_update_markers
+    # Dedup's regex patterns are the shared compiled list.
+    assert dedup._UPDATE_MARKER_PATTERNS is markers.UPDATE_MARKER_PATTERNS
+
+
+@pytest.mark.parametrize("correction", [
+    "Correction: I use bun now, not npm",
+    "That's incorrect — I live in Austin",
+    "actually I switched to Postgres",
+    "no longer at the old company",
+])
+def test_correction_recognized_by_both_gate_and_dedup(correction):
+    """A correction must be a contradiction to the gate AND an update to dedup."""
+    assert gate_mod._is_contradiction(correction) is True
+    assert markers.has_update_markers(correction) is True
+
+
+def test_high_similarity_correction_not_silently_skipped_by_category():
+    """A category='correction' fact at >0.92 cosine reaches arbitration, not SKIP.
+
+    No LLM config → heuristic path → must route to UPDATE (supersede),
+    never SKIP.
+    """
+    memory = _make_memory([
+        {
+            "id": 7,
+            "content": "User uses npm as their package manager",
+            "score": 0.97,            # near-exact: old code would SKIP
+            "score_space": "cosine",
+            "directive": False,
+        },
+    ])
+    decision = check_duplicate(
+        "User uses npm as their package manager",  # no marker words at all
+        memory,
+        category="correction",                     # category alone must route it
+    )
+    assert decision.action != DedupAction.SKIP, (
+        f"correction was silently SKIPped: {decision.reason}"
+    )
+    assert decision.action == DedupAction.UPDATE
+
+
+def test_high_similarity_correction_not_skipped_by_markers():
+    """A marker-bearing correction at >0.92 cosine is not SKIPped (#576/#649)."""
+    memory = _make_memory([
+        {
+            "id": 3,
+            "content": "User lives in Seattle",
+            "score": 0.95,
+            "score_space": "cosine",
+            "directive": False,
+        },
+    ])
+    decision = check_duplicate(
+        "Correction: user moved to Austin",
+        memory,
+    )
+    assert decision.action != DedupAction.SKIP
+    assert decision.action == DedupAction.UPDATE
+
+
+def test_plain_duplicate_still_skipped():
+    """A genuine non-correction near-duplicate is still SKIPped (no regression)."""
+    memory = _make_memory([
+        {
+            "id": 9,
+            "content": "User likes coffee",
+            "score": 0.98,
+            "score_space": "cosine",
+            "directive": False,
+        },
+    ])
+    decision = check_duplicate("User likes coffee", memory, category="preference")
+    assert decision.action == DedupAction.SKIP
+
+
+# ── M-31: lock not stolen from a live holder ──────────────────────────────
+
+def _write_lock(path, pid: int):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{pid}\n", encoding="utf-8")
+
+
+def test_live_holder_lock_is_not_stale(tmp_path, monkeypatch):
+    """A lock held by a LIVE pid must not be considered stale, even if old."""
+    lock = tmp_path / "ingest.lock"
+    _write_lock(lock, os.getpid())  # our own pid → definitely alive
+    # Force the file's mtime far past the TTL.
+    old = 1.0  # epoch+1s, ~decades old
+    os.utime(lock, (old, old))
+    assert pipeline._is_lock_stale(lock) is False
+
+
+def test_dead_pid_lock_is_reclaimed(tmp_path, monkeypatch):
+    """A stale lock from a DEAD pid IS reclaimable."""
+    lock = tmp_path / "ingest.lock"
+    dead_pid = 2_000_000_000  # implausibly high → not alive
+    _write_lock(lock, dead_pid)
+    monkeypatch.setattr(pipeline, "_pid_is_alive", lambda pid: pid != dead_pid)
+    assert pipeline._is_lock_stale(lock) is True
+
+
+def test_empty_lock_falls_back_to_ttl(tmp_path):
+    """A corrupt/empty lock (no attributable holder) is stale past the TTL."""
+    lock = tmp_path / "ingest.lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_text("", encoding="utf-8")
+    os.utime(lock, (1.0, 1.0))  # ancient
+    assert pipeline._is_lock_stale(lock) is True
+
+
+@pytest.mark.skipif(not pipeline._HAS_FCNTL, reason="requires fcntl")
+def test_live_flock_blocks_second_acquirer(tmp_path, monkeypatch):
+    """While one holder flocks the lock, a second acquirer must not steal it.
+
+    We hold the lock via the real context manager (which flocks the inode)
+    and assert a second non-blocking acquire of the same path cannot take an
+    exclusive lock — i.e. mutual exclusion holds and no inode split occurs.
+    """
+    import fcntl
+
+    lock = tmp_path / "ingest.lock"
+    monkeypatch.setattr(pipeline, "_LOCK_PATH", lock)
+
+    with pipeline._dedup_store_lock():
+        # Holder is live and flocking. A second process-like attempt to grab
+        # an exclusive flock on the SAME path must fail immediately.
+        fd = os.open(str(lock), os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            with pytest.raises(OSError):
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        finally:
+            os.close(fd)
+
+
+# ── M-32: detect_contradictions must not commit the caller's txn ─────────
+
+def _make_timeline_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY,
+            content TEXT,
+            sender TEXT,
+            recipient TEXT,
+            timestamp TEXT,
+            category TEXT,
+            modality TEXT,
+            directive INTEGER DEFAULT 0
+        );
+        CREATE TABLE fact_timeline (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            subject TEXT,
+            fact TEXT,
+            source_message_id INTEGER,
+            timestamp TEXT,
+            entity_scope TEXT,
+            valid_from TEXT,
+            valid_to TEXT,
+            superseded_by INTEGER,
+            status TEXT DEFAULT 'active'
+        );
+        CREATE TABLE canary (id INTEGER PRIMARY KEY, note TEXT);
+        """
+    )
+    return conn
+
+
+def test_detect_contradictions_does_not_commit_callers_txn():
+    """The caller's open, uncommitted write must remain rollback-able (#649 M-32).
+
+    The old code did ``conn.commit()`` before its own ``BEGIN IMMEDIATE``,
+    which silently persisted the caller's in-flight rows so a later
+    ``rollback()`` could not undo them. With the SAVEPOINT-based write the
+    caller's transaction is never committed on their behalf.
+    """
+    conn = _make_timeline_db()
+    conn.execute("BEGIN")
+    conn.execute("INSERT INTO canary (note) VALUES ('uncommitted')")
+    assert conn.in_transaction
+
+    # Runs fine even with the caller's txn open (nests via SAVEPOINT).
+    result = consolidation.detect_contradictions(conn)
+    assert isinstance(result, list)
+
+    # The caller's write must still be rollback-able — proof we did NOT
+    # commit it.
+    conn.rollback()
+    rows = conn.execute("SELECT COUNT(*) FROM canary").fetchone()[0]
+    assert rows == 0, "caller's write was committed despite rollback — txn leaked"
+    # And our fact_timeline rows were rolled back with the caller's txn too.
+    assert conn.execute("SELECT COUNT(*) FROM fact_timeline").fetchone()[0] == 0
+
+
+def test_detect_contradictions_runs_without_caller_txn():
+    """With no explicit caller txn, detect_contradictions runs and commits."""
+    conn = _make_timeline_db()
+    conn.execute(
+        "INSERT INTO messages (id, content, sender, timestamp, directive) "
+        "VALUES (1, 'price is now $50 instead of $30', 'u', '2024-01-01', 0)"
+    )
+    conn.commit()
+    result = consolidation.detect_contradictions(conn)
+    assert isinstance(result, list)
+
+
+def test_detect_contradictions_preserves_isolation_level():
+    """isolation_level must not be mutated/leaked by the write (#649 M-32)."""
+    conn = _make_timeline_db()
+    conn.commit()
+    before = conn.isolation_level
+    consolidation.detect_contradictions(conn)
+    assert conn.isolation_level == before
+
+
+def test_build_structured_facts_does_not_commit_callers_txn():
+    """build_structured_facts has the same SAVEPOINT hygiene (#649 M-32)."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY, content TEXT, sender TEXT, recipient TEXT,
+            timestamp TEXT, category TEXT, modality TEXT, directive INTEGER DEFAULT 0
+        );
+        CREATE TABLE summaries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, period TEXT, start_date TEXT,
+            end_date TEXT, entity TEXT, summary TEXT, key_facts TEXT,
+            message_ids TEXT, created_at TEXT
+        );
+        CREATE TABLE canary (id INTEGER PRIMARY KEY, note TEXT);
+        """
+    )
+    conn.execute("BEGIN")
+    conn.execute("INSERT INTO canary (note) VALUES ('uncommitted')")
+    consolidation.build_structured_facts(conn)
+    conn.rollback()
+    assert conn.execute("SELECT COUNT(*) FROM canary").fetchone()[0] == 0

--- a/truememory/consolidation.py
+++ b/truememory/consolidation.py
@@ -33,6 +33,7 @@ import json
 import re
 import sqlite3
 from collections import defaultdict
+from contextlib import contextmanager
 from datetime import datetime, timezone
 
 from truememory.fts_search import _build_safe_fts_query, _fts_search
@@ -41,6 +42,61 @@ from truememory.fts_search import _build_safe_fts_query, _fts_search
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+@contextmanager
+def _consolidation_write(conn: sqlite3.Connection, name: str):
+    """Run a consolidation write phase without leaking the caller's txn.
+
+    The phase-3 writes in ``detect_contradictions`` /
+    ``build_structured_facts`` used to do::
+
+        if conn.in_transaction:
+            conn.commit()              # <-- commits the CALLER's writes!
+        prev = conn.isolation_level
+        conn.isolation_level = None    # <-- mutates shared connection state
+        conn.execute("BEGIN IMMEDIATE")
+        ...
+
+    That ``conn.commit()`` silently committed whatever the caller had
+    in-flight — including writes the caller intended to roll back — which
+    was the leaked-transaction root cause behind a live lock incident
+    (#649, M-32). The ``isolation_level`` mutation also leaked connection
+    state on the error path.
+
+    Instead we wrap the write in a SAVEPOINT. A SAVEPOINT:
+
+    - nests inside the caller's transaction WITHOUT committing it (so a
+      caller who later rolls back loses our rows too — correct, our rows
+      describe their uncommitted state);
+    - works whether or not a transaction is already open (pysqlite opens
+      one implicitly if needed);
+    - rolls back ONLY our own statements on error (``ROLLBACK TO``), never
+      the caller's earlier work;
+    - never touches ``isolation_level``.
+
+    The expensive compute still happens OUTSIDE this context (issue #591),
+    so the SAVEPOINT — like the old ``BEGIN IMMEDIATE`` — only spans the
+    short DELETE+rewrite.
+    """
+    sp = f"consolidation_{name}"
+    conn.execute(f"SAVEPOINT {sp}")
+    try:
+        yield
+    except BaseException:
+        try:
+            conn.execute(f"ROLLBACK TO SAVEPOINT {sp}")
+        except Exception:
+            pass
+        # Always release so we don't leave a dangling savepoint on the
+        # caller's transaction.
+        try:
+            conn.execute(f"RELEASE SAVEPOINT {sp}")
+        except Exception:
+            pass
+        raise
+    else:
+        conn.execute(f"RELEASE SAVEPOINT {sp}")
+
 
 def _get_all_messages_chrono(conn: sqlite3.Connection) -> list[dict]:
     """Fetch all messages ordered by timestamp."""
@@ -763,19 +819,21 @@ def detect_contradictions(conn: sqlite3.Connection) -> list[dict]:
     # --- Phase 1: read ---------------------------------------------------
     all_msgs = _get_all_messages_chrono(conn)
 
-    # --- Phase 2: compute (no transaction held) --------------------------
+    # --- Phase 2: compute (no transaction held, #591) --------------------
     insert_rows, supersede_updates, contradictions = _compute_contradictions(
         all_msgs,
     )
 
-    # --- Phase 3: write (short atomic transaction) -----------------------
-    # Same manual-transaction pattern used by build_summaries (#401).
-    if conn.in_transaction:
-        conn.commit()
-    prev_isolation = conn.isolation_level
-    try:
-        conn.isolation_level = None
-        conn.execute("BEGIN IMMEDIATE")
+    # --- Phase 3: write (short SAVEPOINT, #649 M-32) ---------------------
+    # We wrap the write in a SAVEPOINT instead of committing the caller's
+    # transaction + driving our own BEGIN IMMEDIATE. The old code's
+    # ``conn.commit()`` silently committed the caller's in-flight (possibly
+    # to-be-rolled-back) writes — the leaked-transaction root cause behind a
+    # live lock incident — and its ``isolation_level`` mutation leaked
+    # connection state. The SAVEPOINT nests in whatever the caller already
+    # has open, rolls back only our own rows on error, and never touches
+    # isolation_level. See :func:`_consolidation_write`.
+    with _consolidation_write(conn, "contradictions"):
         conn.execute("DELETE FROM fact_timeline")
 
         # Bulk-insert all fact rows and build local_id -> real_db_id map.
@@ -803,16 +861,6 @@ def detect_contradictions(conn: sqlite3.Connection) -> list[dict]:
                 "UPDATE fact_timeline SET valid_to = ? WHERE id = ?",
                 (valid_to, old_db_id),
             )
-
-        conn.execute("COMMIT")
-    except Exception:
-        try:
-            conn.execute("ROLLBACK")
-        except Exception:
-            pass
-        raise
-    finally:
-        conn.isolation_level = prev_isolation
 
     return contradictions
 
@@ -1529,16 +1577,14 @@ def build_structured_facts(conn):
     # --- Phase 1: read ---------------------------------------------------
     all_msgs = _get_all_messages_chrono(conn)
 
-    # --- Phase 2: compute (no transaction held) --------------------------
+    # --- Phase 2: compute (no transaction held, #591) --------------------
     rows = _compute_structured_facts(all_msgs)
 
-    # --- Phase 3: write (short atomic transaction) -----------------------
-    if conn.in_transaction:
-        conn.commit()
-    prev_isolation = conn.isolation_level
-    try:
-        conn.isolation_level = None
-        conn.execute("BEGIN IMMEDIATE")
+    # --- Phase 3: write (short SAVEPOINT, #649 M-32) ---------------------
+    # SAVEPOINT instead of committing the caller's transaction — same
+    # leaked-transaction fix as detect_contradictions. See
+    # :func:`_consolidation_write`.
+    with _consolidation_write(conn, "structured_facts"):
         # Remove old structured_fact rows (don't touch other summary types).
         conn.execute("DELETE FROM summaries WHERE period = 'structured_fact'")
         if rows:
@@ -1549,14 +1595,5 @@ def build_structured_facts(conn):
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 rows,
             )
-        conn.execute("COMMIT")
-    except Exception:
-        try:
-            conn.execute("ROLLBACK")
-        except Exception:
-            pass
-        raise
-    finally:
-        conn.isolation_level = prev_isolation
 
     return len(rows)

--- a/truememory/ingest/dedup.py
+++ b/truememory/ingest/dedup.py
@@ -28,55 +28,26 @@ from dataclasses import dataclass
 from enum import Enum
 
 from truememory.ingest.extractor import _find_first_balanced
+from truememory.ingest.markers import (
+    UPDATE_MARKER_PATTERNS as _UPDATE_MARKER_PATTERNS,  # noqa: F401  (re-exported)
+    has_update_markers as _has_update_markers,
+)
 from truememory.ingest.models import LLMConfig, LLMError, complete
 
 log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Update-marker detection (issue #576)
+# Update-marker detection (issues #576, #649)
 # ---------------------------------------------------------------------------
-# Patterns that signal a genuine fact *update* rather than a duplicate.
-# When a high-similarity candidate contains these markers, the dedup
-# pipeline should treat it as UPDATE (or delegate to LLM), never SKIP.
+# The marker vocabulary that signals a genuine fact *update* (rather than a
+# duplicate) is now SHARED with the encoding gate via
+# ``truememory.ingest.markers``. Before #649 the gate and dedup kept
+# divergent lists, so corrections that the gate recognised ("Correction:",
+# "that's incorrect", ...) were not recognised by dedup and got SKIPped at
+# high similarity before LLM arbitration ever ran.
 #
-# The list is intentionally broad — false positives are cheap (we pay one
-# LLM call or update an existing memory), but false negatives silently
-# drop real updates.
-
-_UPDATE_MARKER_PATTERNS: list[re.Pattern[str]] = [
-    # Explicit change language
-    re.compile(r"\bchanged?\s+(?:to|from)\b", re.IGNORECASE),
-    re.compile(r"\bnow\s+(?:is|uses?|prefers?|lives?|works?|takes?|runs?|has)\b", re.IGNORECASE),
-    re.compile(r"\bupdated?\b", re.IGNORECASE),
-    re.compile(r"\bno\s+longer\b", re.IGNORECASE),
-    re.compile(r"\bnot\s+anymore\b", re.IGNORECASE),
-    re.compile(r"\bswitched\s+(?:to|from)\b", re.IGNORECASE),
-    re.compile(r"\binstead\s+of\b", re.IGNORECASE),
-    re.compile(r"\bmoved\s+to\b", re.IGNORECASE),
-    re.compile(r"\breplaced\b", re.IGNORECASE),
-    re.compile(r"\bwas\b.*\bnow\b", re.IGNORECASE),
-    re.compile(r"\bformerly\b", re.IGNORECASE),
-    re.compile(r"\bpreviously\b", re.IGNORECASE),
-    re.compile(r"\bused\s+to\b", re.IGNORECASE),
-    re.compile(r"\bactually\b", re.IGNORECASE),
-    # Number-change patterns  ("5mg to 10mg", "6.5% -> 6.25%")
-    re.compile(r"\d[\d.]*[%a-zA-Z]*\s*(?:to|->|-->|=>|→)\s*\d[\d.]*", re.IGNORECASE),
-    # Date-change patterns  ("since 2024", "as of March")
-    re.compile(r"\b(?:since|as\s+of|starting|effective)\s+\w+", re.IGNORECASE),
-]
-
-
-def _has_update_markers(content: str) -> bool:
-    """Return True if *content* contains language suggesting a fact update.
-
-    This is the marker gate for issue #576: high-similarity candidates
-    that contain update markers should be routed to UPDATE (or LLM
-    arbitration), not silently SKIPped.
-    """
-    for pattern in _UPDATE_MARKER_PATTERNS:
-        if pattern.search(content):
-            return True
-    return False
+# ``_UPDATE_MARKER_PATTERNS`` / ``_has_update_markers`` are re-exported here
+# (unchanged names) for backward compatibility with existing callers/tests.
 
 
 class DedupAction(Enum):
@@ -112,12 +83,27 @@ If "update", also provide the merged/updated content that combines the best of b
 Return JSON: {{"action": "add|update|skip", "reason": "brief explanation", "merged": "updated content if action=update, else empty"}}"""
 
 
+def _is_correction(fact: str, category: str = "") -> bool:
+    """Return True if this fact is a correction that must reach arbitration.
+
+    A correction is either explicitly categorized ``correction`` by the
+    extractor, or carries shared update-marker language (#649). Corrections
+    must never be silently SKIPped as near-duplicates — they are routed to
+    LLM arbitration (or the heuristic update path) so the old fact can be
+    superseded.
+    """
+    if (category or "").strip().lower() == "correction":
+        return True
+    return _has_update_markers(fact)
+
+
 def check_duplicate(
     fact: str,
     memory,
     user_id: str = "",
     config: LLMConfig | None = None,
     similarity_threshold: float = 0.15,
+    category: str = "",
 ) -> DedupDecision:
     """
     Check if a fact duplicates an existing memory.
@@ -173,20 +159,23 @@ def check_duplicate(
     top_is_cosine = top.get("score_space", "cosine") == "cosine"
 
     # Very high similarity — likely near-exact duplicate.
-    # BUT: if the new fact contains update markers (issue #576), it may be
-    # a genuine fact change that just happens to embed close to the old
-    # version.  Route those to LLM arbitration (if available) or the
-    # heuristic path rather than silently dropping them.
+    # BUT: if the new fact is a correction (issues #576, #649) — either an
+    # extractor-categorized ``correction`` or carrying shared update-marker
+    # language — it may be a genuine fact change that just happens to embed
+    # close to the old version. Route those to LLM arbitration (if
+    # available) or the heuristic path rather than silently dropping them.
     if top_is_cosine and top_score > 0.92:
-        if _has_update_markers(fact):
+        if _is_correction(fact, category):
             log.debug(
-                "High-similarity candidate (%.2f) has update markers — "
-                "routing to arbitration instead of SKIP",
-                top_score,
+                "High-similarity candidate (%.2f) is a correction "
+                "(category=%r) — routing to arbitration instead of SKIP",
+                top_score, category,
             )
             if config:
                 return _llm_dedup(fact, top_content, top_id, config)
-            return _heuristic_dedup(fact, top_content, top_id, top_score)
+            return _heuristic_dedup(
+                fact, top_content, top_id, top_score, is_correction=True
+            )
         return DedupDecision(
             action=DedupAction.SKIP,
             fact=fact,
@@ -299,10 +288,27 @@ def _heuristic_dedup(
     existing: str,
     existing_id: int | None,
     similarity: float,
+    is_correction: bool = False,
 ) -> DedupDecision:
-    """Heuristic dedup when no LLM is available."""
+    """Heuristic dedup when no LLM is available.
+
+    ``is_correction`` (#649): when the caller has already determined this
+    fact is a correction (by category or shared update markers), it must
+    never be SKIPped as a duplicate — it supersedes the existing memory,
+    so route it to UPDATE.
+    """
     fact_norm = fact.lower().strip()
     existing_norm = existing.lower().strip()
+
+    # Corrections supersede the existing memory — never drop them (#649).
+    if is_correction:
+        return DedupDecision(
+            action=DedupAction.UPDATE,
+            fact=fact,
+            existing_id=existing_id,
+            existing_content=existing,
+            reason="correction supersedes existing memory",
+        )
 
     # Substring containment — one is a subset of the other
     if fact_norm in existing_norm:

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -61,6 +61,14 @@ from dataclasses import dataclass
 
 import numpy as np
 
+# Shared correction/update marker vocabulary (issue #649) — single source
+# of truth used by BOTH this gate and the dedup stage so the two never
+# disagree about what counts as a correction.
+from truememory.ingest.markers import (
+    UPDATE_MARKERS as _CONTRADICTION_MARKERS,  # noqa: F401  (exported; shared vocab)
+    has_update_markers as _has_update_markers,
+)
+
 log = logging.getLogger(__name__)
 
 
@@ -146,30 +154,21 @@ _CATEGORY_THRESHOLD_OVERRIDE = {
 # Patterns that indicate contradictions or corrections — these memories
 # are critical for accuracy and must always pass the gate regardless of
 # PE score or gate threshold (#585).
-_CONTRADICTION_MARKERS = (
-    "actually,",
-    "actually ",
-    "correction:",
-    "correction -",
-    "no longer ",
-    "not anymore",
-    "changed to ",
-    "switched to ",
-    "moved to ",
-    "used to be ",
-    "instead of ",
-    "wrong about ",
-    "was wrong",
-    "is wrong",
-    "not true",
-    "isn't true",
-    "that's incorrect",
-    "that is incorrect",
-)
+#
+# The marker vocabulary is SHARED with the dedup stage (issue #649): the
+# gate and dedup must agree on what counts as a correction, otherwise a
+# correction passes the gate but is then SKIPped by dedup before LLM
+# arbitration. The single source of truth lives in
+# ``truememory.ingest.markers`` (imported at module top as
+# ``_CONTRADICTION_MARKERS`` / ``_has_update_markers``).
 
 
 def _is_contradiction(fact: str, category: str = "") -> bool:
-    """Return True if the fact looks like a contradiction or correction."""
+    """Return True if the fact looks like a contradiction or correction.
+
+    Uses the SAME shared marker vocabulary as dedup (#649) so the two
+    stages never disagree.
+    """
     cat = (category or "").strip().lower()
     if cat == "correction":
         return True
@@ -177,8 +176,7 @@ def _is_contradiction(fact: str, category: str = "") -> bool:
     # Check for "not X but Y" pattern
     if " not " in lower and " but " in lower:
         return True
-    return any(lower.startswith(m) or (f" {m}" if not m.endswith(" ") else f" {m}") in lower
-               for m in _CONTRADICTION_MARKERS)
+    return _has_update_markers(fact)
 
 
 class EncodingGate:

--- a/truememory/ingest/markers.py
+++ b/truememory/ingest/markers.py
@@ -1,0 +1,101 @@
+"""
+Shared contradiction / update marker vocabulary (issue #649)
+============================================================
+
+A correction ("Correction: X", "that's incorrect", "no longer Y") must be
+treated coherently by BOTH the encoding gate and the dedup stage. Before
+this module the gate's contradiction vocabulary (``_CONTRADICTION_MARKERS``)
+and dedup's update vocabulary (``_UPDATE_MARKER_PATTERNS``) diverged, so a
+correction could pass the gate (recognised as a contradiction) and then be
+silently SKIPped by dedup (NOT recognised as an update) before LLM
+arbitration ever ran. M-13.
+
+This module is the single source of truth. The gate consumes
+:data:`UPDATE_MARKERS` for substring/startswith matching; dedup consumes
+:data:`UPDATE_MARKER_PATTERNS` (the same vocabulary compiled to regex, plus
+number/date-change patterns that have no plain-substring equivalent).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Plain-substring markers — words/phrases that signal a correction or a
+# fact update. Used by the encoding gate (startswith / " marker " match)
+# and compiled into word-boundary regexes for dedup below.
+#
+# Keep these lowercase and free of leading/trailing punctuation where a
+# word-boundary regex is meaningful; entries with trailing punctuation
+# (e.g. "correction:") are matched as substrings by the gate.
+UPDATE_MARKERS: tuple[str, ...] = (
+    "actually",
+    "correction:",
+    "correction -",
+    "no longer",
+    "not anymore",
+    "changed to",
+    "changed from",
+    "switched to",
+    "switched from",
+    "moved to",
+    "used to be",
+    "used to",
+    "instead of",
+    "wrong about",
+    "was wrong",
+    "is wrong",
+    "not true",
+    "isn't true",
+    "that's incorrect",
+    "that is incorrect",
+    "updated",
+    "replaced",
+    "formerly",
+    "previously",
+)
+
+
+def _compile_markers() -> list[re.Pattern[str]]:
+    """Compile :data:`UPDATE_MARKERS` plus number/date-change patterns.
+
+    Word-boundary anchored so "actually" matches but "actualization" does
+    not. Markers ending in punctuation (``correction:``) are matched as a
+    leading-boundary substring since ``\\b`` does not sit before ``:``.
+    """
+    patterns: list[re.Pattern[str]] = []
+    for marker in UPDATE_MARKERS:
+        if marker[-1].isalnum():
+            patterns.append(re.compile(rf"\b{re.escape(marker)}\b", re.IGNORECASE))
+        else:
+            patterns.append(re.compile(rf"\b{re.escape(marker)}", re.IGNORECASE))
+    # Structural change patterns with no plain-substring equivalent.
+    patterns.extend([
+        # "now is/uses/prefers/lives/works/takes/runs/has ..."
+        re.compile(
+            r"\bnow\s+(?:is|uses?|prefers?|lives?|works?|takes?|runs?|has)\b",
+            re.IGNORECASE,
+        ),
+        # "was ... now ..."
+        re.compile(r"\bwas\b.*\bnow\b", re.IGNORECASE),
+        # Number-change patterns  ("5mg to 10mg", "6.5% -> 6.25%")
+        re.compile(r"\d[\d.]*[%a-zA-Z]*\s*(?:to|->|-->|=>|→)\s*\d[\d.]*", re.IGNORECASE),
+        # Date-change patterns  ("since 2024", "as of March")
+        re.compile(r"\b(?:since|as\s+of|starting|effective)\s+\w+", re.IGNORECASE),
+    ])
+    return patterns
+
+
+# Regex form for dedup (and any caller that needs full-text scanning).
+UPDATE_MARKER_PATTERNS: list[re.Pattern[str]] = _compile_markers()
+
+
+def has_update_markers(content: str) -> bool:
+    """Return True if *content* contains correction/update language.
+
+    Single shared predicate used by both the gate and dedup so the two
+    stages never disagree about what counts as a correction (#649).
+    """
+    for pattern in UPDATE_MARKER_PATTERNS:
+        if pattern.search(content):
+            return True
+    return False

--- a/truememory/ingest/pipeline.py
+++ b/truememory/ingest/pipeline.py
@@ -51,6 +51,22 @@ try:
 except ImportError:  # pragma: no cover — Windows path
     _HAS_FCNTL = False
 
+# Cross-platform PID liveness — reuse the shared helper so the lock and the
+# rest of truememory agree on what "alive" means (#649, M-31). Fall back to
+# a local os.kill probe if _platform is unavailable (older install).
+try:
+    from truememory._platform import pid_is_alive as _pid_is_alive
+except ImportError:  # pragma: no cover — defensive
+    def _pid_is_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+            return True
+        except PermissionError:
+            return True
+        except OSError:
+            return False
+
+
 _LOCK_PATH = Path(os.environ.get(
     "TRUEMEMORY_INGEST_LOCK",
     str(Path.home() / ".truememory" / "ingest.lock"),
@@ -60,27 +76,51 @@ _LOCK_PATH = Path(os.environ.get(
 _LOCK_TTL_SECONDS = 3600
 
 
-def _is_lock_stale(lock_path: Path) -> bool:
-    """Check if a lock file is stale (dead PID or expired TTL)."""
+def _read_lock_pid(lock_path: Path) -> int | None:
+    """Read the holder PID from the lock file, or None if unreadable/garbage."""
     try:
         content = lock_path.read_text(encoding="utf-8").strip()
-        if not content:
-            return True
-        pid = int(content)
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            return True
-        except PermissionError:
-            pass
-    except (OSError, ValueError):
-        pass
-    try:
-        age = time.time() - lock_path.stat().st_mtime
-        if age > _LOCK_TTL_SECONDS:
-            return True
     except OSError:
-        pass
+        return None
+    if not content:
+        return None
+    try:
+        return int(content)
+    except ValueError:
+        return None
+
+
+def _is_lock_stale(lock_path: Path) -> bool:
+    """Check if a lock file is stale and therefore safe to steal.
+
+    A lock is stale ONLY when its holder is gone (#649, M-31):
+
+    - The PID is unreadable / garbage (no live holder we can attribute it
+      to), OR
+    - The recorded PID is DEAD.
+
+    Critically, the TTL is **only** consulted when the holder PID is dead.
+    The previous implementation stole the lock once ``mtime`` exceeded the
+    TTL even when the holder process was alive and still flocking the
+    inode — producing two simultaneous holders and a dedup TOCTOU. A live
+    holder is NEVER stale here regardless of age; long-running ingests
+    heartbeat the mtime, but liveness — not age — is the authority.
+    """
+    pid = _read_lock_pid(lock_path)
+    if pid is None:
+        # No attributable holder. Fall back to TTL so a corrupt/empty lock
+        # left by a crash mid-write doesn't wedge ingestion forever.
+        try:
+            age = time.time() - lock_path.stat().st_mtime
+            return age > _LOCK_TTL_SECONDS
+        except OSError:
+            # Path vanished (someone else reclaimed it) — treat as stale.
+            return True
+
+    if not _pid_is_alive(pid):
+        return True
+
+    # Holder is alive — NOT stale, regardless of mtime age.
     return False
 
 
@@ -100,8 +140,21 @@ def _dedup_store_lock():
     (no fcntl) we skip locking and rely on ``busy_timeout`` + the embedding
     similarity check as best-effort protection.
 
-    The lock file contains the holder's PID. On acquisition, stale locks
-    from dead processes or locks older than 1 hour are automatically stolen.
+    Locking discipline (#649, M-31). ``flock`` is the authority on
+    mutual exclusion, NOT the PID/mtime bookkeeping:
+
+    - We never unlink a path that may still be flocked by a live holder.
+      A dead holder's flock is already released by the kernel, so our
+      blocking ``flock(LOCK_EX)`` simply succeeds — no manual TTL steal is
+      needed, and a TTL-driven unlink of a live holder's path (the old bug)
+      would split the lock across two inodes and give two simultaneous
+      holders.
+    - After acquiring the flock we verify the path still resolves to the
+      same inode as our open fd. If a previous holder unlinked/replaced the
+      path while we waited, we are holding a stale inode; we drop it and
+      retry against the live path.
+    - The PID is written purely for diagnostics (and to let an operator see
+      who holds it). mtime is refreshed on acquire as a heartbeat.
     """
     if not _HAS_FCNTL:
         yield
@@ -113,27 +166,23 @@ def _dedup_store_lock():
         yield
         return
 
-    if _LOCK_PATH.exists() and _is_lock_stale(_LOCK_PATH):
-        log.info("Removing stale ingest lock file %s", _LOCK_PATH)
-        try:
-            _LOCK_PATH.unlink(missing_ok=True)
-        except OSError:
-            pass
-
-    try:
-        lock_fd = os.open(str(_LOCK_PATH), os.O_CREAT | os.O_RDWR, 0o600)
-    except OSError as e:
-        log.debug("Could not open ingest lock file %s: %s", _LOCK_PATH, e)
+    lock_fd = _acquire_flock(_LOCK_PATH)
+    if lock_fd is None:
+        # Could not open/lock the path at all — degrade open rather than
+        # block ingestion. busy_timeout remains as best-effort protection.
         yield
         return
 
     try:
+        # Heartbeat + diagnostics: record our PID and refresh mtime so a
+        # long-running ingest is never mistaken for a crashed holder.
         try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
-        except OSError as e:
-            log.debug("flock acquire failed: %s", e)
-        os.write(lock_fd, f"{os.getpid()}\n".encode())
-        os.ftruncate(lock_fd, os.lseek(lock_fd, 0, os.SEEK_CUR))
+            os.ftruncate(lock_fd, 0)
+            os.lseek(lock_fd, 0, os.SEEK_SET)
+            os.write(lock_fd, f"{os.getpid()}\n".encode())
+            os.fsync(lock_fd)
+        except OSError:
+            pass
         try:
             yield
         finally:
@@ -146,6 +195,59 @@ def _dedup_store_lock():
             os.close(lock_fd)
         except OSError:
             pass
+
+
+def _acquire_flock(lock_path: Path, _max_retries: int = 5) -> int | None:
+    """Open *lock_path* and acquire an exclusive flock, returning the fd.
+
+    Guards against the unlink-while-held race (#649, M-31): after the
+    blocking ``flock`` returns, the path is re-stat'd and compared to the
+    locked fd's inode. If they diverge (the path was replaced while we
+    waited), the held inode is stale — we release it and retry against the
+    current path. Returns ``None`` if locking is impossible.
+    """
+    for _ in range(_max_retries):
+        try:
+            lock_fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+        except OSError as e:
+            log.debug("Could not open ingest lock file %s: %s", lock_path, e)
+            return None
+
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        except OSError as e:
+            log.debug("flock acquire failed: %s", e)
+            # Cannot enforce mutual exclusion — caller degrades open.
+            try:
+                os.close(lock_fd)
+            except OSError:
+                pass
+            return None
+
+        # Verify the path still points at the inode we locked. If a prior
+        # holder unlinked/replaced it while we waited, we hold a dead inode.
+        try:
+            fd_ino = os.fstat(lock_fd).st_ino
+            path_ino = os.stat(str(lock_path)).st_ino
+        except OSError:
+            path_ino = None
+            fd_ino = -1
+
+        if path_ino == fd_ino:
+            return lock_fd
+
+        # Stale inode (path was replaced under us) — drop and retry.
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        try:
+            os.close(lock_fd)
+        except OSError:
+            pass
+
+    log.debug("Gave up acquiring ingest flock after %d retries", _max_retries)
+    return None
 
 
 def _set_busy_timeout(memory, timeout_ms: int | None = None) -> None:
@@ -365,6 +467,7 @@ class IngestionPipeline:
                     self.memory,
                     user_id=self.user_id,
                     config=self.llm_config if self.use_llm_dedup else None,
+                    category=fact.category,
                 )
                 trace_entry["dedup"] = {
                     "action": dedup.action.value,
@@ -488,6 +591,7 @@ class IngestionPipeline:
                     self.memory,
                     user_id=self.user_id,
                     config=self.llm_config if self.use_llm_dedup else None,
+                    category=fact.category,
                 )
 
                 if dedup.action == DedupAction.ADD:


### PR DESCRIPTION
Fixes #649.

Three concurrency/coherence findings, minimal targeted fixes. Touches only `encoding_gate.py`, `dedup.py`, `pipeline.py`, `consolidation.py`, a new shared `markers.py`, and a new test file.

## M-13 (P1) — gate × dedup marker divergence
The encoding gate's contradiction vocabulary (`_CONTRADICTION_MARKERS`) and dedup's update vocabulary (`_UPDATE_MARKER_PATTERNS`) had diverged, so a correction ("Correction:", "that's incorrect", ...) could pass the gate yet be SKIPped by dedup as a near-duplicate before LLM arbitration ever ran. Aggravator: `category="correction"` was never passed into `check_duplicate()`.

- New `truememory/ingest/markers.py` is the single source of truth: `UPDATE_MARKERS` (substring vocab) + `UPDATE_MARKER_PATTERNS` (compiled regex) + `has_update_markers()`.
- `encoding_gate.py` imports `UPDATE_MARKERS` as `_CONTRADICTION_MARKERS` and `has_update_markers` — gate and dedup now share the exact same objects.
- `dedup.py` re-exports the shared names (back-compat) and uses them.
- `check_duplicate(..., category=...)` added; corrections (by category OR markers) at >0.92 cosine route to arbitration / heuristic UPDATE instead of SKIP. `_heuristic_dedup(..., is_correction=True)` never SKIPs a correction.
- `pipeline.py` threads `fact.category` into both `check_duplicate` call sites.

## M-31 (P2) — dedup-store lock stolen from a live holder
`_is_lock_stale` TTL-stole the lock (3600s) even when the holder PID was alive; the stealer unlinked the path while the holder still flocked the old inode → two holders → dedup TOCTOU.

- `_is_lock_stale` now only treats a lock as stale when the holder PID is **dead** (reuses `truememory._platform.pid_is_alive`); a live holder is never stale regardless of mtime. TTL only applies to a corrupt/empty (unattributable) lock.
- New `_acquire_flock` makes `flock` the authority on mutual exclusion and verifies the path still resolves to the locked inode after acquire (defeats the unlink-while-held split); no manual TTL unlink of a possibly-held path. mtime is refreshed as a heartbeat on acquire.

## M-32 (P2) — leaked caller transaction in consolidation
`detect_contradictions()` (public API) and `build_structured_facts()` did `if conn.in_transaction: conn.commit()` before their own `BEGIN IMMEDIATE`, silently committing the caller's in-flight (possibly to-be-rolled-back) writes — the leaked-transaction root cause behind a live lock incident. They also mutated shared `isolation_level`.

- New `_consolidation_write()` context manager wraps the phase-3 write in a **SAVEPOINT**: nests in whatever the caller has open without committing it, rolls back only our own rows on error (`ROLLBACK TO`), and never touches `isolation_level`.
- Expensive compute still runs outside the write lock, so #591's no-write-lock-during-compute contract is preserved.

## Tests
New `tests/test_issue_649_dedup_gate_hygiene.py`:
- gate and dedup consume the **same** shared marker objects (identity asserts); a `category="correction"` (and a marker-bearing) fact at >0.92 cosine is NOT SKIPped — it reaches UPDATE; a plain near-duplicate is still SKIPped.
- a lock held by a **live** PID is not stale; a **dead**-PID stale lock is reclaimed; while a holder flocks the lock a second `LOCK_NB` acquire fails (no steal); empty lock falls back to TTL.
- `detect_contradictions` / `build_structured_facts` do NOT commit the caller's open transaction (caller's uncommitted write is still rollback-able); `isolation_level` is preserved.

Targeted run (`HF_HUB_OFFLINE=1`, FTS-only): **233 passed**, including the previously-failing #580 (24) and #591 (2) which my first cut had regressed and are now green. `ruff check truememory/ tests/` clean.