### PR TITLE
test: CI hardening — hermetic test sockets, benchmarks __init__.py, py3.14 matrix, real-vector gate coverage (#654)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    # Issue #654 (M-82): matrix entries flagged `experimental` (e.g. 3.14)
+    # don't gate the merge; all stable entries default to false and remain
+    # required.
+    continue-on-error: ${{ matrix.experimental || false }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -29,6 +33,15 @@ jobs:
             python-version: "3.11"
           - os: ubuntu-latest
             python-version: "3.13"
+          # Issue #654 (M-82): Python 3.14 is the homebrew default but was
+          # untested. Added non-gating (continue-on-error) for now: 3.14 may
+          # surface the known test_upgrade_path UnicodeDecodeError + gate_eval
+          # issues that are environment/version-specific, and we do NOT skip
+          # real tests just to make 3.14 green. Promote to required once 3.14
+          # is clean.
+          - os: ubuntu-latest
+            python-version: "3.14"
+            experimental: true
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
@@ -51,13 +64,19 @@ jobs:
       - name: Lint
         run: ruff check truememory/ tests/
 
-  # Issue #426: model-download tests run here, isolated from the gate. This job
-  # exercises real HuggingFace downloads so coverage is NOT weakened, but a
-  # network flake here does not block PRs or releases (continue-on-error).
+  # Issue #426 / #654 (M-52): model-download tests run here, isolated from the
+  # gate. This job exercises real HuggingFace downloads + the real embedding
+  # path (test_issue_654_real_vector_smoke), so the L2-vs-cosine class of bug
+  # can no longer merge green.
+  #
+  # Previously this job was `continue-on-error: true`, which silently swallowed
+  # real-vector regressions (this is how the M-03 cosine bug shipped). It is now
+  # gating, but with a 3x retry loop so a transient HfHubHTTPError (network
+  # flake, not a code regression) does not block PRs or releases. Only a
+  # genuine, reproducible failure across all attempts fails CI.
   network-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python 3.12
@@ -68,8 +87,20 @@ jobs:
           cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: pip install -e ".[all,dev]"
-      - name: Run network-marked tests
-        run: pytest tests/ -v -m "network"
+      - name: Run network-marked tests (retried for transient HF flakes)
+        run: |
+          for attempt in 1 2 3; do
+            echo "::group::network-tests attempt $attempt"
+            if pytest tests/ -v -m "network"; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "network-tests attempt $attempt failed; retrying after backoff..."
+            sleep $((attempt * 15))
+          done
+          echo "network-tests failed after 3 attempts — treating as a real regression."
+          exit 1
 
   # Hunter F26: catch packaging regressions (missing py.typed, metadata
   # errors, broken README rendering, sdist contents) in CI instead of
@@ -92,3 +123,10 @@ jobs:
         run: python -m build
       - name: Verify package metadata
         run: twine check --strict dist/*
+      # Issue #654 (M-83): actually install the built wheel and exercise the
+      # console entry point, so a broken/missing entry-point or import-time
+      # failure is caught here (not just at release).
+      - name: Install wheel and smoke-test console script
+        run: |
+          pip install dist/*.whl
+          truememory-mcp --help

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,7 @@
+"""TrueMemory benchmark suites (regular package, not a PEP 420 namespace).
+
+Issue #654 (M-81): keeping ``benchmarks`` a *regular* package (with this
+``__init__.py``) prevents an unrelated editable-installed ``benchmarks``
+distribution on a contributor's machine from shadowing the repo's package and
+breaking ``from benchmarks... import ...`` in the test suite.
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,51 @@ requires_sqlite_ext = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_truememory_home(tmp_path_factory):
+    """Point the model-server socket/state and ``$HOME`` at a session tmp dir.
+
+    Issue #654 (M-54): ``model_client.SOCK_PATH`` / ``model_server.SOCK_PATH``
+    are computed at import time from ``Path.home() / ".truememory"`` — i.e. the
+    contributor's REAL user-global socket. Without isolation, a test that
+    probes ``_server_ready()`` / autostart can connect to (or stomp on)
+    whatever live daemon the developer is running, producing order- and
+    machine-dependent flakes.
+
+    This session-scoped autouse fixture redirects the module-level path
+    attributes on both modules at a hermetic tmp ``.truememory`` dir and sets
+    ``$HOME`` so any *new* code that recomputes ``Path.home()`` also lands in
+    the sandbox. Per-test ``patch.object(..., "SOCK_PATH", ...)`` calls still
+    override these baselines within their own scope, so existing socket tests
+    are unaffected.
+    """
+    home = tmp_path_factory.mktemp("tm_home")
+    tm_dir = home / ".truememory"
+    tm_dir.mkdir(parents=True, exist_ok=True)
+
+    # Set HOME first so it is captured by the per-test ``_isolate_environ``
+    # snapshot and therefore persists across the whole session.
+    os.environ["HOME"] = str(home)
+
+    for mod_name in ("truememory.model_client", "truememory.model_server"):
+        try:
+            mod = __import__(mod_name, fromlist=["_TRUEMEMORY_DIR"])
+        except Exception:
+            continue
+        if hasattr(mod, "_TRUEMEMORY_DIR"):
+            mod._TRUEMEMORY_DIR = tm_dir
+        for attr, name in (
+            ("SOCK_PATH", "model.sock"),
+            ("PID_PATH", "model_server.pid"),
+            ("PORT_PATH", "model_server.port"),
+            ("TOKEN_PATH", "model_server.token"),
+            ("LOCK_PATH", "model_server.lock"),
+        ):
+            if hasattr(mod, attr):
+                setattr(mod, attr, tm_dir / name)
+    yield
+
+
 @pytest.fixture(autouse=True)
 def _isolate_environ():
     """Snapshot/restore ``os.environ`` around every test.

--- a/tests/test_issue_654_real_vector_smoke.py
+++ b/tests/test_issue_654_real_vector_smoke.py
@@ -1,0 +1,78 @@
+"""Issue #654 (M-52): real-embedding smoke test for cosine-correct ranking.
+
+Every other build_vectors / cosine test in the suite stubs the encoder, so a
+regression in the *real* embedding path (the L2-vs-cosine bug from M-03, a
+model-resolution break, or a build_vectors/search_vector mismatch) can still
+merge green. This test closes that gap by running the genuine edge-tier
+Model2Vec embedder (``minishlab/potion-base-8M``) end to end and asserting the
+ranking is cosine-correct: a query semantically close to one stored message
+must out-rank a semantically distant one.
+
+It is marked ``network`` because the real model is downloaded from HuggingFace
+(or read from the local HF cache). It therefore runs in the dedicated
+``network-tests`` CI job — NOT the offline gate (which sets HF_HUB_OFFLINE=1
+and does not vendor the model). Adding it to the gate would introduce a flaky
+network dependency, which issue #654 explicitly forbids; instead the
+``network-tests`` job is made to fail (not silently continue-on-error) on a
+real regression. See .github/workflows/ci.yml.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import requires_sqlite_ext
+
+
+def _load_vec(conn):
+    import sqlite_vec
+
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+
+
+@pytest.mark.network
+@requires_sqlite_ext
+def test_real_model2vec_cosine_ranking():
+    """Real embeddings must rank a semantically-near message above a far one.
+
+    This is the assertion the L2-vs-cosine bug (M-03) would have failed: with a
+    broken metric, the distractor could out-rank or tie the true match.
+    """
+    from truememory import vector_search as vs
+    from truememory.storage import create_db
+
+    # Force the edge-tier (Model2Vec) embedder so the test is deterministic and
+    # CPU-only regardless of the contributor's ambient tier.
+    vs.set_embedding_model("model2vec")
+
+    conn = create_db(":memory:")
+    _load_vec(conn)
+    vs.init_vec_table(conn)
+
+    rows = [
+        (1, "The cat sat on the warm windowsill in the afternoon sun."),
+        (2, "Quarterly revenue grew on strong enterprise software sales."),
+    ]
+    for mid, content in rows:
+        conn.execute("INSERT INTO messages(id, content) VALUES (?, ?)", (mid, content))
+    conn.commit()
+
+    inserted = vs.build_vectors(conn)
+    assert inserted == 2, f"expected 2 real vectors, built {inserted}"
+
+    results = vs.search_vector(conn, "a kitten relaxing by the sunny window", limit=2)
+    assert results, "real-embedder search returned no results"
+
+    by_id = {r["id"]: r["score"] for r in results}
+    assert 1 in by_id and 2 in by_id, f"missing ids in {by_id}"
+
+    # Cosine-correct: the feline/window message must out-rank the finance one.
+    assert by_id[1] > by_id[2], (
+        f"cosine ranking regression: near-match score {by_id[1]:.4f} did not "
+        f"beat distractor {by_id[2]:.4f}"
+    )
+    # Scores are normalized to (0, 1]; sanity-check the transform.
+    assert 0.0 < by_id[1] <= 1.0 and 0.0 < by_id[2] <= 1.0, by_id
+
+    conn.close()


### PR DESCRIPTION
Fixes #654. CI/test-only hardening (no production `truememory/` source changed). All five findings from `D2_macos_ci.md`.

## M-54 (P2) — hermetic test sockets
`model_client.SOCK_PATH` / `model_server.SOCK_PATH` are computed at import time from `Path.home() / ".truememory"` — the contributor's real user-global socket — with no env override. Added a **session-scoped autouse** fixture `_isolate_truememory_home` in `tests/conftest.py` that redirects the module-level `_TRUEMEMORY_DIR`, `SOCK_PATH`, `PID_PATH`, `PORT_PATH`, `TOKEN_PATH`, `LOCK_PATH` on both modules to a tmp `.truememory` dir, and sets `$HOME` (captured by the existing per-test `_isolate_environ` snapshot so it persists). Per-test `patch.object(..., "SOCK_PATH", ...)` calls still override these baselines, so existing socket tests are unaffected — verified: 67 socket/model-server tests pass, and a probe confirms `SOCK_PATH` no longer points at the real `~/.truememory`.

## M-81 (P3) — benchmarks namespace shadowing
Added `benchmarks/__init__.py` (one docstring) so `benchmarks` is a regular package, not a PEP 420 namespace package an external editable `benchmarks` dist can shadow. Does not affect packaging: `pyproject.toml` sets `packages = ["truememory"]` explicitly and the sdist excludes `/benchmarks`.

Note: the issue also lists `benchmarks/gate_eval/__init__.py` and `.../candidates/__init__.py`, but **that subtree is gitignored and absent from the repo/CI** (0 tracked files). `tests/test_gate_eval_harness.py` is `skipif(not _HAS_BENCHMARKS)`, so it skips in CI rather than fails — the root-cause shadowing fix is the top-level `benchmarks/__init__.py`. When `gate_eval/` is committed, its subdirs should get `__init__.py` too.

## M-82 (P3) — Python 3.14
Added `3.14` to the ubuntu matrix, **non-gating** via `matrix.experimental` → `continue-on-error`. 3.14 may surface the known `test_upgrade_path` UnicodeDecodeError / gate_eval issues that are env/version-specific; per the issue I did **not** skip any real test to make 3.14 green. Promote to required once 3.14 is clean.

## M-83 (P3) — wheel exercise in build-check
`build-check` now runs `pip install dist/*.whl && truememory-mcp --help` after `twine check`, catching a broken/missing console entry point or import-time failure at PR time. (`truememory-mcp --help` is supported and exits cleanly.)

## M-52 (P2) — real-vector regression coverage (the decision)
The only job exercising real embeddings was `continue-on-error: true`, so the L2-vs-cosine bug (M-03) merged green. A real-embedder test **cannot** run in the offline gate (`HF_HUB_OFFLINE=1`, and `potion-base-8M` is not vendored) — the issue explicitly forbids adding a flaky network dependency to the gate. So:

1. Added `tests/test_issue_654_real_vector_smoke.py`, a **`network`-marked** test that runs the genuine edge-tier model2vec embedder end-to-end through `build_vectors` + `search_vector` and asserts cosine-correct ranking (a semantically near message out-ranks a distant one — exactly what the L2-vs-cosine bug would fail). It runs in the `network-tests` job, not the gate.
2. Made the `network-tests` job **gating instead of `continue-on-error: true`**, with a dependency-free 3x retry loop + backoff so a transient `HfHubHTTPError` doesn't block PRs but a genuine, reproducible real-vector regression now fails CI.

## Validation
- `ruff check truememory/ tests/` — clean.
- `HF_HUB_OFFLINE=1 pytest ... -k "conftest or socket or gate_eval or benchmark"` — 26 passed, 4 skipped (gate_eval skips: subtree absent).
- 67 socket/model-server tests pass with the new isolation fixture.
- New smoke test is correctly `network`-gated (deselected under `-m "not network"`).
- ci.yml validated as YAML.

## Caveats
- `gate_eval/` subtree is gitignored/absent here, so its harness test stays skipped in CI (not newly passing).
- 3.14 matrix entry is intentionally non-gating until proven clean.
- The real-vector smoke test runs only in the (now-gating, retried) network job — it requires HF model access by design.

Touched only `.github/workflows/ci.yml`, `tests/conftest.py`, `benchmarks/__init__.py`, `tests/test_issue_654_real_vector_smoke.py`. No production source, no README.
