### PR TITLE
fix: config.json schema validation at every reader (non-dict, null tier, null providers, BOM, unknown tier) (#640)

### DIFF
--- a/tests/test_issue_640_config_validation.py
+++ b/tests/test_issue_640_config_validation.py
@@ -1,0 +1,220 @@
+"""Regression tests for issue #640 — config.json schema validation at every reader.
+
+Covers:
+  M-25 (a) non-str / null tier does not crash import (mcp_server tier->environ).
+  M-25 (b) valid-JSON non-object config (null / "x" / [..]) is routed to the
+           corrupt-rename recovery instead of raising AttributeError.
+  M-25 (c) reranker lazy tier resolution survives a non-dict config.
+  M-25 (d) explicit ``deepsearch_provider: null`` does not crash deep search.
+  M-87     a BOM-prefixed valid config loads (utf-8-sig), not renamed as corrupt.
+  M-88     an unknown tier string does NOT trigger a custom-model download path;
+           "PRO" normalizes to "pro".
+
+All configs are written to a tmp dir; the real ~/.truememory is never touched.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def server(monkeypatch, tmp_path):
+    """Isolated mcp_server module with a fresh temp config dir.
+
+    Mirrors the fixture in tests/test_issue_502_config.py so config readers
+    point at a throwaway directory.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".truememory").mkdir()
+    db_path = tmp_path / "memories.db"
+    monkeypatch.setenv("TRUEMEMORY_DB", str(db_path))
+    monkeypatch.setenv("TRUEMEMORY_EMBED_MODEL", "edge")
+    import truememory.mcp_server as ms
+
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", home / ".truememory")
+    monkeypatch.setattr(ms, "_CONFIG_PATH", home / ".truememory" / "config.json")
+    monkeypatch.setattr(ms, "_DB_PATH", str(db_path))
+    monkeypatch.setattr(ms, "_memory", None)
+    ms._config_cache = None
+    ms._config_cache_mtime = 0.0
+    ms._config_cache_time = 0.0
+    yield ms
+    ms._config_cache = None
+    ms._config_cache_mtime = 0.0
+    ms._config_cache_time = 0.0
+
+
+def _reset_cache(server):
+    server._config_cache = None
+    server._config_cache_mtime = 0.0
+    server._config_cache_time = 0.0
+
+
+# -----------------------------------------------------------------------
+# M-25 (b) — valid-JSON non-object config is handled, not an AttributeError
+# -----------------------------------------------------------------------
+
+
+class TestNonObjectConfig:
+    @pytest.mark.parametrize("body", ["null", '"hello"', "[1, 2]", "3"])
+    def test_non_dict_config_routed_to_recovery(self, server, body):
+        """A valid-JSON non-object config must return {} (corrupt-rename path),
+        never raise AttributeError/TypeError."""
+        server._CONFIG_PATH.write_text(body, encoding="utf-8")
+        _reset_cache(server)
+
+        result = server._load_config()
+        assert result == {}
+        # File renamed to a .corrupt backup, not left in place.
+        assert not server._CONFIG_PATH.exists()
+        backups = list(server._CONFIG_PATH.parent.glob("config.json.corrupt.*"))
+        assert backups, "non-object config was not renamed to a .corrupt backup"
+
+    def test_list_config_does_not_crash_per_tool(self, server):
+        """A list config must not raise when callers do config.get(...)."""
+        server._CONFIG_PATH.write_text("[1, 2, 3]", encoding="utf-8")
+        _reset_cache(server)
+        # Should be coerced to {} — .get() works fine.
+        assert server._load_config().get("tier") is None
+
+
+# -----------------------------------------------------------------------
+# M-25 (a) — non-str / null tier must not crash the tier->environ assignment
+# -----------------------------------------------------------------------
+
+
+class TestNullTier:
+    @pytest.mark.parametrize("tier_val", [None, 3, ["pro"], {"x": 1}, ""])
+    def test_non_str_tier_does_not_crash(self, server, tier_val):
+        """A loaded config with a non-str tier must not crash the import-time
+        tier->environ assignment (a non-str value would raise TypeError)."""
+        server._CONFIG_PATH.write_text(
+            json.dumps({"tier": tier_val}), encoding="utf-8"
+        )
+        _reset_cache(server)
+        startup_tier = server._load_config().get("tier")
+        env = {}
+        # This is the exact guard shipped in mcp_server.py.
+        if isinstance(startup_tier, str) and startup_tier.strip():
+            env["TRUEMEMORY_EMBED_MODEL"] = startup_tier
+        # Non-str / empty tier leaves the env var unset (no TypeError).
+        assert "TRUEMEMORY_EMBED_MODEL" not in env
+
+    def test_null_tier_config_loads_clean(self, server):
+        """{"tier": null} is a valid object; load returns it without crash."""
+        server._CONFIG_PATH.write_text(json.dumps({"tier": None}), encoding="utf-8")
+        _reset_cache(server)
+        result = server._load_config()
+        assert result == {"tier": None}
+
+
+# -----------------------------------------------------------------------
+# M-25 (d) — explicit deepsearch_provider: null must not crash deep search
+# -----------------------------------------------------------------------
+
+
+class TestNullDeepsearchProvider:
+    def test_null_provider_returns_none_no_crash(self, server):
+        """deepsearch_provider: null -> _build_deepsearch_llm_fn returns None
+        (fall back to default) instead of raising None.strip()."""
+        server._CONFIG_PATH.write_text(
+            json.dumps({"tier": "pro", "deepsearch_provider": None,
+                        "deepsearch_model": None}),
+            encoding="utf-8",
+        )
+        _reset_cache(server)
+        assert server._build_deepsearch_llm_fn() is None
+
+    def test_missing_provider_returns_none(self, server):
+        server._CONFIG_PATH.write_text(json.dumps({"tier": "pro"}), encoding="utf-8")
+        _reset_cache(server)
+        assert server._build_deepsearch_llm_fn() is None
+
+
+# -----------------------------------------------------------------------
+# M-87 — a BOM-prefixed valid config loads, not renamed as corrupt
+# -----------------------------------------------------------------------
+
+
+class TestBomConfig:
+    def test_bom_config_loads(self, server):
+        """A valid config saved with a UTF-8 BOM must load via utf-8-sig."""
+        cfg = {"tier": "base", "anthropic_api_key": "sk-test"}
+        # encoding="utf-8-sig" prepends the BOM bytes.
+        server._CONFIG_PATH.write_text(json.dumps(cfg), encoding="utf-8-sig")
+        _reset_cache(server)
+
+        result = server._load_config()
+        assert result["tier"] == "base"
+        assert result["anthropic_api_key"] == "sk-test"
+        # Not renamed away.
+        assert server._CONFIG_PATH.exists()
+        assert not list(server._CONFIG_PATH.parent.glob("config.json.corrupt.*"))
+
+
+# -----------------------------------------------------------------------
+# M-25 (c) — reranker lazy tier resolution survives a non-dict config
+# -----------------------------------------------------------------------
+
+
+class TestRerankerNonDictConfig:
+    @pytest.mark.parametrize("body", ["null", '"x"', "[1, 2]"])
+    def test_reranker_tier_resolution_falls_back_to_edge(
+        self, monkeypatch, tmp_path, body,
+    ):
+        import truememory.reranker as rr
+
+        cfg_dir = tmp_path / ".truememory"
+        cfg_dir.mkdir()
+        (cfg_dir / "config.json").write_text(body, encoding="utf-8")
+        import pathlib
+        monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+        # Ensure env var doesn't short-circuit the config read.
+        monkeypatch.delenv("TRUEMEMORY_EMBED_MODEL", raising=False)
+
+        assert rr._resolve_tier_from_env_and_config() == "edge"
+
+    def test_reranker_bom_config_resolves_tier(self, monkeypatch, tmp_path):
+        import truememory.reranker as rr
+
+        cfg_dir = tmp_path / ".truememory"
+        cfg_dir.mkdir()
+        (cfg_dir / "config.json").write_text(
+            json.dumps({"tier": "pro"}), encoding="utf-8-sig"
+        )
+        import pathlib
+        monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+        monkeypatch.delenv("TRUEMEMORY_EMBED_MODEL", raising=False)
+
+        assert rr._resolve_tier_from_env_and_config() == "pro"
+
+
+# -----------------------------------------------------------------------
+# M-88 — unknown tier must not trigger custom-model download; "PRO" -> "pro"
+# -----------------------------------------------------------------------
+
+
+class TestUnknownTierResolution:
+    def test_pro_normalizes_to_pro_model(self):
+        import truememory.vector_search as vs
+
+        # "PRO" (wrong case) must resolve to the same model as "pro".
+        assert vs._resolve_model_name("PRO") == vs._resolve_model_name("pro")
+        assert vs._resolve_model_name("PRO") != "model2vec"
+
+    @pytest.mark.parametrize("garbage", ["garbage-tier", "Pr0", " proo", "xyz"])
+    def test_unknown_tier_falls_back_to_safe_default(self, garbage):
+        import truememory.vector_search as vs
+
+        # An unknown string with no "/" must NOT be returned verbatim (which
+        # would be loaded as a custom HF model id) — fall back to model2vec.
+        assert vs._resolve_model_name(garbage) == "model2vec"
+
+    def test_hf_repo_id_still_honoured(self):
+        import truememory.vector_search as vs
+
+        # A value that clearly looks like a HF repo id is still passed through.
+        assert vs._resolve_model_name("some-org/some-model") == "some-org/some-model"

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -61,6 +61,13 @@ _config_cache_time: float = 0.0
 _config_write_lock = threading.Lock()
 
 
+class _ConfigShapeError(ValueError):
+    """Config parsed as valid JSON but the top-level value is not an object
+    (M-25b / #640). Routed to the same corrupt-rename recovery as a parse
+    error so a hand-edited ``null`` / ``"x"`` / ``[..]`` never bricks the
+    server at import or per-tool."""
+
+
 def _load_config() -> dict:
     """Load persistent config from ~/.truememory/config.json.
 
@@ -91,7 +98,17 @@ def _load_config() -> dict:
         _config_cache_time = now
         return {}
     try:
-        result = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        # encoding="utf-8-sig" transparently strips a leading UTF-8 BOM
+        # (M-87 / #640): editors that prepend a BOM otherwise made json.loads
+        # raise JSONDecodeError, renaming an otherwise-valid config away.
+        result = json.loads(_CONFIG_PATH.read_text(encoding="utf-8-sig"))
+        if not isinstance(result, dict):
+            # Valid JSON but wrong shape (null / "x" / [..]). Treat exactly
+            # like a parse error: rename to a .corrupt backup and fall back to
+            # an empty config so the server never hard-bricks (M-25b / #640).
+            raise _ConfigShapeError(
+                f"top-level JSON value is {type(result).__name__}, expected object"
+            )
         try:
             _config_cache_mtime = _CONFIG_PATH.stat().st_mtime
         except OSError:
@@ -99,17 +116,21 @@ def _load_config() -> dict:
         _config_cache = result
         _config_cache_time = now
         return result.copy()
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, _ConfigShapeError) as e:
         # .with_suffix would replace ".json"; we want to APPEND to preserve
         # the origin filename in the backup so users can find it easily.
         backup = _CONFIG_PATH.parent / f"{_CONFIG_PATH.name}.corrupt.{int(time.time())}"
+        if isinstance(e, json.JSONDecodeError):
+            _reason = f"JSON parse error at line {e.lineno} col {e.colno}"
+        else:
+            _reason = str(e)
         try:
             _CONFIG_PATH.rename(backup)
             print(
-                f"truememory: config.json is corrupt (JSON parse error at "
-                f"line {e.lineno} col {e.colno}). Saved corrupt file to "
-                f"{backup} — your API keys may be recoverable from there. "
-                f"Run `truememory-mcp --setup` to recreate the config.",
+                f"truememory: config.json is corrupt ({_reason}). "
+                f"Saved corrupt file to {backup} — your API keys may be "
+                f"recoverable from there. Run `truememory-mcp --setup` to "
+                f"recreate the config.",
                 file=sys.stderr,
             )
         except OSError:
@@ -197,8 +218,13 @@ def _save_config(config: dict) -> None:
 # EMBEDDING_MODEL. If we import truememory.client first, the env var isn't
 # set yet and it defaults to "edge"/model2vec regardless of configured tier.
 _startup_config = _load_config()
-if "tier" in _startup_config:
-    os.environ["TRUEMEMORY_EMBED_MODEL"] = _startup_config["tier"]
+_startup_tier = _startup_config.get("tier")
+# os.environ values must be str; a non-str tier (e.g. config edited to
+# {"tier": 3} or null) would raise TypeError at import and hard-brick the
+# server. Only set the env var when the tier is a non-empty string (M-25a /
+# #640); otherwise leave it unset so downstream resolvers fall back to Edge.
+if isinstance(_startup_tier, str) and _startup_tier.strip():
+    os.environ["TRUEMEMORY_EMBED_MODEL"] = _startup_tier
 
 from truememory import __version__  # noqa: E402
 from truememory.client import Memory  # noqa: E402
@@ -511,8 +537,11 @@ def _build_deepsearch_llm_fn():
     the caller to fall back to ``_get_llm_fn()``.
     """
     config = _load_config()
-    ds_provider = config.get("deepsearch_provider", "").strip().lower()
-    ds_model = config.get("deepsearch_model", "").strip()
+    # (config.get(k) or "") tolerates an explicit ``null`` value, which a
+    # missing default would not catch — None.strip() would otherwise crash
+    # every deep search (M-25d / #640).
+    ds_provider = (config.get("deepsearch_provider") or "").strip().lower()
+    ds_model = (config.get("deepsearch_model") or "").strip()
 
     if not ds_provider:
         return None  # No override — caller should use default

--- a/truememory/reranker.py
+++ b/truememory/reranker.py
@@ -102,11 +102,16 @@ def _resolve_tier_from_env_and_config() -> str:
         import json
         cfg_path = Path.home() / ".truememory" / "config.json"
         if cfg_path.exists():
-            data = json.loads(cfg_path.read_text(encoding="utf-8"))
-            tier = (data.get("tier") or "").strip().lower()
-            if tier in _KNOWN_TIERS:
-                return tier
-    except (json.JSONDecodeError, OSError) as e:
+            # utf-8-sig strips a leading BOM (#640). isinstance guard: a
+            # valid-JSON non-object config (null / "x" / [..]) would make
+            # data.get raise AttributeError, crashing lazy tier resolution
+            # (M-25c / #640) — treat it as malformed and fall back to Edge.
+            data = json.loads(cfg_path.read_text(encoding="utf-8-sig"))
+            if isinstance(data, dict):
+                tier = (data.get("tier") or "").strip().lower()
+                if tier in _KNOWN_TIERS:
+                    return tier
+    except (json.JSONDecodeError, OSError, AttributeError, TypeError) as e:
         # Previously a bare `except Exception: pass`
         # that hid corrupt config.json exactly like mcp_server._load_config
         # did. Log a warning so the user knows the fallback fired — the MCP

--- a/truememory/tier_switch/manager.py
+++ b/truememory/tier_switch/manager.py
@@ -364,7 +364,12 @@ class RebuildManager:
         config = {}
         if config_path.exists():
             try:
-                config = json.loads(config_path.read_text())
+                # utf-8-sig tolerates a BOM; isinstance guard discards a
+                # valid-JSON non-object config so the tier write starts from a
+                # clean dict instead of crashing on config["tier"] (#640).
+                loaded = json.loads(config_path.read_text(encoding="utf-8-sig"))
+                if isinstance(loaded, dict):
+                    config = loaded
             except (json.JSONDecodeError, OSError):
                 pass
 

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -96,7 +96,7 @@ def _resolve_model_name(name: str) -> str:
     Raises:
         ValueError: if *name* refers to a model removed in v0.4.0.
     """
-    lowered = name.lower()
+    lowered = name.strip().lower()
     if lowered in _REMOVED_MODELS:
         raise ValueError(
             f"Embedding model {name!r} was removed in TrueMemory v0.4.0. "
@@ -109,7 +109,26 @@ def _resolve_model_name(name: str) -> str:
         except ValueError:
             logger.warning("Custom tier resolution failed; falling back to model2vec.")
             return "model2vec"
-    return _TIER_ALIASES.get(lowered, name)
+    # Known public tier (edge/base/pro, case-insensitively normalized e.g.
+    # "PRO" -> "pro") or known internal model name -> resolve directly.
+    if lowered in _TIER_ALIASES:
+        return _TIER_ALIASES[lowered]
+    if lowered in _MODEL_DIMS:
+        return lowered
+    # M-88 (#640): an unknown/garbage tier string must NOT be silently treated
+    # as a custom HuggingFace model id (which, with CUSTOM_ALLOW_DOWNLOAD=1,
+    # triggers an arbitrary model download). Only honour a value that clearly
+    # looks like a HF repo id (contains "/"); otherwise fall back to a safe
+    # default and log so the misconfiguration is visible.
+    if "/" in lowered:
+        return name
+    logger.warning(
+        "Unknown tier/model %r is not a known tier (edge/base/pro/custom) or "
+        "model name and is not a HuggingFace repo id; falling back to "
+        "model2vec (edge).",
+        name,
+    )
+    return "model2vec"
 
 
 def resolve_tier() -> str:


### PR DESCRIPTION
Fixes #640. Config-corruption hardening so a valid-JSON-but-wrong-shape (or BOM-prefixed, or garbage-tier) config never hard-bricks the MCP server.

## M-25 (P1) — valid-JSON wrong-shape no longer bricks at import / per-tool
- **(a) tier -> environ** (`mcp_server.py`): import-time assignment now only sets `TRUEMEMORY_EMBED_MODEL` when `tier` is a non-empty `str`. A non-str/null tier previously raised `TypeError` at import.
- **(b) `_load_config`** (`mcp_server.py`): added an `isinstance(dict)` check after `json.loads`. A non-object config (`null` / `"x"` / `[..]`) now raises an internal `_ConfigShapeError` routed to the **same corrupt-rename recovery** as `JSONDecodeError` (renames to `config.json.corrupt.<ts>`, returns `{}`) instead of `AttributeError`.
- **(c) reranker** (`reranker.py`): `_resolve_tier_from_env_and_config` guards `isinstance(dict)` and broadens the except to `AttributeError, TypeError`; falls back to Edge.
- **(d) deepsearch** (`mcp_server.py`): `(config.get(k) or "")` for `deepsearch_provider`/`deepsearch_model` so an explicit `null` no longer triggers `None.strip()` on every deep search.
- **manager** (`tier_switch/manager.py`): `_apply_config_switch` guards non-dict before `config["tier"]`.

## M-87 (P3) — UTF-8 BOM no longer treated as corruption
Config reads use `encoding="utf-8-sig"` (`mcp_server.py`, `reranker.py`, `tier_switch/manager.py`), so a BOM-prefixed valid config loads instead of being renamed away.

## M-88 (P3) — unknown tier no longer becomes an arbitrary HF download
`vector_search._resolve_model_name` validates the tier against the known set (case-insensitive, so `"PRO"` -> `"pro"`). A value is only treated as a custom HuggingFace model id when it clearly looks like one (contains `/`); otherwise it falls back to `model2vec` (edge) and logs. This prevents arbitrary downloads under `CUSTOM_ALLOW_DOWNLOAD=1` and the silent HyDE-disable from a hand-edited `"PRO"`.

## Tests
New `tests/test_issue_640_config_validation.py` (24 cases): non-object configs routed to recovery; non-str/null tier no crash; `deepsearch_provider: null` returns None; BOM config loads (not renamed); reranker survives non-dict + BOM; unknown tier -> model2vec, `"PRO"` normalizes to `"pro"`, HF repo ids still honoured.

Targeted run (HF_HUB_OFFLINE=1, `-k "config or tier or load_config or deepsearch or rerank"`): **205 passed, 0 failed**. `ruff check truememory/ tests/` clean.

Touched only: `mcp_server.py`, `reranker.py`, `tier_switch/manager.py`, `vector_search.py`, + the new test file.