### PR TITLE
fix: vector rebuild durability — in-progress marker, no destructive pre-wipe, metadata atomicity, sep-vector batch commits (#647)

### DIFF
--- a/tests/test_issue_647_vector_rebuild.py
+++ b/tests/test_issue_647_vector_rebuild.py
@@ -1,0 +1,337 @@
+"""Issue #647 — vector rebuild durability.
+
+M-21 (P1): ``build_vectors`` used to ``DELETE FROM {tbl}; commit()`` *before*
+any embedding, so a mid-run failure persisted an empty/partial table that
+``engine.open()`` accepted as "built" — and embedder metadata was committed
+separately, so a crash mid tier-migration could leave NEW vectors under OLD
+metadata. Fix: an ``in_progress`` build-state marker written in the SAME
+transaction as the DELETE and cleared with the final commit (alongside the
+embedder metadata); a table left ``in_progress`` is treated as NOT built and
+the build resumes from ``max(rowid)`` rather than re-wiping.
+
+M-45 (P2): ``build_separation_vectors`` never got #619's batch-commit
+treatment — it held one giant write transaction for the entire run. Fix:
+mirror ``build_vectors``' batched commits + the same marker.
+
+These tests construct embeddings by hand (mock model) — no model loads,
+HF_HUB_OFFLINE-safe — and gate on the repo's sqlite-vec skip pattern.
+"""
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+def _can_load_vec() -> bool:
+    """Check if sqlite-vec can actually be loaded (not just importable)."""
+    try:
+        import sqlite_vec
+        conn = sqlite3.connect(":memory:")
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+_HAS_VEC = _can_load_vec()
+
+pytestmark = pytest.mark.skipif(not _HAS_VEC, reason="sqlite-vec cannot load")
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror tests/test_issue_590_build_vectors_batch.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_model():
+    """Deterministic 256-d vectors, text-seeded so identical text → identical vec."""
+    mock = MagicMock()
+
+    def _encode(texts, **kw):
+        vecs = []
+        for t in texts:
+            rng = np.random.RandomState(hash(t) % (2**31))
+            vecs.append(rng.randn(256).astype(np.float32))
+        return np.array(vecs)
+
+    mock.encode = _encode
+    return mock
+
+
+def _make_server(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    db_path = tmp_path / "memories.db"
+    monkeypatch.setenv("TRUEMEMORY_DB", str(db_path))
+    monkeypatch.setenv("TRUEMEMORY_EMBED_MODEL", "edge")
+    import truememory.mcp_server as ms
+
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    monkeypatch.setattr(ms, "_DB_PATH", str(db_path))
+    monkeypatch.setattr(ms, "_memory", None)
+    return ms, db_path
+
+
+def _seed_messages(ms, n: int) -> None:
+    m = ms._get_memory()
+    for i in range(n):
+        m.add(f"memory number {i}", user_id="test")
+
+
+class _CommitCountingConn:
+    """Real connection wrapper that counts commit() calls (3.14-safe proxy)."""
+
+    def __init__(self, real_conn: sqlite3.Connection):
+        self._real = real_conn
+        self.commit_count = 0
+
+    def commit(self):
+        self.commit_count += 1
+        self._real.commit()
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+@pytest.fixture
+def server(monkeypatch, tmp_path):
+    mock_model = _make_mock_model()
+    with patch("truememory.vector_search.get_model", return_value=mock_model):
+        ms, _db = _make_server(monkeypatch, tmp_path)
+        yield ms
+    if ms._memory is not None:
+        try:
+            ms._memory.close()
+        except Exception:
+            pass
+    ms._memory = None
+    import truememory.vector_search as vs
+
+    vs.set_embedding_model("edge")
+
+
+# ---------------------------------------------------------------------------
+# (a) Interrupted build → table marked in_progress → treated as NOT built
+# ---------------------------------------------------------------------------
+
+
+class TestInterruptedBuildNotTrusted:
+    def test_marker_set_during_build_and_failure_leaves_it(self, server, monkeypatch):
+        """A build that raises mid-run leaves the in_progress marker set, and
+        the table is therefore reported as NOT built."""
+        _seed_messages(server, 12)
+        mem = server._get_memory()
+        conn = mem._engine.conn
+        import truememory.vector_search as vs
+
+        monkeypatch.setattr(vs, "_get_batch_size", lambda: 3)
+
+        call_count = {"n": 0}
+        real_encode = vs._encode_with_mps_fallback
+
+        def failing_encode(model, texts, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] >= 3:
+                raise RuntimeError("simulated embedding failure")
+            return real_encode(model, texts, **kwargs)
+
+        monkeypatch.setattr(vs, "_encode_with_mps_fallback", failing_encode)
+
+        tbl = vs._active_vec_table(conn)
+        with pytest.raises(RuntimeError, match="simulated embedding failure"):
+            vs.build_vectors(conn, txn_batch=1)
+
+        # Marker survives the crash -> table is mid-build.
+        assert vs._build_in_progress(conn, tbl) is True
+        # engine-side "is it built?" check must reject the partial table.
+        assert vs.vectors_are_built(conn, tbl) is False
+
+    def test_empty_table_with_marker_not_built(self, server):
+        """A 0-row table left in_progress (the classic crash-before-first-batch
+        case) must NOT be accepted as built."""
+        _seed_messages(server, 3)
+        mem = server._get_memory()
+        conn = mem._engine.conn
+        import truememory.vector_search as vs
+
+        tbl = vs._active_vec_table(conn)
+        conn.execute(f"DELETE FROM {tbl}")
+        vs._mark_build_in_progress(conn, tbl)
+        conn.commit()
+
+        # Old behaviour: SELECT 1 ... LIMIT 1 succeeds -> "built". New: rejected.
+        assert vs.vectors_are_built(conn, tbl) is False
+
+
+# ---------------------------------------------------------------------------
+# (b) Resume after interruption does not wipe already-written vectors
+# ---------------------------------------------------------------------------
+
+
+class TestResumeDoesNotWipe:
+    def test_resume_keeps_prior_vectors_and_completes(self, server, monkeypatch):
+        """After an interruption left N committed vectors + marker, a second
+        build resumes from max(rowid): it does NOT re-wipe and ends with every
+        message embedded exactly once."""
+        _seed_messages(server, 12)
+        mem = server._get_memory()
+        conn = mem._engine.conn
+        import truememory.vector_search as vs
+
+        monkeypatch.setattr(vs, "_get_batch_size", lambda: 3)
+        tbl = vs._active_vec_table(conn)
+
+        # First run: fail on the 3rd embedding batch (rows 1-6 committed).
+        call_count = {"n": 0}
+        real_encode = vs._encode_with_mps_fallback
+
+        def failing_encode(model, texts, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] >= 3:
+                raise RuntimeError("boom")
+            return real_encode(model, texts, **kwargs)
+
+        monkeypatch.setattr(vs, "_encode_with_mps_fallback", failing_encode)
+        with pytest.raises(RuntimeError, match="boom"):
+            vs.build_vectors(conn, txn_batch=1)
+
+        survived = conn.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]
+        assert survived == 6
+        max_before = conn.execute(f"SELECT MAX(rowid) FROM {tbl}").fetchone()[0]
+        assert max_before == 6
+
+        # Second run: encoding works again. Resume must NOT delete the 6 rows.
+        monkeypatch.setattr(vs, "_encode_with_mps_fallback", real_encode)
+
+        # Wrap the connection to assert the resume path issues NO DELETE
+        # (sqlite3.Connection attrs are read-only in 3.14, so proxy instead of
+        # patching .execute in place).
+        class _ExecSpyConn:
+            def __init__(self, real):
+                self._real = real
+                self.executed: list[str] = []
+
+            def execute(self, sql, *a, **k):
+                self.executed.append(sql)
+                return self._real.execute(sql, *a, **k)
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+        spy = _ExecSpyConn(conn)
+        added = vs.build_vectors(spy, txn_batch=1)
+        executed = spy.executed
+
+        # Resumed run only embedded the remaining 6 messages.
+        assert added == 6
+        assert not any(
+            sql.strip().upper().startswith(f"DELETE FROM {tbl.upper()}")
+            for sql in executed
+        ), "resume path must not DELETE already-written vectors"
+
+        total = conn.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]
+        assert total == 12
+        # rowids are unique (no duplicate re-embed of rows 1-6).
+        distinct = conn.execute(
+            f"SELECT count(DISTINCT rowid) FROM {tbl}"
+        ).fetchone()[0]
+        assert distinct == 12
+        # Marker cleared on success.
+        assert vs._build_in_progress(conn, tbl) is False
+        assert vs.vectors_are_built(conn, tbl) is True
+
+
+# ---------------------------------------------------------------------------
+# (c) build_separation_vectors commits in batches (M-45)
+# ---------------------------------------------------------------------------
+
+
+class TestSeparationBatchCommits:
+    def test_separation_does_not_hold_one_giant_txn(self, server, monkeypatch):
+        """build_separation_vectors must commit multiple times (DELETE/marker +
+        per-batch commits + final), not a single end-of-run commit."""
+        _seed_messages(server, 12)
+        mem = server._get_memory()
+        real_conn = mem._engine.conn
+        import truememory.vector_search as vs
+
+        monkeypatch.setattr(vs, "_get_batch_size", lambda: 3)  # 4 batches
+
+        wrapper = _CommitCountingConn(real_conn)
+        count = vs.build_separation_vectors(wrapper, txn_batch=1)
+        assert count == 12
+
+        # DELETE/marker (1) + 4 batch commits + final clear/metadata (1) >= 6.
+        assert wrapper.commit_count >= 6, (
+            f"separation build held too few commits ({wrapper.commit_count}); "
+            f"expected batched commits, not one giant transaction"
+        )
+
+    def test_separation_marker_cleared_on_success(self, server):
+        _seed_messages(server, 5)
+        mem = server._get_memory()
+        conn = mem._engine.conn
+        import truememory.vector_search as vs
+
+        vs.build_separation_vectors(conn, txn_batch=1)
+        sep_tbl = vs._active_sep_table(conn)
+        assert vs._build_in_progress(conn, sep_tbl) is False
+
+
+# ---------------------------------------------------------------------------
+# (d) Marker cleared on success alongside embedder metadata
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerClearedWithMetadata:
+    def test_marker_cleared_and_metadata_written(self, server):
+        _seed_messages(server, 5)
+        mem = server._get_memory()
+        conn = mem._engine.conn
+        import truememory.vector_search as vs
+
+        tbl = vs._active_vec_table(conn)
+        n = vs.build_vectors(conn, txn_batch=1)
+        assert n == 5
+
+        # Marker gone, table trusted.
+        assert vs._build_in_progress(conn, tbl) is False
+        assert vs.vectors_are_built(conn, tbl) is True
+
+        # Embedder metadata stamped (model + dim), so no NEW-vectors-under-OLD
+        # -metadata window.
+        model, dim = vs._read_embedder_metadata(conn)
+        assert model == vs.EMBEDDING_MODEL
+        assert dim == vs._embedding_dim
+
+    def test_metadata_and_marker_clear_share_final_commit(self, server, monkeypatch):
+        """The marker clear and embedder-metadata write must be committed
+        together — never a window where vectors are present + trusted but
+        metadata is stale."""
+        _seed_messages(server, 5)
+        mem = server._get_memory()
+        real_conn = mem._engine.conn
+        import truememory.vector_search as vs
+
+        tbl = vs._active_vec_table(real_conn)
+        # Stale metadata from a hypothetical previous embedder.
+        vs._ensure_metadata_table(real_conn)
+        real_conn.execute(
+            "INSERT OR REPLACE INTO metadata(key, value, updated_at) "
+            "VALUES ('embed_model', 'stale-old-model', '')"
+        )
+        real_conn.commit()
+
+        # After the final commit of a successful build, metadata is current AND
+        # the marker is clear in the same observable state.
+        vs.build_vectors(real_conn, txn_batch=1)
+        model, _ = vs._read_embedder_metadata(real_conn)
+        assert model == vs.EMBEDDING_MODEL
+        assert vs._build_in_progress(real_conn, tbl) is False

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -1288,12 +1288,17 @@ class TrueMemoryEngine:
         # rebuild; route the user through truememory_configure() instead.
         self._has_vectors = False
         if _HAS_VECTOR:
-            from truememory.vector_search import _active_vec_table
+            from truememory.vector_search import (
+                _active_vec_table,
+                vectors_are_built,
+            )
             vec_tbl = _active_vec_table(self.conn)
-            try:
-                self.conn.execute(f"SELECT 1 FROM {vec_tbl} LIMIT 1").fetchone()
+            # vectors_are_built() returns False for a table left ``in_progress``
+            # by an interrupted build (issue #647) — so a partial/empty table is
+            # rebuilt rather than trusted, not just one that's missing.
+            if vectors_are_built(self.conn, vec_tbl):
                 self._has_vectors = True
-            except Exception:
+            else:
                 logger.warning(
                     "Vector table %r missing or unreadable; attempting rebuild "
                     "with current model=%s",

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -313,8 +313,13 @@ def _ensure_metadata_table(conn: sqlite3.Connection) -> None:
     )
 
 
-def _write_embedder_metadata(conn: sqlite3.Connection) -> None:
-    """Record `(embed_model, embed_dim)` so later opens can detect drift."""
+def _write_embedder_metadata_no_commit(conn: sqlite3.Connection) -> None:
+    """Stage `(embed_model, embed_dim)` rows WITHOUT committing.
+
+    Lets callers (build_vectors / build_separation_vectors) commit the embedder
+    metadata in the same transaction as clearing the in-progress marker, so the
+    table is never "trusted" under stale metadata (issue #647).
+    """
     _ensure_metadata_table(conn)
     now = datetime.datetime.now(datetime.timezone.utc).isoformat()
     conn.execute(
@@ -325,7 +330,88 @@ def _write_embedder_metadata(conn: sqlite3.Connection) -> None:
         "INSERT OR REPLACE INTO metadata(key, value, updated_at) VALUES (?, ?, ?)",
         ("embed_dim", str(_embedding_dim), now),
     )
+
+
+def _write_embedder_metadata(conn: sqlite3.Connection) -> None:
+    """Record `(embed_model, embed_dim)` so later opens can detect drift."""
+    _write_embedder_metadata_no_commit(conn)
     conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Build-state marker (issue #647)
+# ---------------------------------------------------------------------------
+#
+# A vec0 table that exists with rows looks "built" to engine.open() — but a run
+# killed mid-embed (or one that hit a None content / NaN embedding) leaves a
+# partial or empty table that must NOT be trusted. We persist an in-progress
+# marker in the SAME transaction as the destructive DELETE and clear it only
+# with the final commit (alongside the embedder metadata). Any table whose
+# marker is still ``in_progress`` is treated as NOT built and rebuilt.
+#
+# This is deliberately separate from #631's ``*_cos_stage`` staging tables:
+# that machinery makes the *L2→cosine re-norm* (no re-embed) crash-safe; this
+# marker makes the *re-embed* (build_vectors / build_separation_vectors) crash-
+# safe. They compose — a build leaves the marker; a cosine migration leaves a
+# stage table; neither touches the other's state.
+
+_BUILD_STATE_KEY_PREFIX = "vec_build_state:"
+
+
+def _build_state_key(table_name: str) -> str:
+    return f"{_BUILD_STATE_KEY_PREFIX}{table_name}"
+
+
+def _mark_build_in_progress(conn: sqlite3.Connection, table_name: str) -> None:
+    """Record that *table_name* is mid-build. Caller controls the commit so the
+    marker lands in the same transaction as the DELETE that wipes the table."""
+    _ensure_metadata_table(conn)
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata(key, value, updated_at) VALUES (?, ?, ?)",
+        (_build_state_key(table_name), "in_progress", now),
+    )
+
+
+def _clear_build_in_progress(conn: sqlite3.Connection, table_name: str) -> None:
+    """Clear the in-progress marker for *table_name*. Caller controls commit."""
+    _ensure_metadata_table(conn)
+    conn.execute(
+        "DELETE FROM metadata WHERE key = ?", (_build_state_key(table_name),)
+    )
+
+
+def _build_in_progress(conn: sqlite3.Connection, table_name: str) -> bool:
+    """True if *table_name* has an uncleared in-progress build marker."""
+    try:
+        _ensure_metadata_table(conn)
+        row = conn.execute(
+            "SELECT value FROM metadata WHERE key = ?",
+            (_build_state_key(table_name),),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return False
+    return bool(row) and row[0] == "in_progress"
+
+
+def vectors_are_built(
+    conn: sqlite3.Connection, table_name: str | None = None
+) -> bool:
+    """True if the active (or named) vec table is present, readable, and not
+    mid-build.
+
+    A table left ``in_progress`` by an interrupted build is treated as NOT
+    built so engine.open() rebuilds it rather than trusting partial/empty data
+    (issue #647, M-21). Also returns False if the table is missing/unreadable.
+    """
+    tbl = table_name or _active_vec_table(conn)
+    if _build_in_progress(conn, tbl):
+        return False
+    try:
+        conn.execute(f"SELECT 1 FROM {tbl} LIMIT 1").fetchone()
+    except sqlite3.OperationalError:
+        return False
+    return True
 
 
 def _read_embedder_metadata(
@@ -667,8 +753,35 @@ def build_vectors(
         return 0
 
     tbl = table_name or _active_vec_table(conn)
-    conn.execute(f"DELETE FROM {tbl}")
-    conn.commit()
+
+    # Resume vs. fresh build (issue #647, M-21).
+    #
+    # If a prior run was interrupted it left an ``in_progress`` marker. The
+    # rows already written are valid (each is L2-normalized at write time), so
+    # we resume from ``max(rowid)`` instead of re-wiping — no data confusion,
+    # no redundant re-embedding. On a fresh build we wipe and set the marker in
+    # the SAME transaction, so a crash before completion never leaves an
+    # untracked partial/empty table that engine.open() would trust.
+    resume_after = 0
+    if _build_in_progress(conn, tbl):
+        try:
+            resume_after = conn.execute(
+                f"SELECT MAX(rowid) FROM {tbl}"
+            ).fetchone()[0] or 0
+        except sqlite3.OperationalError:
+            resume_after = 0
+    if resume_after > 0:
+        messages = [m for m in messages if m["id"] > resume_after]
+        if not messages:
+            # Everything was already embedded before the interruption; just
+            # finalize (clear marker + write metadata) so the table is trusted.
+            _clear_build_in_progress(conn, tbl)
+            _write_embedder_metadata(conn)
+            return 0
+    else:
+        conn.execute(f"DELETE FROM {tbl}")
+        _mark_build_in_progress(conn, tbl)
+        conn.commit()  # DELETE + marker land atomically
 
     model = get_model()
     batch_size = _get_batch_size()
@@ -718,11 +831,13 @@ def build_vectors(
                 conn.commit()
                 batches_since_commit = 0
 
-    # Final commit for any remaining rows since last batch commit.
-    if batches_since_commit > 0:
-        conn.commit()
-
-    _write_embedder_metadata(conn)
+    # Final commit: clear the in-progress marker and stamp embedder metadata in
+    # the SAME transaction so the table is only ever "trusted" once it is fully
+    # built under the current embedder (issue #647: no NEW vectors under OLD
+    # metadata, no empty/partial table accepted as built).
+    _clear_build_in_progress(conn, tbl)
+    _write_embedder_metadata_no_commit(conn)
+    conn.commit()
     return total
 
 
@@ -892,6 +1007,7 @@ def build_separation_vectors(
     messages: list[dict] | None = None,
     *,
     table_name: str | None = None,
+    txn_batch: int | None = None,
 ) -> int:
     """
     Build separation embeddings: ``"{sender} to {recipient} on {date}: {content}"``.
@@ -929,11 +1045,34 @@ def build_separation_vectors(
         return 0
 
     tbl = table_name or _active_sep_table(conn)
-    conn.execute(f"DELETE FROM {tbl}")
+
+    # Resume vs. fresh build — same durability contract as build_vectors
+    # (issue #647, M-21 + M-45). Marker + DELETE land atomically; batched
+    # commits below release the write lock during the run (#619 treatment).
+    resume_after = 0
+    if _build_in_progress(conn, tbl):
+        try:
+            resume_after = conn.execute(
+                f"SELECT MAX(rowid) FROM {tbl}"
+            ).fetchone()[0] or 0
+        except sqlite3.OperationalError:
+            resume_after = 0
+    if resume_after > 0:
+        messages = [m for m in messages if m["id"] > resume_after]
+        if not messages:
+            _clear_build_in_progress(conn, tbl)
+            _write_embedder_metadata(conn)
+            return 0
+    else:
+        conn.execute(f"DELETE FROM {tbl}")
+        _mark_build_in_progress(conn, tbl)
+        conn.commit()  # DELETE + marker land atomically
 
     model = get_model()
     batch_size = _get_batch_size()
+    commit_every = txn_batch if txn_batch is not None else _BUILD_VECTORS_TXN_BATCH
     total = 0
+    batches_since_commit = 0
 
     try:
         import torch
@@ -975,11 +1114,19 @@ def build_separation_vectors(
                 )
 
             total += len(rows_to_insert)
+            batches_since_commit += 1
             del embeddings
             _flush_mps_cache()
 
+            if batches_since_commit >= commit_every:
+                conn.commit()
+                batches_since_commit = 0
+
+    # Final commit: clear the in-progress marker + stamp embedder metadata
+    # atomically (issue #647).
+    _clear_build_in_progress(conn, tbl)
+    _write_embedder_metadata_no_commit(conn)
     conn.commit()
-    _write_embedder_metadata(conn)
     return total
 
 


### PR DESCRIPTION
Fixes #647.

## How it integrates with #631's existing rebuild machinery
#631 added the `*_cos_stage` durable staging tables that make the **L2→cosine re-normalization** (re-inserting existing vectors, no re-embed) crash-safe and resumable (`migrate_to_cosine_metric` / `_finish_cosine_swap`). That machinery is left untouched.

This PR adds a **separate, orthogonal** durability layer for the **re-embed** path (`build_vectors` / `build_separation_vectors`): a `metadata` build-state marker. The two compose cleanly — a re-embed sets/clears the marker; a cosine migration leaves a stage table; neither reads or writes the other's state. No competing mechanism was introduced.

## M-21 (P1) — build_vectors durability
- **Before:** `DELETE FROM {tbl}; commit()` ran *before* any embedding, so a kill / None-content / NaN-embedding mid-run persisted an empty or partial table. `engine.open()` accepted any existing table (even 0 rows) as "built". Embedder metadata was committed *separately* at the end → a crash mid tier-migration left NEW vectors under OLD metadata.
- **Now:** a `vec_build_state:{tbl} = 'in_progress'` marker is written in the **same transaction** as the DELETE, and cleared with the **final commit alongside the embedder metadata** (`_write_embedder_metadata_no_commit` + single `commit()`). So a table is only ever trusted once it is fully built under the current embedder.
- **engine.open() change (minimal):** the old `SELECT 1 FROM {tbl} LIMIT 1` "is it built?" probe is replaced by `vectors_are_built(conn, tbl)`, which returns False when the marker is `in_progress` (partial/empty table is rebuilt, not trusted) — a tiny build-state read, no other engine logic touched.
- **Resume, not re-wipe:** if a prior run left the marker, the build resumes from `max(rowid)` and only embeds the remaining messages. Already-written rows are valid (each L2-normalized at write time), so there is no data confusion and no redundant re-embedding.

## M-45 (P2) — build_separation_vectors batch commits
- Mirrors `build_vectors`' #619 batched-commit treatment (commits every `txn_batch` embedding batches instead of one giant end-of-run transaction that held the write lock for the whole run) **plus** the same in-progress marker + resume contract. Added a `txn_batch` param for parity.

## Tests — `tests/test_issue_647_vector_rebuild.py`
sqlite-vec-gated (repo skip pattern), mock model, `HF_HUB_OFFLINE`-safe, vectors built by hand — no model loads:
- (a) interrupted build (raises mid-batch) leaves marker `in_progress`; `vectors_are_built()` returns False; a 0-row marked table is also rejected.
- (b) resume after interruption keeps the already-committed vectors (asserts **no DELETE** issued on the resume path), embeds only the remainder, ends with every message embedded exactly once, marker cleared.
- (c) `build_separation_vectors` commits in batches (commit counter ≥ 6 for 4 batches) — no single giant txn.
- (d) marker cleared on success alongside embedder metadata; stale metadata is overwritten in the same final commit.

## Test results
- New file: 7 passed.
- Regression (`-k "build_vector or rebuild or separation or vec_build or migrat"`): 43 passed, 1 failed — `test_upgrade_path.py::test_metadata_written_on_build_vectors`, a **pre-existing py3.14 env-only baseline UnicodeDecodeError** (fails identically on clean `main`; unrelated to this change).
- #590 batch tests + #483/#631 cosine-migration tests: 10 passed (commit-count expectations and cosine staging unaffected).

## Scope
Touched only `truememory/vector_search.py`, a minimal build-state read in `truememory/engine.py`, and the new test file. No README / unrelated files.