### PR TITLE
fix: model server lifecycle — exclusive bind lock, throttler TOCTOU, server-side deadline, protocol handshake (#646)

### DIFF
--- a/tests/test_issue_489_mps_safety.py
+++ b/tests/test_issue_489_mps_safety.py
@@ -125,7 +125,12 @@ class TestModelServerMpsRestore(unittest.TestCase):
         """
         import inspect
         from truememory import model_server
-        handler_source = inspect.getsource(model_server.ModelServer.handle_request)
+        # Issue #646 split in-flight bookkeeping (handle_request) from op
+        # dispatch (_handle_request_inner); the embed OOM path lives in the
+        # latter now.
+        handler_source = inspect.getsource(
+            model_server.ModelServer._handle_request_inner
+        )
         recovery_source = inspect.getsource(
             model_server.ModelServer._recover_embed_oom_locked
         )

--- a/tests/test_issue_646_model_server.py
+++ b/tests/test_issue_646_model_server.py
@@ -1,0 +1,380 @@
+"""Regression tests for issue #646: model-server lifecycle hardening.
+
+Covers:
+  - M-20: _cleanup only removes artifacts THIS process owns (PID == getpid());
+    a stale/dead-PID artifact is reclaimed by a new server's bind lock.
+  - M-43: throttler check captures a local under the lock (no AttributeError
+    when _throttler is nulled mid-flight).
+  - M-44: a request whose deadline already passed is rejected before encode.
+  - M-53: the client raises a clear protocol-mismatch error on non-JSON bytes.
+  - M-74: in-flight counter prevents idle shutdown mid-request.
+
+All hermetic: no real model loads, no real daemon. Stub sockets / fake
+servers only. HF_HUB_OFFLINE is set by the test runner.
+"""
+from __future__ import annotations
+
+import json
+import os
+import struct
+import time
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# M-20: _cleanup ownership + stale-artifact reclamation
+# ---------------------------------------------------------------------------
+
+
+class TestM20CleanupOwnership:
+    def _point_paths_at_tmp(self, monkeypatch, tmp_path):
+        """Redirect the module-level artifact paths into a temp dir."""
+        from truememory import model_server as ms
+        for name, fname in (
+            ("SOCK_PATH", "model.sock"),
+            ("PID_PATH", "model_server.pid"),
+            ("PORT_PATH", "model_server.port"),
+            ("TOKEN_PATH", "model_server.token"),
+            ("LOCK_PATH", "model_server.lock"),
+        ):
+            monkeypatch.setattr(ms, name, tmp_path / fname)
+        return ms
+
+    def test_cleanup_does_not_delete_other_servers_artifacts(
+        self, monkeypatch, tmp_path
+    ):
+        """_cleanup must NOT remove socket/pid/token owned by a DIFFERENT
+        live PID (M-20). Simulate a successor that already rewrote PID_PATH."""
+        ms = self._point_paths_at_tmp(monkeypatch, tmp_path)
+
+        # A successor process owns the artifacts: a DIFFERENT, LIVE pid.
+        other_pid = os.getpid() + 1
+        monkeypatch.setattr(ms, "pid_is_alive", lambda pid: pid == other_pid)
+        ms.PID_PATH.write_text(str(other_pid))
+        ms.SOCK_PATH.write_text("live-socket")
+        ms.TOKEN_PATH.write_text("live-token")
+        ms.PORT_PATH.write_text("12345")
+
+        server = ms.ModelServer()
+        server._cleanup()
+
+        # All four artifacts survive — they belong to the successor.
+        assert ms.PID_PATH.exists()
+        assert ms.SOCK_PATH.exists()
+        assert ms.TOKEN_PATH.exists()
+        assert ms.PORT_PATH.exists()
+
+    def test_cleanup_removes_own_artifacts(self, monkeypatch, tmp_path):
+        """When PID_PATH names THIS process, _cleanup removes the artifacts."""
+        ms = self._point_paths_at_tmp(monkeypatch, tmp_path)
+
+        ms.PID_PATH.write_text(str(os.getpid()))
+        ms.SOCK_PATH.write_text("my-socket")
+        ms.TOKEN_PATH.write_text("my-token")
+        ms.PORT_PATH.write_text("12345")
+
+        server = ms.ModelServer()
+        server._cleanup()
+
+        assert not ms.PID_PATH.exists()
+        assert not ms.SOCK_PATH.exists()
+        assert not ms.TOKEN_PATH.exists()
+        assert not ms.PORT_PATH.exists()
+
+    def test_stale_dead_pid_artifact_reclaimed_by_bind_lock(
+        self, monkeypatch, tmp_path
+    ):
+        """A new server takes the exclusive bind lock even when a stale PID
+        file from a crashed predecessor is present (M-20)."""
+        ms = self._point_paths_at_tmp(monkeypatch, tmp_path)
+
+        # Stale artifacts from a crashed predecessor (dead PID).
+        ms.PID_PATH.write_text("999999999")
+        ms.SOCK_PATH.write_text("stale")
+
+        server = ms.ModelServer()
+        fd = server._acquire_bind_lock()
+        try:
+            assert isinstance(fd, int)
+            assert ms.LOCK_PATH.exists()
+        finally:
+            os.close(fd)
+
+    def test_second_server_cannot_take_held_lock(self, monkeypatch, tmp_path):
+        """While one server holds the bind lock, a second one is refused
+        (M-20: only one server binds)."""
+        if os.name == "nt":
+            pytest.skip("flock semantics differ on Windows")
+        ms = self._point_paths_at_tmp(monkeypatch, tmp_path)
+
+        s1 = ms.ModelServer()
+        fd1 = s1._acquire_bind_lock()
+        try:
+            s2 = ms.ModelServer()
+            with pytest.raises(RuntimeError):
+                s2._acquire_bind_lock()
+        finally:
+            os.close(fd1)
+
+
+# ---------------------------------------------------------------------------
+# M-43: throttler TOCTOU
+# ---------------------------------------------------------------------------
+
+
+class TestM43ThrottlerToctou:
+    def test_throttler_nulled_midflight_no_attribute_error(self):
+        """If _throttler is set inactive/nulled between the truthiness check
+        and use, the captured local must not raise AttributeError (M-43)."""
+        from truememory.model_server import ModelServer
+
+        server = ModelServer()
+
+        # Simulate an active throttler whose attribute is yanked away
+        # immediately after the active flag is read.
+        class FlakyThrottler:
+            def before_batch(self):
+                pass
+
+            def after_batch(self, n, t):
+                pass
+
+            def should_flush_cache(self):
+                return False
+
+        # The fix captures `self._throttler` to a local under the lock, so a
+        # concurrent _deactivate_throttler (which nulls self._throttler) can't
+        # cause an AttributeError. Verify the capture pattern directly.
+        server._throttler = FlakyThrottler()
+        server._throttler_active = True
+
+        with server._lock:
+            throttler = server._throttler if server._throttler_active else None
+        # Now another thread deactivates (nulls the attribute).
+        with server._lock:
+            server._deactivate_throttler()
+        # The captured local is still usable — no AttributeError.
+        assert throttler is not None
+        throttler.before_batch()
+        assert server._throttler is None
+
+    def test_embed_with_active_throttler_does_not_crash(self, monkeypatch):
+        """End-to-end: an embed request with the throttler active completes
+        without an AttributeError even under concurrent deactivation."""
+        from truememory.model_server import ModelServer
+
+        server = ModelServer()
+
+        fake_model = MagicMock()
+        fake_model.encode.return_value = np.zeros((2, 4), dtype=np.float32)
+        monkeypatch.setattr(server, "_get_embed_model", lambda tier: fake_model)
+
+        class FakeThrottler:
+            def before_batch(self):
+                pass
+
+            def after_batch(self, n, t):
+                pass
+
+            def should_flush_cache(self):
+                return False
+
+        server._throttler = FakeThrottler()
+        server._throttler_active = True
+
+        resp = server.handle_request({"op": "embed", "texts": ["a", "b"], "tier": ""})
+        assert resp["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# M-44: server-side deadline rejection before encode
+# ---------------------------------------------------------------------------
+
+
+class TestM44ServerDeadline:
+    def test_expired_deadline_rejected_before_encode(self, monkeypatch):
+        """A request carrying an already-passed deadline is rejected without
+        ever calling the encode lane (M-44)."""
+        from truememory.model_server import ModelServer
+
+        server = ModelServer()
+
+        encode_called = {"n": 0}
+
+        def boom(tier):
+            encode_called["n"] += 1
+            raise AssertionError("encode must not run for expired request")
+
+        monkeypatch.setattr(server, "_get_embed_model", boom)
+
+        resp = server.handle_request({
+            "op": "embed",
+            "texts": ["x"],
+            "tier": "",
+            "deadline": time.time() - 5.0,  # already passed
+        })
+        assert resp["ok"] is False
+        assert "deadline" in resp["error"].lower()
+        assert encode_called["n"] == 0
+
+    def test_future_deadline_runs_normally(self, monkeypatch):
+        """A request with a comfortable future deadline still encodes."""
+        from truememory.model_server import ModelServer
+
+        server = ModelServer()
+        fake_model = MagicMock()
+        fake_model.encode.return_value = np.zeros((1, 4), dtype=np.float32)
+        monkeypatch.setattr(server, "_get_embed_model", lambda tier: fake_model)
+
+        resp = server.handle_request({
+            "op": "embed",
+            "texts": ["x"],
+            "tier": "",
+            "deadline": time.time() + 100.0,
+        })
+        assert resp["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# M-53: client protocol-mismatch detection
+# ---------------------------------------------------------------------------
+
+
+class _StubSock:
+    """A minimal socket stub that replays a canned response payload."""
+
+    def __init__(self, response_bytes: bytes):
+        self._to_send = response_bytes
+        self.sent = bytearray()
+        self.timeout = None
+
+    def settimeout(self, t):
+        self.timeout = t
+
+    def sendall(self, data):
+        self.sent.extend(data)
+
+    def recv(self, n):
+        if not self._to_send:
+            return b""
+        chunk = self._to_send[:n]
+        self._to_send = self._to_send[n:]
+        return chunk
+
+    def close(self):
+        pass
+
+
+def _framed(payload: bytes) -> bytes:
+    return struct.pack(">I", len(payload)) + payload
+
+
+class TestM53ProtocolMismatch:
+    def test_pickle_garbage_raises_protocol_mismatch(self, monkeypatch):
+        """Non-JSON (e.g. pickle-era daemon) bytes raise a clear
+        ProtocolMismatchError, not an inscrutable UnicodeDecodeError (M-53)."""
+        from truememory import model_client as mc
+
+        # Invalid UTF-8 / non-JSON bytes (pickle protocol 2 header).
+        garbage = b"\x80\x02}q\x00X\x04\x00\x00\x00okq\x01\x88s."
+        stub = _StubSock(_framed(garbage))
+        monkeypatch.setattr(mc, "_connect", lambda deadline=None: stub)
+
+        with pytest.raises(mc.ProtocolMismatchError) as ei:
+            mc._send_request({"op": "ping"})
+        assert "protocol mismatch" in str(ei.value).lower()
+
+    def test_wrong_version_raises_protocol_mismatch(self, monkeypatch):
+        """A well-formed JSON response with an incompatible protocol version
+        is rejected (M-53)."""
+        from truememory import model_client as mc
+
+        body = json.dumps({"ok": True, "protocol": 999}).encode("utf-8")
+        stub = _StubSock(_framed(body))
+        monkeypatch.setattr(mc, "_connect", lambda deadline=None: stub)
+
+        with pytest.raises(mc.ProtocolMismatchError):
+            mc._send_request({"op": "ping"})
+
+    def test_matching_version_decodes_fine(self, monkeypatch):
+        """A correct-version JSON response decodes normally."""
+        from truememory import model_client as mc
+
+        body = json.dumps(
+            {"ok": True, "protocol": mc.PROTOCOL_VERSION}
+        ).encode("utf-8")
+        stub = _StubSock(_framed(body))
+        monkeypatch.setattr(mc, "_connect", lambda deadline=None: stub)
+
+        resp = mc._send_request({"op": "ping"})
+        assert resp["ok"] is True
+
+    def test_autostart_does_not_swallow_protocol_mismatch(self, monkeypatch):
+        """_request_with_autostart must re-raise ProtocolMismatchError rather
+        than treat it as a connection failure and retry (M-53)."""
+        from truememory import model_client as mc
+
+        def raise_mismatch(request, timeout=None):
+            raise mc.ProtocolMismatchError(
+                "protocol mismatch — old model server running; restart it"
+            )
+
+        monkeypatch.setattr(mc, "_send_request", raise_mismatch)
+        # If autostart were attempted, this would explode loudly.
+        monkeypatch.setattr(
+            mc, "_start_server",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("no retry")),
+        )
+
+        with pytest.raises(mc.ProtocolMismatchError):
+            mc._request_with_autostart({"op": "ping"})
+
+
+# ---------------------------------------------------------------------------
+# M-74: in-flight counter blocks idle shutdown
+# ---------------------------------------------------------------------------
+
+
+class TestM74InflightCounter:
+    def test_inflight_incremented_during_request(self, monkeypatch):
+        """While the request body runs, _inflight is > 0; it returns to 0
+        and activity is re-stamped at completion (M-74)."""
+        from truememory.model_server import ModelServer
+
+        server = ModelServer()
+        observed = {}
+
+        def slow_handle_request_inner(request):
+            with server._activity_lock:
+                observed["inflight_during"] = server._inflight
+            return {"ok": True}
+
+        monkeypatch.setattr(server, "_handle_request_inner", slow_handle_request_inner)
+
+        before = server._last_activity
+        time.sleep(0.01)
+        resp = server.handle_request({"op": "ping"})
+
+        assert resp["ok"] is True
+        assert observed["inflight_during"] == 1
+        assert server._inflight == 0
+        # Activity stamped at completion too (M-74), so it advanced.
+        assert server._last_activity >= before
+
+    def test_inflight_decremented_on_exception(self, monkeypatch):
+        """_inflight is restored even when the request body raises."""
+        from truememory.model_server import ModelServer
+
+        server = ModelServer()
+
+        def boom(request):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(server, "_handle_request_inner", boom)
+
+        with pytest.raises(RuntimeError):
+            server.handle_request({"op": "ping"})
+        assert server._inflight == 0

--- a/truememory/model_client.py
+++ b/truememory/model_client.py
@@ -45,6 +45,15 @@ _HEADER_FMT = ">I"
 _HEADER_SIZE = struct.calcsize(_HEADER_FMT)
 _MAX_MESSAGE_SIZE = 10 * 1024 * 1024  # 10 MB
 
+# Issue #646 (M-53): wire protocol version. Must match
+# ``model_server.PROTOCOL_VERSION``. On mismatch / non-JSON the client raises
+# a clear ConnectionError instead of an inscrutable UnicodeDecodeError.
+PROTOCOL_VERSION = 1
+
+
+class ProtocolMismatchError(ConnectionError):
+    """Raised when the server speaks an incompatible/foreign protocol."""
+
 _SERVER_START_TIMEOUT = 30.0
 _REQUEST_TIMEOUT = 120.0
 
@@ -281,12 +290,34 @@ def _start_server(wait_timeout: float | None = None) -> bool:
     return False
 
 
-def _connect(timeout: float | None = None) -> socket.socket:
-    """Open a connection to the model server (Unix or TCP)."""
-    request_timeout = _REQUEST_TIMEOUT if timeout is None else timeout
+def _remaining(deadline: float | None) -> float | None:
+    """Seconds left until *deadline* (a time.monotonic() value), or None.
+
+    Raises :class:`TimeoutError` if the deadline has already passed (M-76).
+    """
+    if deadline is None:
+        return None
+    left = deadline - time.monotonic()
+    if left <= 0:
+        raise TimeoutError("model server request deadline exceeded")
+    return left
+
+
+def _connect(
+    deadline: float | None = None, timeout: float | None = None
+) -> socket.socket:
+    """Open a connection to the model server (Unix or TCP).
+
+    *deadline* is an absolute ``time.monotonic()`` value bounding the TOTAL
+    request, not just this op (issue #646, M-76). *timeout* is a legacy
+    relative-seconds alias (converted to a deadline) kept for callers/tests
+    that predate the total-deadline change.
+    """
+    if deadline is None and timeout is not None:
+        deadline = time.monotonic() + timeout
     if _USE_UNIX:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(request_timeout)
+        sock.settimeout(_remaining(deadline) if deadline is not None else _REQUEST_TIMEOUT)
         try:
             sock.connect(str(SOCK_PATH))
         except OSError:
@@ -303,7 +334,7 @@ def _connect(timeout: float | None = None) -> socket.socket:
         raise ConnectionError("Model server token file not found")
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.settimeout(request_timeout)
+    sock.settimeout(_remaining(deadline) if deadline is not None else _REQUEST_TIMEOUT)
     try:
         sock.connect((_LOOPBACK_HOST, port))
         sock.sendall(token)
@@ -314,25 +345,71 @@ def _connect(timeout: float | None = None) -> socket.socket:
 
 
 def _send_request(request: dict, timeout: float | None = None) -> dict:
-    """Send a request to the model server and return the response."""
-    sock = _connect(timeout)
+    """Send a request to the model server and return the response.
+
+    *timeout* bounds the TOTAL request (connect + send + recv), not each
+    socket op (issue #646, M-76): the old per-op settimeout could blow ~4x
+    the intended budget in the worst case. A single ``time.monotonic()``
+    deadline is computed once and the remaining budget is re-applied before
+    each blocking op.
+
+    The deadline is also shipped to the server in the payload (M-44) so an
+    already-expired request fails cheaply server-side, before the global
+    lock and a full encode.
+    """
+    deadline = None if timeout is None else time.monotonic() + timeout
+    sock = _connect(deadline)
     try:
-        data = json.dumps(request).encode("utf-8")
+        payload = request
+        if timeout is not None and "deadline" not in payload:
+            # Server checks this wall-clock epoch deadline before encode (M-44).
+            payload = {**request, "deadline": time.time() + max(_remaining(deadline), 0.0)}
+        data = json.dumps(payload).encode("utf-8")
         header = struct.pack(_HEADER_FMT, len(data))
+        sock.settimeout(_remaining(deadline) if deadline is not None else _REQUEST_TIMEOUT)
         sock.sendall(header + data)
 
+        sock.settimeout(_remaining(deadline) if deadline is not None else _REQUEST_TIMEOUT)
         resp_header = _recv_exact(sock, _HEADER_SIZE)
         if not resp_header:
             raise ConnectionError("Server closed connection")
         resp_len = struct.unpack(_HEADER_FMT, resp_header)[0]
         if resp_len > _MAX_MESSAGE_SIZE:
             raise ConnectionError(f"Response too large: {resp_len} bytes")
+        sock.settimeout(_remaining(deadline) if deadline is not None else _REQUEST_TIMEOUT)
         resp_data = _recv_exact(sock, resp_len)
         if not resp_data:
             raise ConnectionError("Incomplete response")
-        return json.loads(resp_data, object_hook=_json_object_hook)
+        return _decode_response(resp_data)
     finally:
         sock.close()
+
+
+def _decode_response(resp_data: bytes) -> dict:
+    """Decode a server response, detecting a foreign/stale protocol (M-53).
+
+    A stale pickle-era daemon (or any non-JSON producer) returns bytes that
+    aren't valid UTF-8 JSON; previously that surfaced as an inscrutable
+    UnicodeDecodeError. Detect it and raise a clear, actionable error. A
+    well-formed JSON response carrying an incompatible ``protocol`` version
+    is rejected the same way.
+    """
+    try:
+        resp = json.loads(resp_data, object_hook=_json_object_hook)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as e:
+        raise ProtocolMismatchError(
+            "protocol mismatch — old model server running; restart it"
+        ) from e
+    if not isinstance(resp, dict):
+        raise ProtocolMismatchError(
+            "protocol mismatch — old model server running; restart it"
+        )
+    proto = resp.get("protocol")
+    if proto is not None and proto != PROTOCOL_VERSION:
+        raise ProtocolMismatchError(
+            "protocol mismatch — old model server running; restart it"
+        )
+    return resp
 
 
 def _recv_exact(sock: socket.socket, n: int) -> bytes | None:
@@ -368,6 +445,11 @@ def _request_with_autostart(request: dict, timeout: float | None = None) -> dict
 
     try:
         return _send_request(request, timeout=timeout)
+    except ProtocolMismatchError:
+        # A stale/foreign server is bound (M-53). Restarting won't help until
+        # it's killed — surface the clear, actionable error rather than spin
+        # through an autostart retry (which can't bind anyway).
+        raise
     except TimeoutError:
         # socket.timeout is TimeoutError on Python >= 3.10.
         if has_deadline:

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -71,9 +71,38 @@ PORT_PATH = _TRUEMEMORY_DIR / "model_server.port"
 TOKEN_PATH = _TRUEMEMORY_DIR / "model_server.token"
 IDLE_TIMEOUT = int(os.environ.get("TRUEMEMORY_MODEL_SERVER_IDLE", "300"))
 
+LOCK_PATH = _TRUEMEMORY_DIR / "model_server.lock"
+
+# Issue #646 (M-53): protocol/version handshake. Bumped whenever the wire
+# format changes incompatibly. The client echoes this back on mismatch.
+PROTOCOL_VERSION = 1
+
 _HEADER_FMT = ">I"
 _HEADER_SIZE = struct.calcsize(_HEADER_FMT)
 _MAX_MESSAGE_SIZE = 10 * 1024 * 1024  # 10 MB
+
+
+def _safe_to_cleanup_artifacts() -> bool:
+    """Return True when this process may remove the shared artifacts (M-20).
+
+    ``_cleanup`` must NOT unlink a live successor's socket/pid/port/token:
+    after a crash a fresh server can already hold the bind lock and have
+    rewritten PID_PATH, and tearing down its files lets concurrent hooks
+    cycle servers indefinitely.
+
+    It is safe to clean when PID_PATH names *this* process, or when it names
+    nothing live (missing file, unparseable, or a dead PID — a stale crash
+    artifact). The ONLY case we refuse is PID_PATH naming a *different live*
+    process — the successor that now owns the artifacts.
+    """
+    try:
+        on_disk = int(PID_PATH.read_text().strip())
+    except (ValueError, OSError):
+        return True  # missing / unparseable — nothing live owns it
+    if on_disk == os.getpid():
+        return True
+    # A different PID is recorded — only refuse if it's actually alive.
+    return not pid_is_alive(on_disk)
 
 
 def _json_default(obj):
@@ -162,6 +191,12 @@ class ModelServer:
         self._fast_encoder = None
         self._fast_model_id: str | None = None
         self._fast_lock = threading.Lock()
+        # Issue #646 (M-20): exclusive bind-lock fd, held for the process
+        # lifetime; released in _cleanup. None until run() acquires it.
+        self._lock_fd: int | None = None
+        # Issue #646 (M-74): in-flight request counter so idle shutdown never
+        # kills a request mid-encode. Guarded by _activity_lock.
+        self._inflight = 0
 
     def _mark_sticky_cpu(self, kind: str) -> bool:
         """Permanently degrade *kind* ("embed"/"rerank") to CPU after an
@@ -426,12 +461,39 @@ class ModelServer:
             return None
 
     def handle_request(self, request: dict) -> dict:
+        # Issue #646 (M-74): count this request as in-flight and stamp
+        # activity at START *and* completion. The in-flight counter keeps the
+        # idle checker from shutting the server down mid-encode; re-stamping
+        # at completion means a long encode that finishes near the idle
+        # horizon isn't reaped the instant it returns.
         with self._activity_lock:
             self._last_activity = time.time()
+            self._inflight += 1
+        try:
+            return self._handle_request_inner(request)
+        finally:
+            with self._activity_lock:
+                self._inflight -= 1
+                self._last_activity = time.time()
+
+    def _handle_request_inner(self, request: dict) -> dict:
         op = request.get("op")
 
         if op == "ping":
             return {"ok": True}
+
+        # Issue #646 (M-44): server-side deadline. The client ships an
+        # absolute monotonic-equivalent deadline as wall-clock epoch seconds
+        # ("deadline"). If it has already passed, fail cheap BEFORE acquiring
+        # the global lock or running a full encode — the client has already
+        # abandoned the request and fallen back to FTS-only.
+        deadline = request.get("deadline")
+        if deadline is not None:
+            try:
+                if time.time() >= float(deadline):
+                    return {"ok": False, "error": "deadline exceeded before encode"}
+            except (TypeError, ValueError):
+                pass
 
         if op == "embed":
             texts = request["texts"]
@@ -457,10 +519,17 @@ class ModelServer:
                 )
 
             if should_activate:
-                self._activate_throttler()
+                with self._lock:
+                    self._activate_throttler()
 
-            if self._throttler_active and self._throttler:
-                self._throttler.before_batch()
+            # Issue #646 (M-43): capture the throttler to a local under the
+            # lock. Reading self._throttler_active then self._throttler
+            # separately raced _deactivate_throttler nulling the attribute
+            # between the two reads (AttributeError on before_batch()).
+            with self._lock:
+                throttler = self._throttler if self._throttler_active else None
+            if throttler is not None:
+                throttler.before_batch()
 
             encode_start = time.time()
             # `vectors` is assigned on exactly one of two paths: inside the
@@ -493,15 +562,18 @@ class ModelServer:
                 vectors = model.encode(texts, show_progress_bar=False)
             encode_time = time.time() - encode_start
 
-            if self._throttler_active and self._throttler:
-                self._throttler.after_batch(len(texts), encode_time)
-                if self._throttler.should_flush_cache():
+            # M-43: re-capture under the lock for the same reason as above.
+            with self._lock:
+                throttler = self._throttler if self._throttler_active else None
+            if throttler is not None:
+                throttler.after_batch(len(texts), encode_time)
+                if throttler.should_flush_cache():
                     self._flush_mps_cache()
 
             with self._lock:
                 should_deactivate = self._throttler_active and len(self._embed_timestamps) < 3
-            if should_deactivate:
-                self._deactivate_throttler()
+                if should_deactivate:
+                    self._deactivate_throttler()
 
             return {"ok": True, "vectors": np.asarray(vectors, dtype=np.float32)}
 
@@ -543,7 +615,12 @@ class ModelServer:
         return {"ok": False, "error": f"Unknown op: {op}"}
 
     def _activate_throttler(self):
-        """Start adaptive throttling for sustained workload."""
+        """Start adaptive throttling for sustained workload.
+
+        Caller must hold ``self._lock`` (issue #646, M-43): activate and
+        deactivate mutate ``_throttler`` / ``_throttler_active`` together and
+        must not interleave with the lock-free readers in ``handle_request``.
+        """
         try:
             from truememory.tier_switch.throttler import DynamicThrottler
         except ImportError:
@@ -572,7 +649,10 @@ class ModelServer:
         )
 
     def _deactivate_throttler(self):
-        """Stop adaptive throttling — workload ended."""
+        """Stop adaptive throttling — workload ended.
+
+        Caller must hold ``self._lock`` (issue #646, M-43).
+        """
         self._throttler = None
         self._throttler_active = False
         self._embed_timestamps.clear()
@@ -650,6 +730,11 @@ class ModelServer:
         return bytes(buf)
 
     def _send_response(self, conn: socket.socket, response: dict):
+        # Issue #646 (M-53): tag every response with the protocol version so
+        # a newer client can detect a version mismatch instead of choking on
+        # an unexpected payload shape.
+        if "protocol" not in response:
+            response = {**response, "protocol": PROTOCOL_VERSION}
         data = json.dumps(response, default=_json_default).encode("utf-8")
         if len(data) > _MAX_MESSAGE_SIZE:
             data = json.dumps({"ok": False, "error": "Response too large"}).encode("utf-8")
@@ -663,8 +748,12 @@ class ModelServer:
                 break
             with self._activity_lock:
                 last = self._last_activity
+                inflight = self._inflight
             elapsed = time.time() - last
-            if elapsed >= IDLE_TIMEOUT:
+            # Issue #646 (M-74): never idle-shut-down while a request is
+            # mid-flight, even if its start timestamp is older than the idle
+            # horizon (a long batch encode can outlast IDLE_TIMEOUT).
+            if elapsed >= IDLE_TIMEOUT and inflight == 0:
                 log.info(
                     "Idle timeout (%.0fs), shutting down model server", elapsed
                 )
@@ -713,12 +802,43 @@ class ModelServer:
                 f2.write(text)
             tmp.unlink(missing_ok=True)
 
+    def _acquire_bind_lock(self):
+        """Take an exclusive lock BEFORE binding (issue #646, M-20).
+
+        The previous design wrote PID_PATH then bound, leaving a multi-second
+        TOCTOU window (PID written before imports finish) during which a
+        second concurrent starter would also bind and the two servers would
+        cycle each other's artifacts indefinitely. Holding an OS-level
+        exclusive lock for the process lifetime makes "only one server binds"
+        atomic. On POSIX we use ``flock``; on Windows ``msvcrt.locking``. The
+        fd is kept open (and stored on ``self``) until the process exits.
+
+        Returns the lock fd, or raises ``RuntimeError`` if another live
+        server holds the lock.
+        """
+        fd = os.open(str(LOCK_PATH), os.O_CREAT | os.O_RDWR, 0o644)
+        try:
+            if sys.platform == "win32":
+                import msvcrt
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            os.close(fd)
+            raise RuntimeError("another model server holds the bind lock")
+        return fd
+
     def run(self):
         _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
 
-        PID_PATH.write_text(str(os.getpid()))
+        # Exclusive bind lock BEFORE touching socket/pid artifacts (M-20).
+        self._lock_fd = self._acquire_bind_lock()
 
         if _USE_UNIX:
+            # We hold the exclusive lock, so any socket file here is stale
+            # (a crashed predecessor); safe to remove now that no live peer
+            # can own it.
             if SOCK_PATH.exists():
                 SOCK_PATH.unlink()
             srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -733,6 +853,9 @@ class ModelServer:
             self._atomic_write_text(TOKEN_PATH, self._token.hex(), mode=0o600)
             self._atomic_write_text(PORT_PATH, str(self._bound_port), mode=0o600)
             transport_desc = f"tcp={_LOOPBACK_HOST}:{self._bound_port}"
+        # PID written only AFTER a successful bind — never advertises a
+        # not-yet-listening server (M-20). We own the artifacts from here.
+        PID_PATH.write_text(str(os.getpid()))
         srv.listen(16)
         srv.settimeout(2.0)
 
@@ -767,11 +890,24 @@ class ModelServer:
         if getattr(self, "_cleaned_up", False):
             return
         self._cleaned_up = True
-        for p in (SOCK_PATH, PID_PATH, PORT_PATH, TOKEN_PATH):
+        # Only remove artifacts THIS process owns (issue #646, M-20). After a
+        # crash a fresh server may already hold the lock and have rewritten
+        # PID_PATH; unlinking its live socket/token here would let concurrent
+        # hooks cycle servers indefinitely.
+        if _safe_to_cleanup_artifacts():
+            for p in (SOCK_PATH, PID_PATH, PORT_PATH, TOKEN_PATH):
+                try:
+                    p.unlink(missing_ok=True)
+                except OSError:
+                    pass
+        # Release the bind lock (lock fd is process-owned, always safe).
+        lock_fd = getattr(self, "_lock_fd", None)
+        if lock_fd is not None:
             try:
-                p.unlink(missing_ok=True)
+                os.close(lock_fd)
             except OSError:
                 pass
+            self._lock_fd = None
         # Reset the embed snapshot and fast-lane identity so no stale model
         # identity survives a stop (issue #577, panel round 2).
         self._embed_state = None
@@ -806,6 +942,11 @@ def main():
     if hasattr(signal, "SIGHUP"):
         signal.signal(signal.SIGHUP, _handle_signal)
 
+    # Fast pre-check: a live PID means a server is (probably) already up.
+    # This is advisory only — the authoritative guard is the exclusive bind
+    # lock taken inside run() (issue #646, M-20), which closes the TOCTOU
+    # window this check alone left open. Stale artifacts from a crashed
+    # predecessor are reclaimed under the lock in run(), not here.
     if PID_PATH.exists():
         try:
             old_pid = int(PID_PATH.read_text().strip())
@@ -814,18 +955,19 @@ def main():
                 sys.exit(1)
         except (ValueError, OSError):
             pass
-        PID_PATH.unlink(missing_ok=True)
-        if SOCK_PATH.exists():
-            SOCK_PATH.unlink(missing_ok=True)
-        PORT_PATH.unlink(missing_ok=True)
-        TOKEN_PATH.unlink(missing_ok=True)
 
     server = ModelServer()
 
     # Ensure cleanup runs even on unhandled exit.
     atexit.register(server._cleanup)
 
-    server.run()
+    try:
+        server.run()
+    except RuntimeError as e:
+        # Lost the bind-lock race to a concurrent starter (M-20). Exit
+        # cleanly without touching the winner's artifacts.
+        log.error("Model server start aborted: %s", e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #646.

Model-server lifecycle / socket hardening. Minimal, conservative changes to `truememory/model_server.py` and `truememory/model_client.py` only (+ tests). This server was implicated in a real production lock incident, so the bind/cleanup path is the priority.

## Changes per finding

**M-20 (P1) — duplicate bind race / cleanup ownership.**
- New `_acquire_bind_lock()` takes an OS-level exclusive lock (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows) on `~/.truememory/model_server.lock` **before** binding the socket, held for the process lifetime. This closes the multi-second TOCTOU window where the old code wrote PID_PATH (before imports finished) and two concurrent starters could both bind and cycle each other indefinitely.
- PID_PATH is now written **after** a successful bind, never advertising a not-yet-listening server.
- `run()` only unlinks a pre-existing socket *while holding the exclusive lock* (so it's provably stale).
- `_cleanup()` now consults `_safe_to_cleanup_artifacts()`: it removes the shared artifacts only when PID_PATH names this process, is missing/unparseable, or names a **dead** PID. It refuses when PID_PATH names a *different live* process (a successor that now owns them) — the exact case that let crashed/concurrent hooks cycle servers.
- `main()` keeps the advisory PID pre-check but the authoritative guard is now the lock; a lost-race `RuntimeError` exits cleanly without touching the winner's files.

**M-43 (P2) — throttler TOCTOU.** `handle_request` (now `_handle_request_inner`) captures `self._throttler` to a local under `self._lock` before `before_batch()`/`after_batch()`, instead of re-reading `self._throttler_active` then `self._throttler` separately (which raced `_deactivate_throttler` nulling the attribute → AttributeError). `_activate_throttler`/`_deactivate_throttler` are now called under `self._lock`.

**M-44 (P2) — server-side deadline.** The client ships an absolute wall-clock `deadline` in the request payload; the server checks it at the top of dispatch and returns a cheap error **before** acquiring the global lock or encoding, instead of running a full encode for an already-abandoned request.

**M-53 (P2) — protocol handshake.** New `ProtocolMismatchError(ConnectionError)`. `_decode_response()` detects non-JSON bytes (a stale pickle-era daemon) or an incompatible `protocol` version and raises `"protocol mismatch — old model server running; restart it"` instead of an inscrutable `UnicodeDecodeError`. Responses are tagged with `PROTOCOL_VERSION`. `_request_with_autostart` re-raises the mismatch rather than treating it as a connection failure and retrying.

**M-74 (P3) — idle shutdown vs in-flight requests.** `handle_request` wraps dispatch with an in-flight counter and stamps activity at **completion** as well as start. The idle checker refuses to shut down while `_inflight > 0`, so a long batch encode that outlasts the idle horizon is never reaped mid-flight.

**M-76 (P3) — per-op vs total deadline.** The client computes a single `time.monotonic()` deadline once and re-applies the *remaining* budget before each blocking socket op (connect/send/recv), instead of a per-op `settimeout` that could blow ~4x the intended budget.

### Deferred
**M-75 (P3) — fast-lane device.** The single-text fast lane (#577) intentionally uses a *separate CPU* encoder so hook recall never contends on the global lock or MPS pool. Making it honor the main lane's device (MPS) risks reintroducing exactly the MPS contention #577 removed. Deferred as not-low-risk; the ~1e-5 ranking jitter and extra RAM copy are the documented cost of the fast lane. Out of scope here.

## Tests
New `tests/test_issue_646_model_server.py` (14 tests, all hermetic — stub sockets / fake servers, no real model loads, `HF_HUB_OFFLINE=1`):
- `_cleanup` does NOT delete a different live server's socket/pid/token; DOES remove its own; stale dead-PID artifacts are reclaimable; a held bind lock refuses a second server.
- throttler capture-to-local survives mid-flight deactivation (no AttributeError); embed with active throttler completes.
- expired-deadline request rejected before encode; future deadline encodes.
- client raises `ProtocolMismatchError` on pickle/garbage bytes and on wrong protocol version; matching version decodes; autostart doesn't swallow the mismatch.
- in-flight counter is 1 during a request, returns to 0 (and on exception), activity re-stamped at completion.

Adjusted `tests/test_issue_489_mps_safety.py` to inspect `_handle_request_inner` (the embed-dispatch body after the in-flight wrapper split) — behavior-preserving.

`ruff check truememory/ tests/` passes. Targeted run: `104 passed, 0 failed` across `-k "model_server or model_client or throttle or socket or deadline or embed"`; plus 489/598/577 suites green (45 + 22).