### PR TITLE
fix: installer + adapter honesty — hook-entry dedup, alwaysLoad target + atomic writes, capability-parameterized prompts, antigravity verify (#651)

### DIFF
--- a/tests/test_issue_600_antigravity_groq_deepsearch.py
+++ b/tests/test_issue_600_antigravity_groq_deepsearch.py
@@ -31,7 +31,8 @@ def test_antigravity_adapter_properties():
     assert adapter.name == "Antigravity"
     assert adapter.cli_id == "antigravity"
     assert isinstance(adapter.config_path, Path)
-    assert adapter.config_path.name == "mcp.json"
+    # Antigravity reads mcp_config.json (issue #651 / M-66), not mcp.json.
+    assert adapter.config_path.name == "mcp_config.json"
 
 
 def test_antigravity_implements_all_abstract_methods():

--- a/tests/test_issue_651_installer_adapters.py
+++ b/tests/test_issue_651_installer_adapters.py
@@ -1,0 +1,316 @@
+"""Tests for issue #651: installer + adapter honesty.
+
+Covers:
+- M-29: install_hooks is idempotent (re-running does not duplicate hook entries).
+- M-63: the alwaysLoad/MCP patch targets ~/.claude.json and writes atomically;
+        subprocess failures are surfaced, not swallowed.
+- M-62: hook-less adapters' generic prompt does NOT promise auto-loaded
+        directives or SessionEnd transcript capture; hook-capable ones do.
+- M-66: the antigravity adapter targets/verifies the documented mcp_config.json.
+
+All filesystem access is redirected to tmp dirs / fake homes; the real
+~/.claude and ~/.antigravity are never touched. No model loads.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# M-29: install_hooks idempotency
+# ---------------------------------------------------------------------------
+
+def _count_tm_hook_entries(settings: dict) -> dict[str, int]:
+    """Count truememory hook entries per event in a settings dict."""
+    counts: dict[str, int] = {}
+    for event, entries in settings.get("hooks", {}).items():
+        if not isinstance(entries, list):
+            continue
+        n = 0
+        for h in entries:
+            if not isinstance(h, dict):
+                continue
+            inner = h.get("hooks", [])
+            if isinstance(inner, list) and any(
+                isinstance(ih, dict) and "truememory" in str(ih.get("command", "")).lower()
+                for ih in inner
+            ):
+                n += 1
+            elif "truememory" in str(h.get("command", "")).lower():
+                n += 1
+        counts[event] = n
+    return counts
+
+
+def _make_claude_adapter(tmp_path: Path):
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+
+    adapter = ClaudeAdapter()
+    settings_path = tmp_path / ".claude" / "settings.json"
+    # Patch config_path to point at the fake home.
+    patcher = patch.object(
+        type(adapter), "config_path",
+        new=property(lambda self: settings_path),
+    )
+    return adapter, settings_path, patcher
+
+
+def test_install_hooks_is_idempotent(tmp_path):
+    """Running install_hooks twice must not duplicate hook entries (M-29)."""
+    adapter, settings_path, patcher = _make_claude_adapter(tmp_path)
+    with patcher:
+        adapter.install_hooks(python_path="/usr/bin/python3")
+        first = json.loads(settings_path.read_text())
+        adapter.install_hooks(python_path="/usr/bin/python3")
+        second = json.loads(settings_path.read_text())
+
+    counts_first = _count_tm_hook_entries(first)
+    counts_second = _count_tm_hook_entries(second)
+
+    # Each of the 4 events should have exactly one truememory entry, both times.
+    assert counts_first == counts_second
+    assert counts_first  # non-empty
+    for event, n in counts_second.items():
+        assert n == 1, f"{event} has {n} truememory entries after 2 installs (expected 1)"
+
+
+def test_install_hooks_commands_are_module_form(tmp_path):
+    """Sanity: the bug was module-form commands vs .py-path dedup needle."""
+    adapter, settings_path, patcher = _make_claude_adapter(tmp_path)
+    with patcher:
+        adapter.install_hooks(python_path="/usr/bin/python3")
+    settings = json.loads(settings_path.read_text())
+    cmds = [
+        ih["command"]
+        for entries in settings["hooks"].values()
+        for h in entries
+        for ih in h.get("hooks", [])
+    ]
+    assert cmds
+    assert all("-m truememory.ingest.hooks" in c for c in cmds)
+    # The dedup needle ".py" path must NOT appear (that was the broken needle).
+    assert all("session_start.py" not in c for c in cmds)
+
+
+def test_install_hooks_thrice_no_growth(tmp_path):
+    """Three installs (the issue's repro) stay at one entry per event."""
+    adapter, settings_path, patcher = _make_claude_adapter(tmp_path)
+    with patcher:
+        for _ in range(3):
+            adapter.install_hooks(python_path="/usr/bin/python3")
+        settings = json.loads(settings_path.read_text())
+    for event, n in _count_tm_hook_entries(settings).items():
+        assert n == 1, f"{event} grew to {n} entries after 3 installs"
+
+
+# ---------------------------------------------------------------------------
+# M-63: install_mcp targets ~/.claude.json + atomic write + subprocess check
+# ---------------------------------------------------------------------------
+
+def test_install_mcp_patches_claude_json_not_settings(tmp_path):
+    """alwaysLoad must be written to ~/.claude.json (what the CLI reads)."""
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+
+    adapter = ClaudeAdapter()
+    settings_path = tmp_path / ".claude" / "settings.json"
+    claude_json = tmp_path / ".claude.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Simulate `claude mcp add` having written the server entry to ~/.claude.json.
+    claude_json.write_text(json.dumps({
+        "mcpServers": {"truememory": {"command": "py", "args": ["-m", "truememory.mcp_server"]}}
+    }))
+    settings_path.write_text(json.dumps({"existing": "keep"}))
+
+    class _OK:
+        returncode = 0
+        stderr = b""
+
+    with patch.object(type(adapter), "config_path", new=property(lambda self: settings_path)), \
+         patch.object(type(adapter), "mcp_config_path", new=property(lambda self: claude_json)), \
+         patch("subprocess.run", return_value=_OK()):
+        adapter.install_mcp(python_path="py")
+
+    patched = json.loads(claude_json.read_text())
+    assert patched["mcpServers"]["truememory"]["alwaysLoad"] is True
+    # settings.json must be left untouched (no truncation, no mcp added there).
+    assert json.loads(settings_path.read_text()) == {"existing": "keep"}
+
+
+def test_install_mcp_atomic_write_no_leftover_tmp(tmp_path):
+    """The atomic patch must not leave a .tmp file behind."""
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+
+    adapter = ClaudeAdapter()
+    claude_json = tmp_path / ".claude.json"
+    settings_path = tmp_path / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    claude_json.write_text(json.dumps({
+        "mcpServers": {"truememory": {"command": "py"}}
+    }))
+
+    class _OK:
+        returncode = 0
+        stderr = b""
+
+    with patch.object(type(adapter), "config_path", new=property(lambda self: settings_path)), \
+         patch.object(type(adapter), "mcp_config_path", new=property(lambda self: claude_json)), \
+         patch("subprocess.run", return_value=_OK()):
+        adapter.install_mcp(python_path="py")
+
+    leftover = list(tmp_path.glob(".*.tmp"))
+    assert not leftover, f"left tmp files: {leftover}"
+
+
+def test_install_mcp_skips_patch_when_add_fails(tmp_path, capsys):
+    """A failed `claude mcp add` must be surfaced, not swallowed, and skip patch."""
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+
+    adapter = ClaudeAdapter()
+    claude_json = tmp_path / ".claude.json"
+    settings_path = tmp_path / ".claude" / "settings.json"
+
+    class _Fail:
+        returncode = 1
+        stderr = b"boom"
+
+    with patch.object(type(adapter), "config_path", new=property(lambda self: settings_path)), \
+         patch.object(type(adapter), "mcp_config_path", new=property(lambda self: claude_json)), \
+         patch("subprocess.run", return_value=_Fail()):
+        adapter.install_mcp(python_path="py")
+
+    err = capsys.readouterr().err
+    assert "claude mcp add" in err  # failure surfaced
+    assert not claude_json.exists()  # no phantom patch
+
+
+def test_atomic_write_json_replaces_in_place(tmp_path):
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+
+    target = tmp_path / "cfg.json"
+    target.write_text('{"old": true}')
+    ClaudeAdapter._atomic_write_json(target, {"new": True})
+    assert json.loads(target.read_text()) == {"new": True}
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
+# ---------------------------------------------------------------------------
+# M-62: capability-parameterized generic prompt honesty
+# ---------------------------------------------------------------------------
+
+def test_hookless_prompt_omits_false_guarantees():
+    """A hook-less adapter's prompt must not claim auto-load or SessionEnd."""
+    from truememory.hooks.adapters.base import get_generic_system_prompt
+
+    prompt = get_generic_system_prompt(has_hooks=False, has_session_start=False).lower()
+    assert "injected automatically at the start of every session" not in prompt
+    assert "sessionend" not in prompt
+    assert "captures the full transcript" not in prompt
+    assert "memory.md" not in prompt
+    # It should still teach storing + directives.
+    assert "truememory_store" in prompt
+    assert "directive" in prompt
+    # And it should tell a hook-less host to store manually.
+    assert "store" in prompt and "yourself" in prompt
+
+
+def test_hookful_prompt_keeps_autoload_guarantee():
+    """A hook-capable adapter keeps the auto-load promise (template path)."""
+    from truememory.hooks.adapters.base import get_generic_system_prompt
+
+    prompt = get_generic_system_prompt(has_hooks=True, has_session_start=True).lower()
+    # Template-derived prompt mentions auto-loaded directives / every session.
+    assert "every session" in prompt or "session start" in prompt
+    assert "truememory" in prompt
+
+
+def test_antigravity_prompt_is_honest():
+    """The real Antigravity adapter (hook-less) yields an honest prompt."""
+    from truememory.hooks.adapters.antigravity import AntigravityAdapter
+
+    adapter = AntigravityAdapter()
+    assert adapter.has_hooks is False
+    assert adapter.has_session_start is False
+    prompt = adapter.get_system_prompt_content().lower()
+    assert "sessionend" not in prompt
+    assert "injected automatically at the start of every session" not in prompt
+    assert "truememory_store" in prompt
+
+
+def test_claude_adapter_declares_hooks():
+    from truememory.hooks.adapters.claude import ClaudeAdapter
+
+    a = ClaudeAdapter()
+    assert a.has_hooks is True
+    assert a.has_session_start is True
+
+
+@pytest.mark.parametrize("cli_id,expected", [
+    ("claude", True),
+    ("hermes", True),
+    ("kimi", True),
+    ("cursor", True),
+    ("gemini", True),
+    ("codex", True),
+    ("openclaw", True),
+    ("antigravity", False),
+    ("chatgpt", False),
+])
+def test_adapter_hook_capability_flags(cli_id, expected):
+    """Capability flags must match whether the adapter installs real hooks."""
+    from truememory.hooks.registry import get_adapter
+
+    adapter = get_adapter(cli_id)
+    assert adapter is not None
+    assert adapter.has_hooks is expected
+
+
+# ---------------------------------------------------------------------------
+# M-66: antigravity targets/verifies the documented config filename
+# ---------------------------------------------------------------------------
+
+def test_antigravity_config_filename_is_mcp_config(tmp_path, monkeypatch):
+    """The adapter must read/write the documented mcp_config.json filename."""
+    from truememory.hooks.adapters import antigravity as ag_mod
+    from truememory.hooks.adapters.antigravity import AntigravityAdapter
+
+    config_path = tmp_path / ".antigravity" / "mcp_config.json"
+    monkeypatch.setattr(ag_mod, "_MCP_CONFIG", config_path)
+
+    adapter = AntigravityAdapter()
+    assert adapter.config_path.name == "mcp_config.json"
+
+    adapter.install_mcp(python_path="/usr/bin/python3")
+    # Written to the documented filename.
+    assert config_path.exists()
+    assert config_path.name == "mcp_config.json"
+    data = json.loads(config_path.read_text())
+    assert "truememory" in data["mcpServers"]
+
+
+def test_antigravity_verify_checks_documented_target(tmp_path, monkeypatch):
+    """verify() must pass only when the documented config holds our entry."""
+    from truememory.hooks.adapters import antigravity as ag_mod
+    from truememory.hooks.adapters.antigravity import AntigravityAdapter
+
+    config_path = tmp_path / ".antigravity" / "mcp_config.json"
+    monkeypatch.setattr(ag_mod, "_MCP_CONFIG", config_path)
+    adapter = AntigravityAdapter()
+
+    # No config yet -> verify False.
+    assert adapter.verify() is False
+
+    # A config at the WRONG filename must NOT satisfy verify().
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    (config_path.parent / "mcp.json").write_text(json.dumps({
+        "mcpServers": {"truememory": {"command": "py"}}
+    }))
+    assert adapter.verify() is False
+
+    # Install at the documented filename -> verify True.
+    adapter.install_mcp(python_path="py")
+    assert adapter.verify() is True

--- a/truememory/hooks/adapters/antigravity.py
+++ b/truememory/hooks/adapters/antigravity.py
@@ -1,7 +1,17 @@
 """Antigravity adapter -- MCP config for the Antigravity AI CLI.
 
-Antigravity uses a JSON MCP config file at ~/.antigravity/mcp.json,
-following the same mcpServers format as Claude Desktop / ChatGPT Desktop.
+Antigravity reads its MCP config from a JSON file named ``mcp_config.json``
+(the filename its docs and "View raw config" UI use), following the same
+mcpServers format as Claude Desktop / ChatGPT Desktop. Earlier versions of
+this adapter wrote ``~/.antigravity/mcp.json`` — a filename the host does not
+read — and verify() re-read that same file, so a broken install still reported
+success. We now write/verify ``mcp_config.json``.
+
+NOTE (uncertainty): community docs also place this file under ``~/.gemini/``
+(e.g. ``~/.gemini/config/mcp_config.json`` or ``~/.gemini/antigravity/``)
+rather than ``~/.antigravity/``. The directory is left as ``~/.antigravity``
+pending confirmation; the filename fix is the high-confidence change. See PR
+notes for M-66.
 """
 from __future__ import annotations
 
@@ -17,7 +27,7 @@ from pathlib import Path
 from truememory.hooks.adapters.base import CLIAdapter, get_generic_system_prompt
 
 _ANTIGRAVITY_DIR = Path.home() / ".antigravity"
-_MCP_CONFIG = _ANTIGRAVITY_DIR / "mcp.json"
+_MCP_CONFIG = _ANTIGRAVITY_DIR / "mcp_config.json"
 
 _TRUEMEMORY_MARKER = "truememory"
 
@@ -155,7 +165,13 @@ class AntigravityAdapter(CLIAdapter):
         return _ANTIGRAVITY_DIR / "ANTIGRAVITY.md"
 
     def get_system_prompt_content(self) -> str:
-        return get_generic_system_prompt()
+        # Antigravity has no lifecycle hooks: pass capability flags so the
+        # prompt does not falsely promise auto-loaded directives or SessionEnd
+        # transcript capture.
+        return get_generic_system_prompt(
+            has_hooks=self.has_hooks,
+            has_session_start=self.has_session_start,
+        )
 
     def _has_mcp_entry(self) -> bool:
         if not _MCP_CONFIG.exists():

--- a/truememory/hooks/adapters/base.py
+++ b/truememory/hooks/adapters/base.py
@@ -13,6 +13,21 @@ from pathlib import Path
 class CLIAdapter(ABC):
     """Base interface for CLI-specific TrueMemory integration."""
 
+    # --- Capability flags -------------------------------------------------
+    # Hook-less adapters (Antigravity, ChatGPT, Cursor, ...) expose MCP tools
+    # but cannot register lifecycle hooks. Their system prompt MUST NOT promise
+    # auto-loading directives or SessionEnd transcript capture, because nothing
+    # delivers those. Adapters that DO install hooks override these to True.
+    @property
+    def has_hooks(self) -> bool:
+        """True if install_hooks registers real lifecycle hooks."""
+        return False
+
+    @property
+    def has_session_start(self) -> bool:
+        """True if a SessionStart hook injects directives every session."""
+        return self.has_hooks
+
     @property
     @abstractmethod
     def name(self) -> str:
@@ -68,26 +83,51 @@ class CLIAdapter(ABC):
 
 # Served when CLAUDE_TEMPLATE.md is missing or unreadable. Must carry the
 # same directive guidance as the template (issue #589, D-7) so directives
-# stay discoverable even on broken installs.
+# stay discoverable even on broken installs. The auto-load / store-manually
+# sentence is appended per the host's hook capability (issue #651, M-62).
 _FALLBACK_PROMPT = (
     "# TrueMemory — Persistent Memory\n\n"
     "You have access to TrueMemory MCP tools for persistent memory.\n"
     "- Use `truememory_store` to save user facts, preferences, and decisions.\n"
     '- When the user gives a standing instruction ("always do X", "never do Y", '
     '"from now on..."), store it as a directive: '
-    '`truememory_store(content="...", directive=True)`. Directives auto-load '
-    "at the start of every session — regular memories do not.\n"
+    '`truememory_store(content="...", directive=True)`.\n'
     "- Use `truememory_search` to recall stored memories before answering.\n"
-    "- Directives are injected automatically at session start — you do not "
-    "need to search for them.\n"
     "- Search TrueMemory FIRST on any 'do you remember' question.\n"
 )
 
+# Appended only for hosts with a SessionStart hook — they get directives
+# injected automatically. Hook-less hosts must be told to fetch them.
+_FALLBACK_AUTOLOAD = (
+    "- Directives are injected automatically at the start of every session — "
+    "you do not need to search for them.\n"
+)
+_FALLBACK_NO_AUTOLOAD = (
+    "- This host has no session-start hook, so directives are NOT auto-injected. "
+    "At the start of a session, call `truememory_search` for standing "
+    "instructions and follow any directives it returns.\n"
+)
 
-def get_generic_system_prompt() -> str:
-    """Return the TrueMemory system prompt for non-Claude CLIs."""
+
+def get_generic_system_prompt(
+    has_hooks: bool = False,
+    has_session_start: bool | None = None,
+) -> str:
+    """Return the TrueMemory system prompt for non-Claude CLIs.
+
+    The base template (CLAUDE_TEMPLATE.md) is written for Claude Code, which
+    installs SessionStart/SessionEnd hooks and uses MEMORY.md. Hook-less
+    adapters (Antigravity, ChatGPT) must NOT inherit those promises — there is
+    no hook to auto-load directives or capture the transcript, and they have no
+    MEMORY.md. Pass the adapter's capability flags so the prompt is honest.
+    """
+    if has_session_start is None:
+        has_session_start = has_hooks
+
     template = Path(__file__).parent.parent.parent / "ingest" / "CLAUDE_TEMPLATE.md"
-    if template.exists():
+    if has_hooks and template.exists():
+        # Hook-capable non-Claude host: the template's hook-based guarantees
+        # hold, just relabel Claude-specific bits.
         try:
             content = template.read_text(encoding="utf-8").strip()
             content = content.replace("Claude Code's built-in auto-memory", "The host CLI's built-in memory")
@@ -95,4 +135,16 @@ def get_generic_system_prompt() -> str:
             return content
         except OSError:
             pass
-    return _FALLBACK_PROMPT
+
+    # Hook-less host (or unreadable template): build an honest prompt that does
+    # not claim auto-load / SessionEnd capture / MEMORY.md.
+    prompt = _FALLBACK_PROMPT
+    prompt += _FALLBACK_AUTOLOAD if has_session_start else _FALLBACK_NO_AUTOLOAD
+    if not has_hooks:
+        prompt += (
+            "- This host does NOT capture the transcript at session end. "
+            "TrueMemory cannot extract memories automatically here, so store "
+            "important facts, preferences, decisions, and corrections yourself "
+            "with `truememory_store` as the conversation happens.\n"
+        )
+    return prompt

--- a/truememory/hooks/adapters/claude.py
+++ b/truememory/hooks/adapters/claude.py
@@ -6,6 +6,7 @@ The existing `truememory-ingest install` command continues working unchanged.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -15,6 +16,10 @@ from truememory.hooks.adapters.base import CLIAdapter
 
 class ClaudeAdapter(CLIAdapter):
     """Adapter for Claude Code CLI."""
+
+    @property
+    def has_hooks(self) -> bool:
+        return True
 
     @property
     def name(self) -> str:
@@ -55,31 +60,72 @@ class ClaudeAdapter(CLIAdapter):
             pass
         return False
 
+    @property
+    def mcp_config_path(self) -> Path:
+        # `claude mcp add --scope user` writes the server entry to ~/.claude.json,
+        # NOT ~/.claude/settings.json. The alwaysLoad patch must target the same
+        # file the CLI actually reads, or it's a silent no-op.
+        return Path.home() / ".claude.json"
+
     def install_mcp(self, python_path: str | None = None) -> None:
         py = python_path or sys.executable
+        added = False
         try:
             import subprocess
-            subprocess.run(
+            result = subprocess.run(
                 ["claude", "mcp", "add", "--scope", "user", "truememory",
                  "--", py, "-m", "truememory.mcp_server"],
                 check=False,
                 capture_output=True,
             )
+            if result.returncode == 0:
+                added = True
+            else:
+                stderr = (result.stderr or b"").decode("utf-8", "replace").strip()
+                print(
+                    f"\033[33m⚠ `claude mcp add` exited {result.returncode}"
+                    f"{f': {stderr}' if stderr else ''}.\033[0m",
+                    file=sys.stderr,
+                )
         except FileNotFoundError:
-            pass
+            print(
+                "\033[33m⚠ `claude` CLI not found on PATH; skipping MCP "
+                "registration.\033[0m",
+                file=sys.stderr,
+            )
 
-        # `claude mcp add` doesn't support alwaysLoad, so patch it in directly.
+        # `claude mcp add` doesn't support alwaysLoad, so patch it into the file
+        # the CLI wrote (~/.claude.json). Only bother if the add succeeded;
+        # otherwise there is no entry to patch.
+        if not added:
+            return
+        mcp_path = self.mcp_config_path
         try:
-            if self.config_path.exists():
-                cfg = json.loads(self.config_path.read_text(encoding="utf-8"))
-                mcp = cfg.get("mcpServers", {})
-                if "truememory" in mcp and not mcp["truememory"].get("alwaysLoad"):
-                    mcp["truememory"]["alwaysLoad"] = True
-                    self.config_path.write_text(
-                        json.dumps(cfg, indent=2), encoding="utf-8",
-                    )
+            if mcp_path.exists():
+                cfg = json.loads(mcp_path.read_text(encoding="utf-8"))
+                if isinstance(cfg, dict):
+                    mcp = cfg.get("mcpServers", {})
+                    if (
+                        isinstance(mcp, dict)
+                        and isinstance(mcp.get("truememory"), dict)
+                        and not mcp["truememory"].get("alwaysLoad")
+                    ):
+                        mcp["truememory"]["alwaysLoad"] = True
+                        self._atomic_write_json(mcp_path, cfg)
         except (json.JSONDecodeError, OSError):
             pass
+
+    @staticmethod
+    def _atomic_write_json(path: Path, data: dict) -> None:
+        # tmp-in-same-dir + replace: a crash mid-write must never truncate the
+        # user's config. A bare write_text() can leave a half-written file.
+        tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        try:
+            tmp.replace(path)
+        except OSError:
+            tmp.unlink(missing_ok=True)
+            raise
 
     def install_hooks(
         self,
@@ -236,9 +282,14 @@ class ClaudeAdapter(CLIAdapter):
             existing["hooks"].setdefault(event, [])
             if not isinstance(existing["hooks"][event], list):
                 existing["hooks"][event] = []
-            # Don't add duplicates (match on stop.py / session_start.py etc.)
+            # Don't add duplicates. Match on the "truememory" substring rather
+            # than the absolute .py file path: _build_command emits module-form
+            # commands ("-m truememory.ingest.hooks.X"), so the .py path never
+            # appears in the command and the old check matched nothing — every
+            # re-install appended another entry. The "truememory" needle is the
+            # same one the migration/uninstall code already uses, keeping
+            # install idempotent across upgrades.
             for hook in hooks:
-                hook_file = str(hook_files[event])
                 already_present = False
                 for h in existing["hooks"][event]:
                     if not isinstance(h, dict):
@@ -246,10 +297,10 @@ class ClaudeAdapter(CLIAdapter):
                     inner_hooks = h.get("hooks", [])
                     if isinstance(inner_hooks, list):
                         for ih in inner_hooks:
-                            if isinstance(ih, dict) and hook_file in ih.get("command", ""):
+                            if isinstance(ih, dict) and "truememory" in str(ih.get("command", "")).lower():
                                 already_present = True
                                 break
-                    if hook_file in h.get("command", ""):
+                    if "truememory" in str(h.get("command", "")).lower():
                         already_present = True
                     if already_present:
                         break
@@ -312,14 +363,31 @@ class ClaudeAdapter(CLIAdapter):
                 del mcp_servers["truememory"]
                 settings["mcpServers"] = mcp_servers
 
-            self.config_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+            self._atomic_write_json(self.config_path, settings)
         except (json.JSONDecodeError, OSError):
             pass
 
+    def _mcp_registered(self) -> bool:
+        # The MCP server entry lives in ~/.claude.json (written by
+        # `claude mcp add`), not in settings.json. Check the real target.
+        mcp_path = self.mcp_config_path
+        if not mcp_path.exists():
+            return False
+        try:
+            cfg = json.loads(mcp_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return False
+        if not isinstance(cfg, dict):
+            return False
+        return "truememory" in cfg.get("mcpServers", {})
+
     def verify(self) -> bool:
+        # A complete install is hooks (settings.json) AND the MCP server entry
+        # (~/.claude.json). The old verify() only checked hooks, so a half
+        # install where `claude mcp add` failed still reported success.
         if not self.config_path.exists():
             return False
-        return self.is_configured()
+        return self.is_configured() and self._mcp_registered()
 
     def get_system_prompt_path(self) -> Path | None:
         return Path.home() / ".claude" / "CLAUDE.md"

--- a/truememory/hooks/adapters/codex.py
+++ b/truememory/hooks/adapters/codex.py
@@ -94,6 +94,10 @@ class CodexAdapter(CLIAdapter):
     """Adapter for OpenAI Codex CLI."""
 
     @property
+    def has_hooks(self) -> bool:
+        return True
+
+    @property
     def name(self) -> str:
         return "Codex CLI"
 

--- a/truememory/hooks/adapters/cursor.py
+++ b/truememory/hooks/adapters/cursor.py
@@ -88,6 +88,10 @@ class CursorAdapter(CLIAdapter):
     """Adapter for Cursor IDE."""
 
     @property
+    def has_hooks(self) -> bool:
+        return True
+
+    @property
     def name(self) -> str:
         return "Cursor"
 

--- a/truememory/hooks/adapters/gemini.py
+++ b/truememory/hooks/adapters/gemini.py
@@ -89,6 +89,10 @@ class GeminiAdapter(CLIAdapter):
     """Adapter for Google Gemini CLI."""
 
     @property
+    def has_hooks(self) -> bool:
+        return True
+
+    @property
     def name(self) -> str:
         return "Gemini CLI"
 

--- a/truememory/hooks/adapters/hermes.py
+++ b/truememory/hooks/adapters/hermes.py
@@ -92,6 +92,10 @@ class HermesAdapter(CLIAdapter):
     """Adapter for Hermes Agent (Nous Research)."""
 
     @property
+    def has_hooks(self) -> bool:
+        return True
+
+    @property
     def name(self) -> str:
         return "Hermes Agent"
 
@@ -200,7 +204,10 @@ class HermesAdapter(CLIAdapter):
 
     def get_system_prompt_content(self) -> str:
         from truememory.hooks.adapters.base import get_generic_system_prompt
-        return get_generic_system_prompt()
+        return get_generic_system_prompt(
+            has_hooks=self.has_hooks,
+            has_session_start=self.has_session_start,
+        )
 
     # -- Private helpers --
 

--- a/truememory/hooks/adapters/kimi.py
+++ b/truememory/hooks/adapters/kimi.py
@@ -48,6 +48,10 @@ class KimiAdapter(CLIAdapter):
     """Adapter for Kimi CLI (Moonshot AI)."""
 
     @property
+    def has_hooks(self) -> bool:
+        return True
+
+    @property
     def name(self) -> str:
         return "Kimi CLI"
 
@@ -146,7 +150,10 @@ class KimiAdapter(CLIAdapter):
 
     def get_system_prompt_content(self) -> str:
         from truememory.hooks.adapters.base import get_generic_system_prompt
-        return get_generic_system_prompt()
+        return get_generic_system_prompt(
+            has_hooks=self.has_hooks,
+            has_session_start=self.has_session_start,
+        )
 
     # -- Private helpers --
 

--- a/truememory/hooks/adapters/openclaw.py
+++ b/truememory/hooks/adapters/openclaw.py
@@ -111,6 +111,10 @@ class OpenClawAdapter(CLIAdapter):
     """Adapter for OpenClaw agent gateway."""
 
     @property
+    def has_hooks(self) -> bool:
+        return True
+
+    @property
     def name(self) -> str:
         return "OpenClaw"
 
@@ -197,7 +201,10 @@ class OpenClawAdapter(CLIAdapter):
 
     def get_system_prompt_content(self) -> str:
         from truememory.hooks.adapters.base import get_generic_system_prompt
-        return get_generic_system_prompt()
+        return get_generic_system_prompt(
+            has_hooks=self.has_hooks,
+            has_session_start=self.has_session_start,
+        )
 
     # -- Private helpers --
 


### PR DESCRIPTION
Fixes #651 (Theme T10). Installer + adapter honesty.

## M-29 (P1) — duplicate hook entries on every install
`ClaudeAdapter.install_hooks` deduped against the absolute `.py` file path, but `_build_command` emits module-form commands (`-m truememory.ingest.hooks.X`), so the needle never matched and every install/upgrade appended 4 more hook entries (N× latency / context injection / extraction spawns).
**Fix:** match on the `"truememory"` substring (same needle the migration/uninstall code already uses), making re-install idempotent. Verified at 2 and 3 installs.

## M-63 (P2) — alwaysLoad patch hit the wrong file; non-atomic writes; swallowed failures
`claude mcp add --scope user` writes the server entry to `~/.claude.json`, but the alwaysLoad patch read `~/.claude/settings.json` → silent no-op. Bare `write_text` could truncate config; subprocess failures were swallowed; `verify()` checked hooks only.
**Fix:** new `mcp_config_path` property (`~/.claude.json`); patch + uninstall use `_atomic_write_json` (tmp-in-same-dir + replace); `claude mcp add` return code checked and surfaced to stderr (skip the patch if it failed); `verify()` now also confirms the MCP server registration in `~/.claude.json`.

## M-62 (P2) — hook-less adapters promised hooks they don't have
`get_generic_system_prompt` served the Claude template verbatim to all non-Claude CLIs, promising auto-loaded directives, SessionEnd transcript capture, and MEMORY.md — false for hook-less hosts (antigravity, chatgpt), which were also told not to store manually.
**Fix:** capability model on `CLIAdapter` (`has_hooks` / `has_session_start`, default False). `get_generic_system_prompt(has_hooks, has_session_start)` now emits an honest prompt: hook-less hosts get a 'directives are NOT auto-injected — search at session start' line plus a 'store facts yourself, no transcript capture here' line; hook-capable hosts keep the template guarantees. Hook-installing adapters (claude, hermes, kimi, cursor, gemini, codex, openclaw) declare `has_hooks=True` and pass their flags through (no prompt regression); antigravity/chatgpt stay False.

## M-66 (P2) — antigravity wrote/verified a filename the host doesn't read
Adapter hardcoded `~/.antigravity/mcp.json`; the documented filename is `mcp_config.json`, and `verify()` re-read its own output (self-fulfilling).
**Fix:** target/verify `mcp_config.json`. **Caveat:** community docs also place this file under `~/.gemini/` (e.g. `~/.gemini/config/mcp_config.json` or `~/.gemini/antigravity/`) rather than `~/.antigravity/`; the filename fix is the high-confidence change, the directory is left as `~/.antigravity` pending confirmation (noted in the adapter docstring).

## Tests
New `tests/test_issue_651_installer_adapters.py` (22 cases): install_hooks idempotency at 2 & 3 runs + module-form command assertion; install_mcp targets `~/.claude.json`, writes atomically (no leftover tmp), leaves settings.json untouched, surfaces + skips on `claude mcp add` failure; hook-less prompt omits auto-load/SessionEnd/MEMORY.md and tells the host to store manually while hook-capable keeps the guarantee; per-adapter capability-flag matrix; antigravity targets + verifies `mcp_config.json` (and rejects a stray `mcp.json`). Updated one assertion in `test_issue_600` for the new filename. All fake-home/tmp; `HF_HUB_OFFLINE=1`, no model loads.

Targeted suite green (`-k 'adapter or install or claude_adapter or antigravity or hook'`): 271 passed, 1 failed — `test_spawn_cap_blocks_when_at_cap`, a pre-existing baseline failure in `tests/ingest/test_stop_hook_safety.py` (extraction-budget vs spawn-cap ordering) that fails identically on the clean base branch and is unrelated to these files. `ruff check truememory/ tests/` clean.

Files touched: `truememory/hooks/adapters/{base,claude,antigravity,hermes,kimi,cursor,gemini,codex,openclaw}.py` + tests. No README/unrelated edits.