### PR TITLE
fix: intensity validation fail-closed + recall flow coherence (#636)

### DIFF
--- a/tests/ingest/test_recall_debounce.py
+++ b/tests/ingest/test_recall_debounce.py
@@ -71,16 +71,22 @@ class TestRecallMarker:
 
 class TestAutoRecallGate:
     def test_fresh_marker_short_circuits_recall(self, marker_dir, monkeypatch):
-        """A fresh marker makes _try_auto_recall return None before doing any
-        recall work (no detection, no Memory load)."""
+        """A consumed debounce marker makes _try_auto_recall return None before
+        doing any recall work (no detection, no Memory load).
+
+        Issue #636 (M-41): the marker is now consumed once in main() and the
+        result passed in as ``debounced`` (so the proactive and auto-recall
+        paths can't double-consume it). The short-circuit semantics are
+        unchanged — only who reads the marker moved upstream.
+        """
         def _boom(*_a, **_k):
             raise AssertionError("recall work must not run when marker is fresh")
 
         monkeypatch.setattr(ups, "_detect_recall", _boom)
-        _shared.mark_recall_injected("session-first")
 
         result = ups._try_auto_recall(
-            "what's my favorite editor", "", "", session_id="session-first"
+            "what's my favorite editor", "", "", session_id="session-first",
+            debounced=True,
         )
         assert result is None
 

--- a/tests/test_issue_396_memory_intensity.py
+++ b/tests/test_issue_396_memory_intensity.py
@@ -271,19 +271,23 @@ class TestPromptCounting:
 
 class TestProactiveRecallScheduling:
     def test_standard_returns_none(self):
+        # Issue #636: now returns (context, searched). Standard never searches.
         from truememory.ingest.hooks.user_prompt_submit import _try_proactive_recall
-        result = _try_proactive_recall(
+        ctx, searched = _try_proactive_recall(
             "what is X", "", "", "session", "standard", 5,
         )
-        assert result is None
+        assert ctx is None
+        assert searched is False
 
     def test_enhanced_skips_non_5th(self):
+        # Off-cadence: no context AND searched=False so auto-recall can still run.
         from truememory.ingest.hooks.user_prompt_submit import _try_proactive_recall
         # prompt_count=3 is not a multiple of 5
-        result = _try_proactive_recall(
+        ctx, searched = _try_proactive_recall(
             "what is X", "", "", "session", "enhanced", 3,
         )
-        assert result is None
+        assert ctx is None
+        assert searched is False
 
     def test_enhanced_triggers_on_5th(self):
         """Enhanced search should attempt recall on 5th prompt.
@@ -295,12 +299,13 @@ class TestProactiveRecallScheduling:
         # This test verifies the scheduling logic doesn't block the 5th prompt
         from truememory.ingest.hooks.user_prompt_submit import _try_proactive_recall
         # With an invalid db_path, it will fail at Memory() but that's after
-        # passing the scheduling check
-        result = _try_proactive_recall(
+        # passing the scheduling check. Issue #636: still reports searched=True
+        # because the cadence gate passed and the search was attempted.
+        ctx, searched = _try_proactive_recall(
             "what is X", "", "/nonexistent/db", "session", "enhanced", 5,
         )
-        # Result is None because Memory fails, but the scheduling check passed
-        assert result is None
+        assert ctx is None
+        assert searched is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_636_intensity_validation.py
+++ b/tests/test_issue_636_intensity_validation.py
@@ -1,0 +1,314 @@
+"""Tests for issue #636 — intensity validation + recall flow coherence.
+
+Covers four findings in the ingest hooks:
+
+- M-16 (P1): intensity config failed OPEN to "max" on any invalid value. The
+  exclusion-based dispatch (``!= "standard"`` / ``!= "enhanced"`` → max) meant
+  ``"MAX"``, ``"Enhanced"``, garbage, and JSON ``null`` all enabled the most
+  expensive every-prompt mode. Readers now normalize (lowercase + allowlist)
+  and fail CLOSED to "standard". We assert that in BOTH user_prompt_submit and
+  session_start readers.
+- M-41 (P2): ``_try_proactive_recall`` consumed the one-shot #561 debounce
+  marker, returned None, and ``main()`` then fell through to ``_try_auto_recall``
+  which saw no marker and re-ran the exact first-prompt search #561 suppressed.
+  We assert auto-recall does NOT fire when the marker was consumed.
+- M-42 (P2): max intensity built a second ``Memory()`` in ``_try_auto_recall``
+  when proactive recall found nothing — double engine init + double search. We
+  assert a single Memory construction (and both instances closed).
+- M-72 (P3): "max" was nullified by the 8KB payload cap. The recall budget now
+  scales with intensity. We assert max gets a larger effective budget while an
+  explicit env override stays authoritative.
+
+All tests mock the model/embedding layer (no real model loads).
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+
+
+# ---------------------------------------------------------------------------
+# Fakes — fully model-free (mirrors tests/test_issue_634_per_exchange_store.py)
+# ---------------------------------------------------------------------------
+
+class _FakeMemory:
+    """Records construction/close; search() returns configurable results."""
+
+    instances: list["_FakeMemory"] = []
+    next_results: list[dict] = []
+
+    def __init__(self, path=None, **kwargs):
+        self.closed = False
+        self.searches: list[str] = []
+        self.search_results: list[dict] = list(_FakeMemory.next_results)
+        _FakeMemory.instances.append(self)
+
+    def search(self, query, user_id=None, limit=10, **kwargs):
+        self.searches.append(query)
+        return list(self.search_results)
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _reset_fakes():
+    _FakeMemory.instances.clear()
+    _FakeMemory.next_results = []
+    yield
+    _FakeMemory.instances.clear()
+    _FakeMemory.next_results = []
+
+
+@pytest.fixture
+def patched_memory(monkeypatch):
+    """Patch Memory + deadline setter used by the recall paths."""
+    import truememory.client as client
+    monkeypatch.setattr(client, "Memory", _FakeMemory)
+    import truememory.model_client as mc
+    monkeypatch.setattr(mc, "set_request_timeout", lambda v: None)
+    return _FakeMemory
+
+
+def _set_marker(monkeypatch, consumed: bool):
+    """Make consume_recall_injected return ``consumed`` exactly once.
+
+    Tracks how many times it is actually called so tests can assert the marker
+    is consumed exactly once across the whole prompt (M-41).
+    """
+    import truememory.ingest.hooks._shared as shared
+    calls = {"n": 0}
+
+    def fake_consume(session_id, within_seconds=None):
+        calls["n"] += 1
+        # one-shot: True on first call, False afterwards (mirrors real marker)
+        return consumed and calls["n"] == 1
+
+    monkeypatch.setattr(shared, "consume_recall_injected", fake_consume)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# M-16: invalid intensity normalizes to "standard" (fail closed), not "max"
+# ---------------------------------------------------------------------------
+
+# Genuinely invalid values: not a recognized level even after lowercasing.
+# (Case variants like "MAX"/"Enhanced" ARE valid and covered separately.)
+_INVALID_VALUES = ["TURBO", "garbage", "", "  ", None, 1, True, ["max"]]
+
+
+def _write_config(home, **fields):
+    cfg = home / ".truememory" / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(json.dumps({"tier": "edge", **fields}), encoding="utf-8")
+    return cfg
+
+
+class TestM16UserPromptSubmitNormalization:
+    @pytest.mark.parametrize("value", _INVALID_VALUES)
+    def test_invalid_search_intensity_not_max(self, value, monkeypatch, tmp_path):
+        import truememory.ingest.hooks.user_prompt_submit as ups
+        home = tmp_path / "home"
+        _write_config(home, search_intensity=value, store_intensity=value)
+        monkeypatch.setattr(ups.Path, "home", staticmethod(lambda: home))
+        search, store = ups._get_intensity_config()
+        assert search == "standard", f"{value!r} must not enable an intensity mode"
+        assert store == "standard"
+
+    def test_uppercase_max_is_normalized(self, monkeypatch, tmp_path):
+        import truememory.ingest.hooks.user_prompt_submit as ups
+        home = tmp_path / "home"
+        _write_config(home, search_intensity="MAX")
+        monkeypatch.setattr(ups.Path, "home", staticmethod(lambda: home))
+        search, _ = ups._get_intensity_config()
+        # uppercase MAX is a *valid* level after lowercasing — not garbage
+        assert search == "max"
+
+    def test_valid_values_preserved(self, monkeypatch, tmp_path):
+        import truememory.ingest.hooks.user_prompt_submit as ups
+        home = tmp_path / "home"
+        for v in ("standard", "enhanced", "max"):
+            _write_config(home, search_intensity=v, store_intensity=v)
+            monkeypatch.setattr(ups.Path, "home", staticmethod(lambda: home))
+            search, store = ups._get_intensity_config()
+            assert (search, store) == (v, v)
+
+    def test_normalize_helper_direct(self):
+        import truememory.ingest.hooks.user_prompt_submit as ups
+        assert ups._normalize_intensity("MAX") == "max"
+        assert ups._normalize_intensity("  Enhanced ") == "enhanced"
+        assert ups._normalize_intensity("turbo") == "standard"
+        assert ups._normalize_intensity(None) == "standard"
+        assert ups._normalize_intensity(42) == "standard"
+
+
+class TestM16SessionStartNormalization:
+    @pytest.mark.parametrize("value", _INVALID_VALUES)
+    def test_invalid_search_intensity_not_max(self, value, monkeypatch, tmp_path):
+        import truememory.ingest.hooks.session_start as ss
+        home = tmp_path / "home"
+        _write_config(home, search_intensity=value)
+        monkeypatch.setattr(ss.Path, "home", staticmethod(lambda: home))
+        assert ss._get_search_intensity() == "standard"
+
+    def test_uppercase_normalized(self, monkeypatch, tmp_path):
+        import truememory.ingest.hooks.session_start as ss
+        home = tmp_path / "home"
+        _write_config(home, search_intensity="Enhanced")
+        monkeypatch.setattr(ss.Path, "home", staticmethod(lambda: home))
+        assert ss._get_search_intensity() == "enhanced"
+
+    def test_normalize_helper_direct(self):
+        import truememory.ingest.hooks.session_start as ss
+        assert ss._normalize_intensity("MAX") == "max"
+        assert ss._normalize_intensity("nonsense") == "standard"
+        assert ss._normalize_intensity(None) == "standard"
+
+
+# ---------------------------------------------------------------------------
+# M-41: marker consumed by proactive → auto-recall must NOT fire
+# ---------------------------------------------------------------------------
+
+class TestM41NoDuplicateRecall:
+    def test_proactive_debounced_skips_autorecall(self, patched_memory, monkeypatch):
+        import truememory.ingest.hooks.user_prompt_submit as ups
+        # marker present (consumed once)
+        calls = _set_marker(monkeypatch, consumed=True)
+
+        # Drive main() with a recall-intent prompt under max intensity.
+        monkeypatch.setattr(ups, "_get_intensity_config", lambda: ("max", "standard"))
+        monkeypatch.setattr(ups, "_increment_prompt_count", lambda sid: 1)
+        monkeypatch.setattr(ups, "buffer_message", lambda *a, **k: None)
+        monkeypatch.setattr(ups, "_prune_old_buffers", lambda: None)
+        monkeypatch.setattr(ups, "_try_capture_email", lambda p: None)
+        monkeypatch.setattr(ups, "_try_per_exchange_store", lambda *a, **k: None)
+
+        out = _run_main(monkeypatch, ups, prompt="what is my favorite color?")
+
+        # No Memory was ever constructed (both paths suppressed by the marker).
+        assert _FakeMemory.instances == [], "debounced prompt must not search"
+        # Marker consumed exactly once (not double-consumed by both paths).
+        assert calls["n"] == 1
+        # No recall context emitted.
+        assert out == ""
+
+    def test_direct_proactive_returns_searched_when_debounced(self, patched_memory):
+        import truememory.ingest.hooks.user_prompt_submit as ups
+        ctx, searched = ups._try_proactive_recall(
+            "what is my favorite color?", "", "", "sess", "max", 1, debounced=True,
+        )
+        assert ctx is None
+        assert searched is True, "debounced proactive must report it handled the prompt"
+
+    def test_autorecall_skips_when_debounced(self, patched_memory):
+        import truememory.ingest.hooks.user_prompt_submit as ups
+        out = ups._try_auto_recall(
+            "what is my favorite color?", "", "", "sess", debounced=True,
+        )
+        assert out is None
+        assert _FakeMemory.instances == [], "debounced auto-recall must not search"
+
+
+# ---------------------------------------------------------------------------
+# M-42: empty proactive result must NOT cause a second Memory init / search
+# ---------------------------------------------------------------------------
+
+class TestM42NoDoubleInit:
+    def test_max_empty_result_single_memory(self, patched_memory, monkeypatch):
+        import truememory.ingest.hooks.user_prompt_submit as ups
+        # no marker → proactive runs the real search, which finds nothing
+        _set_marker(monkeypatch, consumed=False)
+        _FakeMemory.next_results = []
+
+        monkeypatch.setattr(ups, "_get_intensity_config", lambda: ("max", "standard"))
+        monkeypatch.setattr(ups, "_increment_prompt_count", lambda sid: 1)
+        monkeypatch.setattr(ups, "buffer_message", lambda *a, **k: None)
+        monkeypatch.setattr(ups, "_prune_old_buffers", lambda: None)
+        monkeypatch.setattr(ups, "_try_capture_email", lambda p: None)
+        monkeypatch.setattr(ups, "_try_per_exchange_store", lambda *a, **k: None)
+
+        out = _run_main(monkeypatch, ups, prompt="what is my favorite color?")
+
+        # Exactly ONE Memory constructed (proactive). Auto-recall does not add
+        # a second when proactive already searched this prompt (M-42).
+        assert len(_FakeMemory.instances) == 1, (
+            f"expected single Memory init, got {len(_FakeMemory.instances)}"
+        )
+        # And it was closed (no leak).
+        assert all(m.closed for m in _FakeMemory.instances)
+        assert out == ""
+
+    def test_proactive_closes_memory_on_empty(self, patched_memory):
+        import truememory.ingest.hooks.user_prompt_submit as ups
+        _FakeMemory.next_results = []
+        ctx, searched = ups._try_proactive_recall(
+            "what is my favorite color?", "", "", "sess", "max", 1, debounced=False,
+        )
+        assert ctx is None
+        assert searched is True
+        assert len(_FakeMemory.instances) == 1
+        assert _FakeMemory.instances[0].closed is True
+
+
+# ---------------------------------------------------------------------------
+# M-72: recall budget scales with intensity; env override authoritative
+# ---------------------------------------------------------------------------
+
+class TestM72BudgetScaling:
+    def test_max_budget_larger_than_standard(self, monkeypatch):
+        # Ensure no env override is in play for this assertion.
+        monkeypatch.delenv("TRUEMEMORY_RECALL_BUDGET_CHARS", raising=False)
+        import importlib
+        import truememory.ingest.hooks.session_start as ss
+        ss = importlib.reload(ss)
+        assert ss._intensity_budget("max") > ss._intensity_budget("standard")
+        assert ss._intensity_budget("enhanced") == ss._intensity_budget("standard")
+
+    def test_env_override_is_authoritative(self, monkeypatch):
+        monkeypatch.setenv("TRUEMEMORY_RECALL_BUDGET_CHARS", "12345")
+        import importlib
+        import truememory.ingest.hooks.session_start as ss
+        ss = importlib.reload(ss)
+        # With an explicit override, all intensities use the pinned budget.
+        assert ss._intensity_budget("max") == 12345
+        assert ss._intensity_budget("standard") == 12345
+        # restore module to default env state for other tests
+        monkeypatch.delenv("TRUEMEMORY_RECALL_BUDGET_CHARS", raising=False)
+        importlib.reload(ss)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_main(monkeypatch, ups, prompt: str) -> str:
+    """Run ups.main() feeding *prompt* on stdin; return emitted additionalContext."""
+    import io
+    import sys
+
+    stdin_payload = json.dumps({"prompt": prompt, "session_id": "sess"})
+    monkeypatch.setattr(sys, "stdin", io.StringIO(stdin_payload))
+
+    captured: list[str] = []
+    monkeypatch.setattr("builtins.print", lambda *a, **k: captured.append(" ".join(str(x) for x in a)))
+    monkeypatch.delenv("TRUEMEMORY_EXTRACTION", raising=False)
+
+    ups.main()
+
+    if not captured:
+        return ""
+    try:
+        return json.loads(captured[0]).get("additionalContext", "")
+    except (json.JSONDecodeError, IndexError):
+        return ""

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -46,13 +46,33 @@ _INTENSITY_MEMORY_LIMITS = {
 }
 
 
+# Issue #636 (M-16): valid intensity levels. Normalize raw config values
+# (lowercase + allowlist) so "MAX"/"Enhanced"/garbage/null resolve to a known
+# level instead of silently mapping to base via .get()'s default — keeping
+# this reader consistent with user_prompt_submit's fail-closed dispatch.
+_VALID_INTENSITIES = frozenset({"standard", "enhanced", "max"})
+
+
+def _normalize_intensity(value: object) -> str:
+    """Normalize a raw config intensity value to a known level (issue #636)."""
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _VALID_INTENSITIES:
+            return normalized
+    return "standard"
+
+
 def _get_search_intensity() -> str:
-    """Read search_intensity from persistent config (default: standard)."""
+    """Read search_intensity from persistent config (default: standard).
+
+    Normalized through the allowlist (issue #636) so an invalid or
+    mismatched-case value resolves predictably rather than slipping through.
+    """
     try:
         config_path = Path.home() / ".truememory" / "config.json"
         if config_path.exists():
             config = json.loads(config_path.read_text(encoding="utf-8"))
-            return config.get("search_intensity", "standard")
+            return _normalize_intensity(config.get("search_intensity", "standard"))
     except Exception:
         pass
     return "standard"
@@ -67,6 +87,30 @@ DIRECTIVE_LIMIT = int(os.environ.get("TRUEMEMORY_DIRECTIVE_LIMIT", "50"))
 # suffixed with a pointer so the agent can fetch the full text on demand.
 RECALL_MEMORY_CHARS = int(os.environ.get("TRUEMEMORY_RECALL_MEMORY_CHARS", "500"))
 RECALL_BUDGET_CHARS = int(os.environ.get("TRUEMEMORY_RECALL_BUDGET_CHARS", "8192"))
+
+# Issue #636 (M-72): "max" intensity raises MEMORY_LIMIT to 35 but the recall
+# payload was still capped at RECALL_BUDGET_CHARS (8KB), so _apply_budget
+# dropped the extra memories and the knob was a silent no-op. Scale the budget
+# with intensity so "max" actually injects a larger payload. An explicit
+# TRUEMEMORY_RECALL_BUDGET_CHARS override is authoritative (multiplier x1).
+_INTENSITY_BUDGET_MULTIPLIER = {
+    "standard": 1.0,
+    "enhanced": 1.0,
+    "max": 2.0,
+}
+_BUDGET_ENV_OVERRIDDEN = "TRUEMEMORY_RECALL_BUDGET_CHARS" in os.environ
+
+
+def _intensity_budget(intensity: str) -> int:
+    """Effective recall payload budget for *intensity* (issue #636, M-72).
+
+    An explicit env override pins the budget (multiplier x1) so operators keep
+    full control; otherwise "max" gets a larger budget so its higher memory
+    limit is not silently nullified by the 8KB cap.
+    """
+    if _BUDGET_ENV_OVERRIDDEN:
+        return RECALL_BUDGET_CHARS
+    return int(RECALL_BUDGET_CHARS * _INTENSITY_BUDGET_MULTIPLIER.get(intensity, 1.0))
 ONBOARDED_MARKER = Path.home() / ".truememory" / ".onboarded"
 BACKLOG_DIR = Path.home() / ".truememory" / "backlog"
 _DRAIN_CAP = 3
@@ -660,13 +704,18 @@ def main():
     global MEMORY_LIMIT
     intensity = _get_search_intensity()
     MEMORY_LIMIT = _INTENSITY_MEMORY_LIMITS.get(intensity, _BASE_MEMORY_LIMIT)
+    # Issue #636 (M-72): scale the recall payload budget with intensity so the
+    # higher "max" memory limit isn't silently capped at 8KB.
+    recall_budget = _intensity_budget(intensity)
 
     try:
         if _is_first_run():
             context = _first_run_context()
             recall_injected = False
         else:
-            context = recall_memories(input_data, user_id=args.user, db_path=args.db)
+            context = recall_memories(
+                input_data, user_id=args.user, db_path=args.db, budget=recall_budget,
+            )
             recall_injected = bool(context)
 
         # Check for available updates
@@ -821,7 +870,7 @@ def _apply_budget(
     return [line for i, (line, _score) in enumerate(memory_lines) if i not in drop]
 
 
-def recall_memories(input_data: dict, user_id: str = "", db_path: str = "") -> str:
+def recall_memories(input_data: dict, user_id: str = "", db_path: str = "", budget: int = 0) -> str:
     """Search TrueMemory and format relevant memories for injection.
 
     Uses a file-based cache (issue #559): after running the 5 search
@@ -947,7 +996,7 @@ def recall_memories(input_data: dict, user_id: str = "", db_path: str = "") -> s
             score = r.get("score", 0.0)
             memory_lines.append((f"- {truncated}", score))
 
-        kept = _apply_budget(memory_lines, directive_block)
+        kept = _apply_budget(memory_lines, directive_block, budget=budget)
 
         if kept:
             lines = [

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -164,15 +164,41 @@ _PROMPT_COUNTER_DIR = Path(os.environ.get(
 ))
 
 
+# Issue #636 (M-16): the only valid intensity values. Any other value —
+# "MAX", "Enhanced", garbage, JSON null — must NOT silently enable the most
+# expensive every-prompt mode. Readers normalize (lowercase + allowlist) and
+# fall back to "standard" so an unrecognized config value fails CLOSED.
+_VALID_INTENSITIES = frozenset({"standard", "enhanced", "max"})
+
+
+def _normalize_intensity(value: object) -> str:
+    """Normalize a raw config intensity value to a known level (issue #636).
+
+    Lowercases strings and validates against the allowlist; any non-string or
+    unrecognized value (None/null, "MAX", "garbage", numbers) falls back to
+    "standard". This makes invalid config fail closed to the cheapest mode
+    instead of the exclusion-based dispatch failing open to "max".
+    """
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _VALID_INTENSITIES:
+            return normalized
+    return "standard"
+
+
 def _get_intensity_config() -> tuple[str, str]:
-    """Read search_intensity and store_intensity from persistent config."""
+    """Read search_intensity and store_intensity from persistent config.
+
+    Values are normalized through the allowlist (issue #636) so invalid or
+    mismatched-case config cannot enable an unintended intensity mode.
+    """
     try:
         config_path = Path.home() / ".truememory" / "config.json"
         if config_path.exists():
             config = json.loads(config_path.read_text(encoding="utf-8"))
             return (
-                config.get("search_intensity", "standard"),
-                config.get("store_intensity", "standard"),
+                _normalize_intensity(config.get("search_intensity", "standard")),
+                _normalize_intensity(config.get("store_intensity", "standard")),
             )
     except Exception:
         pass
@@ -336,35 +362,53 @@ def _try_per_exchange_store(prompt: str, session_id: str, user_id: str, db_path:
         pass  # Never crash the hook
 
 
-def _try_proactive_recall(prompt: str, user_id: str, db_path: str, session_id: str, search_intensity: str, prompt_count: int) -> str | None:
+def _try_proactive_recall(
+    prompt: str,
+    user_id: str,
+    db_path: str,
+    session_id: str,
+    search_intensity: str,
+    prompt_count: int,
+    debounced: bool = False,
+) -> tuple[str | None, bool]:
     """Proactive recall based on search intensity.
 
     Enhanced: recall every ~5th prompt (8 results).
     Max: every prompt gets a memory search (10 results).
     Standard: handled by existing _try_auto_recall (recall-intent only).
+
+    Returns ``(recall_context, searched)``. ``searched`` is True when this
+    function ran (or short-circuited) the search for this prompt — the caller
+    uses it to decide whether the auto-recall fallback would be a redundant
+    second search of the same prompt (issue #636, M-41/M-42).
+
+    ``debounced`` is the result of the one-shot SessionStart recall marker,
+    consumed once by ``main()`` (issue #636, M-41): when True, SessionStart
+    already injected recall for this prompt, so proactive recall is suppressed
+    AND the caller must skip the auto-recall fallback (it would re-run the
+    exact first-prompt search #561 suppressed).
     """
     if search_intensity == "standard":
-        return None
+        return None, False
 
-    # Dedup: skip if session_start already injected recall for this session
-    try:
-        from truememory.ingest.hooks._shared import consume_recall_injected
-        if session_id and consume_recall_injected(session_id):
-            return None
-    except Exception:
-        pass
+    # Dedup: SessionStart already injected recall for this session's first
+    # prompt. Suppress here and tell the caller it was handled so the
+    # auto-recall fallback does not fire the same search again (M-41).
+    if debounced:
+        return None, True
 
     if search_intensity == "enhanced":
-        # Every 5th prompt
+        # Every 5th prompt; off-cadence prompts fall through to auto-recall
+        # (recall-intent detection), so report searched=False.
         if prompt_count % 5 != 0:
-            return None
+            return None, False
         limit = 8
     else:  # max
         limit = 10
 
-    # Skip code-heavy prompts
+    # Skip code-heavy prompts; auto-recall also skips these, so nothing to do.
     if _CODE_RE.search(prompt):
-        return None
+        return None, True
 
     try:
         try:
@@ -374,10 +418,12 @@ def _try_proactive_recall(prompt: str, user_id: str, db_path: str, session_id: s
         except Exception:
             pass
         from truememory.client import Memory
-        m = Memory(path=db_path or None)
-        results = m.search(prompt, user_id=user_id or None, limit=limit)
+        with Memory(path=db_path or None) as m:
+            results = m.search(prompt, user_id=user_id or None, limit=limit)
+        # We searched this prompt — whether or not it found anything, the
+        # auto-recall fallback must not search it again (M-42).
         if not results:
-            return None
+            return None, True
         lines = []
         for r in results[:limit]:
             content = r.get("content", "")[:200]
@@ -387,9 +433,9 @@ def _try_proactive_recall(prompt: str, user_id: str, db_path: str, session_id: s
             "Proactive memory recall:\n"
             + "\n".join(lines)
             + "\n</truememory-recall>"
-        )
+        ), True
     except Exception:
-        return None
+        return None, True
 
 
 def _detect_recall(prompt: str) -> bool:
@@ -400,15 +446,19 @@ def _detect_recall(prompt: str) -> bool:
     return bool(_RECALL_RE.search(prompt))
 
 
-def _try_auto_recall(prompt: str, user_id: str, db_path: str, session_id: str = "") -> str | None:
+def _try_auto_recall(prompt: str, user_id: str, db_path: str, session_id: str = "", debounced: bool = False) -> str | None:
     """Search TrueMemory if prompt looks like a recall question.
 
     Skips the search entirely on the first prompt right after SessionStart,
     which already injected recall (issue #561). The gate runs before detection
     and the Memory load so the redundant first-message recall costs nothing.
+
+    ``debounced`` is the one-shot SessionStart recall marker, consumed once by
+    ``main()`` (issue #636, M-41): consuming it here too would double-consume
+    and let a duplicate search slip through, so the marker is read upstream and
+    passed in.
     """
-    from truememory.ingest.hooks._shared import consume_recall_injected
-    if session_id and consume_recall_injected(session_id):
+    if debounced:
         return None
     if not _detect_recall(prompt):
         return None
@@ -423,8 +473,8 @@ def _try_auto_recall(prompt: str, user_id: str, db_path: str, session_id: str = 
         except Exception:
             pass
         from truememory.client import Memory
-        m = Memory(path=db_path or None)
-        results = m.search(prompt, user_id=user_id or None, limit=5)
+        with Memory(path=db_path or None) as m:
+            results = m.search(prompt, user_id=user_id or None, limit=5)
         if not results:
             return None
         lines = []
@@ -555,16 +605,39 @@ def main():
     except Exception:
         pass  # Never crash the hook
 
-    # Issue #396: proactive recall for enhanced/max search intensity
+    # Issue #561 / #636 (M-41): consume the one-shot SessionStart recall marker
+    # exactly ONCE per prompt. Both the proactive and auto-recall paths used to
+    # call consume_recall_injected() independently — the proactive path consumed
+    # it, returned None, and the auto-recall path then saw no marker and ran the
+    # exact first-prompt search #561 was meant to suppress. We read it here and
+    # pass the result into both paths.
+    debounced = False
+    try:
+        from truememory.ingest.hooks._shared import consume_recall_injected
+        if session_id:
+            debounced = consume_recall_injected(session_id)
+    except Exception:
+        pass
+
+    # Issue #396: proactive recall for enhanced/max search intensity.
+    # ``searched`` is True when the proactive path already searched (or was
+    # debounced for) this prompt, so the auto-recall fallback below would be a
+    # redundant second Memory init + search of the same prompt (issue #636,
+    # M-41/M-42). Only fall back when proactive did not handle this prompt.
     recall_context = None
+    searched = False
     if search_intensity != "standard":
-        recall_context = _try_proactive_recall(
+        recall_context, searched = _try_proactive_recall(
             prompt, args.user, args.db, session_id, search_intensity, prompt_count,
+            debounced=debounced,
         )
 
-    # Fall back to standard recall-intent detection
-    if not recall_context:
-        recall_context = _try_auto_recall(prompt, args.user, args.db, session_id)
+    # Fall back to standard recall-intent detection (only if proactive didn't
+    # already search this prompt).
+    if not recall_context and not searched:
+        recall_context = _try_auto_recall(
+            prompt, args.user, args.db, session_id, debounced=debounced,
+        )
 
     if recall_context:
         print(json.dumps({"additionalContext": recall_context}))


### PR DESCRIPTION
Fixes #636.

## M-16 (P1) — intensity config no longer fails OPEN to "max"
`_get_intensity_config` (user_prompt_submit) and `_get_search_intensity` (session_start) now normalize raw config through an allowlist: `_normalize_intensity(value)` lowercases strings and validates against `{standard, enhanced, max}`, returning `"standard"` for any non-string or unrecognized value (`null`, `"turbo"`, numbers, etc.). Previously the exclusion-based dispatch (`!= "standard"` / `!= "enhanced"` → max) meant `"MAX"`, `"Enhanced"`, garbage, and JSON `null` all silently enabled the most expensive every-prompt mode — while session_start's `.get()` simultaneously treated the same value as base. Now both readers fail CLOSED and case variants like `"MAX"` resolve to the real `max` level consistently.

Scope note: `hooks/core.py` and `mcp_server.py`'s read helpers also read raw, but they already fail-SAFE via `.get(intensity, base)` (not the dangerous fail-OPEN) and are owned by other parallel work, so per the issue's minimal-change constraint they're left untouched. mcp_server's *write* path already validates against `_VALID_INTENSITIES`.

## M-41 (P2) — no duplicate first-prompt recall
The one-shot #561 debounce marker is now consumed exactly once in `main()` and passed into both recall paths as `debounced`. Previously `_try_proactive_recall` consumed it, returned None, and `main()` fell through to `_try_auto_recall`, which saw no marker and re-ran the exact search #561 suppressed (plus duplicate injection). When `debounced` is True both paths now short-circuit.

## M-42 (P2) — no double Memory init / double search
`_try_proactive_recall` now returns `(context, searched)`. When it searched the prompt (including the empty-result case), `main()` skips the `_try_auto_recall` fallback instead of constructing a second `Memory()` and searching the same prompt again. Both recall paths use `Memory(...)` as a context manager, so instances are always closed (no leak).

## M-72 (P3) — "max" budget is no longer a silent no-op
Chosen option: **scale the budget**. `RECALL_BUDGET_CHARS` now scales with intensity (`max` → 2x) via `_intensity_budget()`, so the higher `max` memory limit (35) actually injects a larger payload instead of being clipped back to 8KB by `_apply_budget`. An explicit `TRUEMEMORY_RECALL_BUDGET_CHARS` env override stays authoritative (multiplier x1) so operators keep full control.

## Tests
- New `tests/test_issue_636_intensity_validation.py` (28 tests): invalid/garbage/null/uppercase normalization in both readers; debounced proactive → auto-recall does not fire; empty-result max → single Memory init + closed; budget scales with intensity + env override authoritative.
- Updated `tests/test_issue_396_memory_intensity.py` and `tests/ingest/test_recall_debounce.py` for the new `(context, searched)` / `debounced` contract.
- `ruff check truememory/ tests/` clean. Targeted suite (`-k "intensity or recall or novelty or proactive"`) 153 passed; focused file run 84 passed.

Does not regress #634's per-exchange store or #657's score_space logic (those paths untouched).