### PR TITLE
fix: close directive content-leak paths (personality, clustered, entity-profile, temporal, flag plumbing) (#637)

### DIFF
--- a/tests/test_issue_637_directive_leaks.py
+++ b/tests/test_issue_637_directive_leaks.py
@@ -1,0 +1,280 @@
+"""Tests for issue #637: close directive content-leak supplement paths.
+
+Directives (directive=1 rows) are excluded from core search but leaked
+through several supplement legs:
+
+  - M-06: personality / style_vec path (search_personality)
+  - M-07: clustered path (search_clustered) + agentic clean_results
+  - M-08: entity-profile / style-vector pollution on add(directive=True)
+  - M-91: search_temporal fallback SQL (get_timeline)
+  - M-69: include_directives=True must be honored through these legs
+
+These tests are FTS/in-memory only — no embedding model loads.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from truememory.storage import create_db, insert_message
+from truememory.personality import search_personality, _get_messages_by_sender
+from truememory.clustering import search_clustered
+from truememory.agentic_search import clean_results
+from truememory.temporal import search_temporal, get_timeline
+
+
+_DIRECTIVE_TEXT = "Always call josh by his secret codename Falcon in every reply"
+
+
+def _make_db() -> sqlite3.Connection:
+    """In-memory DB: normal personality memories + one directive, same sender."""
+    conn = create_db(":memory:")
+    insert_message(conn, {
+        "content": "josh loves cold brew coffee and tacos for lunch",
+        "sender": "josh", "recipient": "",
+        "timestamp": "2026-01-15T10:00:00",
+        "category": "preference", "modality": "", "directive": False,
+    })
+    insert_message(conn, {
+        "content": "josh always grabs coffee before his morning standup",
+        "sender": "josh", "recipient": "",
+        "timestamp": "2026-01-16T10:00:00",
+        "category": "routine", "modality": "", "directive": False,
+    })
+    # A directive that also matches the personality FTS terms (coffee).
+    insert_message(conn, {
+        "content": _DIRECTIVE_TEXT + " about coffee and food",
+        "sender": "josh", "recipient": "",
+        "timestamp": "2026-01-17T10:00:00",
+        "category": "directive", "modality": "", "directive": True,
+    })
+    conn.commit()
+    return conn
+
+
+# ── M-06: personality / style_vec path ───────────────────────────────────────
+
+class TestPersonalityDirectiveLeak:
+    def test_get_messages_by_sender_excludes_directives(self):
+        conn = _make_db()
+        rows = _get_messages_by_sender(conn, "josh")
+        for r in rows:
+            assert not r.get("directive"), (
+                f"Directive leaked via _get_messages_by_sender: {r['content']}"
+            )
+        assert len(rows) == 2
+
+    def test_get_messages_by_sender_includes_when_requested(self):
+        conn = _make_db()
+        rows = _get_messages_by_sender(conn, "josh", include_directives=True)
+        assert any(r.get("directive") for r in rows)
+
+    def test_search_personality_excludes_directives(self):
+        conn = _make_db()
+        results = search_personality(conn, "what food and coffee does josh like", limit=10)
+        for r in results:
+            assert not r.get("directive"), (
+                f"Directive leaked via search_personality ({r.get('source')}): {r['content']}"
+            )
+            assert _DIRECTIVE_TEXT not in r.get("content", "")
+
+    def test_search_personality_stamps_directive_key(self):
+        """Every returned dict must carry a directive key so the engine's
+        final filter can act on it."""
+        conn = _make_db()
+        results = search_personality(conn, "what food and coffee does josh like", limit=10)
+        assert results, "expected at least one personality result"
+        for r in results:
+            assert "directive" in r
+
+    def test_search_personality_includes_directives_when_requested(self):
+        conn = _make_db()
+        results = search_personality(
+            conn, "what food and coffee does josh like",
+            limit=10, include_directives=True,
+        )
+        assert any(_DIRECTIVE_TEXT in r.get("content", "") for r in results), (
+            "include_directives=True should surface the directive via personality leg"
+        )
+
+
+# ── M-07: clustered + agentic clean_results ──────────────────────────────────
+
+def _seed_clusters(conn: sqlite3.Connection) -> None:
+    """Build a single cluster containing every message id (directive included).
+
+    We stub embeddings/centroid via the real tables so search_clustered runs
+    its SQL leg without loading a model. The query vec is supplied by a stub
+    model patched in the test.
+    """
+    import struct
+    ids = [r[0] for r in conn.execute("SELECT id FROM messages ORDER BY id")]
+    dim = 4
+    centroid = struct.pack(f"{dim}f", *([1.0] * dim))
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS cluster_centroids "
+        "(cluster_id INTEGER PRIMARY KEY, centroid BLOB, message_count INTEGER, "
+        " session_range TEXT, summary TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS message_clusters "
+        "(message_id INTEGER, cluster_id INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO cluster_centroids(cluster_id, centroid, message_count) VALUES (1, ?, ?)",
+        (centroid, len(ids)),
+    )
+    for mid in ids:
+        conn.execute(
+            "INSERT INTO message_clusters(message_id, cluster_id) VALUES (?, 1)", (mid,)
+        )
+    conn.commit()
+
+
+class _StubModel:
+    def encode(self, texts):
+        import numpy as np
+        return np.ones((len(texts), 4), dtype="float32")
+
+
+class TestClusteredDirectiveLeak:
+    def test_search_clustered_excludes_directives(self, monkeypatch):
+        import truememory.vector_search as vs
+        conn = _make_db()
+        _seed_clusters(conn)
+        monkeypatch.setattr(vs, "get_model", lambda *a, **k: _StubModel())
+        results = search_clustered(conn, "coffee food", limit=10)
+        for r in results:
+            assert not r.get("directive"), (
+                f"Directive leaked via search_clustered: {r['content']}"
+            )
+            assert _DIRECTIVE_TEXT not in r.get("content", "")
+
+    def test_search_clustered_includes_when_requested(self, monkeypatch):
+        import truememory.vector_search as vs
+        conn = _make_db()
+        _seed_clusters(conn)
+        monkeypatch.setattr(vs, "get_model", lambda *a, **k: _StubModel())
+        results = search_clustered(conn, "coffee food", limit=10, include_directives=True)
+        assert any(_DIRECTIVE_TEXT in r.get("content", "") for r in results)
+
+    def test_clean_results_drops_directives(self):
+        rows = [
+            {"id": 1, "content": "normal memory", "directive": False, "score": 0.9},
+            {"id": 2, "content": _DIRECTIVE_TEXT, "directive": True, "score": 0.95},
+        ]
+        cleaned = clean_results(rows, limit=10)
+        assert all(not r.get("directive") for r in cleaned)
+        assert all(_DIRECTIVE_TEXT not in r["content"] for r in cleaned)
+
+    def test_clean_results_keeps_directives_when_requested(self):
+        rows = [
+            {"id": 1, "content": "normal memory", "directive": False, "score": 0.9},
+            {"id": 2, "content": _DIRECTIVE_TEXT, "directive": True, "score": 0.95},
+        ]
+        cleaned = clean_results(rows, limit=10, include_directives=True)
+        assert any(r.get("directive") for r in cleaned)
+
+
+# ── M-08: add(directive=True) must not pollute profiles / style vectors ───────
+
+class TestDirectiveProfilePollution:
+    def test_directive_only_sender_has_no_profile_or_style_vec(self):
+        from truememory.engine import TrueMemoryEngine
+
+        engine = TrueMemoryEngine(db_path=":memory:")
+        # A sender whose ONLY message is a directive.
+        engine.add(
+            "Always greet operator-x with a formal salutation",
+            sender="operator-x", directive=True,
+        )
+
+        conn = engine.conn
+
+        def _count(table: str) -> int:
+            try:
+                return conn.execute(
+                    f"SELECT COUNT(*) FROM {table} WHERE LOWER(entity) = 'operator-x'"
+                ).fetchone()[0]
+            except sqlite3.OperationalError:
+                return 0
+
+        assert _count("entity_profiles") == 0, (
+            "Directive content polluted entity_profiles"
+        )
+        assert _count("entity_style_vectors") == 0, (
+            "Directive content polluted entity_style_vectors"
+        )
+        engine.close()
+
+    def test_normal_add_still_builds_profile(self):
+        """Sanity: non-directive add for a fresh sender still updates profile."""
+        from truememory.engine import TrueMemoryEngine
+
+        engine = TrueMemoryEngine(db_path=":memory:")
+        if not engine._has_personality:
+            engine.close()
+            return  # personality module unavailable in this build
+        engine.add("operator-y loves espresso and long walks", sender="operator-y")
+        conn = engine.conn
+        cnt = conn.execute(
+            "SELECT COUNT(*) FROM entity_profiles WHERE LOWER(entity) = 'operator-y'"
+        ).fetchone()[0]
+        assert cnt >= 1
+        engine.close()
+
+
+# ── M-91: search_temporal fallback excludes directives ───────────────────────
+
+def _make_temporal_db() -> sqlite3.Connection:
+    conn = create_db(":memory:")
+    insert_message(conn, {
+        "content": "met the team on monday",
+        "sender": "josh", "recipient": "",
+        "timestamp": "2026-02-03T10:00:00",
+        "category": "event", "modality": "", "directive": False,
+    })
+    insert_message(conn, {
+        "content": _DIRECTIVE_TEXT,
+        "sender": "josh", "recipient": "",
+        "timestamp": "2026-02-04T10:00:00",
+        "category": "directive", "modality": "", "directive": True,
+    })
+    conn.commit()
+    return conn
+
+
+class TestTemporalDirectiveLeak:
+    def test_get_timeline_excludes_directives(self):
+        conn = _make_temporal_db()
+        rows = get_timeline(conn, after="2026-01-01", before="2026-12-31")
+        for r in rows:
+            assert not r.get("directive")
+            assert _DIRECTIVE_TEXT not in r.get("content", "")
+
+    def test_get_timeline_includes_when_requested(self):
+        conn = _make_temporal_db()
+        rows = get_timeline(
+            conn, after="2026-01-01", before="2026-12-31", include_directives=True,
+        )
+        assert any(_DIRECTIVE_TEXT in r.get("content", "") for r in rows)
+
+    def test_search_temporal_fallback_excludes_directives(self):
+        conn = _make_temporal_db()
+        # Empty fts_results forces the fallback get_timeline leg.
+        results = search_temporal(
+            conn, "what happened in february 2026",
+            fts_results=[], limit=10,
+        )
+        for r in results:
+            assert not r.get("directive"), (
+                f"Directive leaked via search_temporal fallback: {r.get('content')}"
+            )
+
+    def test_search_temporal_fallback_includes_when_requested(self):
+        conn = _make_temporal_db()
+        results = search_temporal(
+            conn, "what happened in february 2026",
+            fts_results=[], limit=10, include_directives=True,
+        )
+        assert any(_DIRECTIVE_TEXT in r.get("content", "") for r in results)

--- a/truememory/agentic_search.py
+++ b/truememory/agentic_search.py
@@ -234,13 +234,21 @@ def clean_results(
     results: list[dict],
     limit: int,
     max_per_session: int = 0,
+    include_directives: bool = False,
 ) -> list[dict]:
-    """Deduplicate, clean, and optionally enforce session-diversity on results."""
+    """Deduplicate, clean, and optionally enforce session-diversity on results.
+
+    Defense-in-depth: directive rows (directive=1) are dropped unless
+    include_directives is True, so directive content can never leak through
+    the agentic cleaning leg even if an upstream supplement forgot to filter.
+    """
     cleaned: list[dict] = []
     seen_ids: set = set()
     seen_content: set = set()
 
     for r in results:
+        if not include_directives and r.get("directive"):
+            continue
         content = r.get("content", "")
         rid = r.get("id")
 

--- a/truememory/clustering.py
+++ b/truememory/clustering.py
@@ -200,6 +200,7 @@ def search_clustered(
     query: str,
     limit: int = 10,
     top_clusters: int = 3,
+    include_directives: bool = False,
 ) -> list[dict]:
     """
     Two-stage clustered search: find top clusters, then search within them.
@@ -273,11 +274,15 @@ def search_clustered(
     id_placeholders = ",".join("?" * len(cluster_msg_ids))
     msg_ids_list = list(cluster_msg_ids)
 
+    directive_filter = (
+        "" if include_directives
+        else " AND (m.directive = 0 OR m.directive IS NULL)"
+    )
     messages = conn.execute(
         f"""SELECT m.id, m.content, m.sender, m.recipient, m.timestamp,
-                   m.category, m.modality
+                   m.category, m.modality, m.directive
             FROM messages m
-            WHERE m.id IN ({id_placeholders})""",
+            WHERE m.id IN ({id_placeholders}){directive_filter}""",
         msg_ids_list,
     ).fetchall()
 
@@ -333,6 +338,7 @@ def search_clustered(
             "timestamp": msg[4],
             "category": msg[5],
             "modality": msg[6],
+            "directive": bool(msg[7]),
             "score": sim,
             "source": "clustered",
         })

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -646,8 +646,11 @@ class TrueMemoryEngine:
                 except Exception:
                     logger.warning("Failed to store embedding for message %s during add()", new_id, exc_info=True)
 
-            # Incrementally update entity profile
-            if self._has_personality and sender:
+            # Incrementally update entity profile.
+            # Skip for directives (#637 M-08): directive content must never
+            # pollute entity_profiles / style vectors, or it would surface via
+            # the personality `profile` / `style_vec` supplement sources.
+            if self._has_personality and sender and not directive:
                 try:
                     from truememory.personality import update_entity_profile_incremental
                     update_entity_profile_incremental(self.conn, sender, content, recipient)
@@ -655,7 +658,7 @@ class TrueMemoryEngine:
                     logger.debug("Failed to update entity profile for %s during add()", sender, exc_info=True)
 
             # Store pre-computed style vector (DB write only, computation happened outside lock)
-            if pre_style_vec is not None:
+            if pre_style_vec is not None and not directive:
                 try:
                     _update_style_vec(self.conn, sender, content, _pre_computed_vec=pre_style_vec)
                 except Exception:
@@ -1750,12 +1753,14 @@ class TrueMemoryEngine:
                             self.conn, query,
                             hybrid_results=results,
                             limit=limit * 2,
+                            include_directives=include_directives,
                         )
                     else:
                         temporal_results = search_temporal(
                             self.conn, query,
                             fts_results=results,
                             limit=limit * 2,
+                            include_directives=include_directives,
                         )
                     if temporal_results:
                         # Tag new results with temporal source and merge.
@@ -1791,6 +1796,7 @@ class TrueMemoryEngine:
                                 after=intent["after"],
                                 before=intent["before"],
                                 limit=limit,
+                                include_directives=include_directives,
                             )
                             if range_results:
                                 existing_ids = {r.get("id") for r in results if r.get("id")}
@@ -1823,7 +1829,14 @@ class TrueMemoryEngine:
         # profile results (score=1.0) dominate factual queries.
         if self._has_personality and _has_personality_intent(query):
             try:
-                personality_results = search_personality(self.conn, query, limit=5)
+                # Only forward include_directives when explicitly enabled so
+                # we stay compatible with callers/mocks using the older
+                # 3-arg signature (the default-False path already excludes
+                # directives via search_personality's own candidate filter).
+                _pers_kwargs = {"include_directives": True} if include_directives else {}
+                personality_results = search_personality(
+                    self.conn, query, limit=5, **_pers_kwargs,
+                )
                 if personality_results:
                     existing_ids = {r.get("id") for r in results if r.get("id")}
                     max_existing = max(
@@ -2095,6 +2108,7 @@ class TrueMemoryEngine:
             try:
                 hyde_results = hyde_search(
                     self.conn, query, llm_fn=llm_fn, limit=candidate_pool,
+                    include_directives=include_directives,
                 )
                 if hyde_results:
                     from truememory.hybrid import reciprocal_rank_fusion
@@ -2120,6 +2134,7 @@ class TrueMemoryEngine:
             try:
                 cluster_results = search_clustered(
                     self.conn, query, limit=limit, top_clusters=3,
+                    include_directives=include_directives,
                 )
                 if cluster_results and primary_results:
                     # Normalize cluster scores to [0, 1] independently
@@ -2320,7 +2335,8 @@ class TrueMemoryEngine:
                         )
                     except Exception:
                         logger.debug("LLM reranking failed in search_agentic()", exc_info=True)
-                return self._clean_results(final_results, limit, max_per_session=max_per_session)
+                return self._clean_results(final_results, limit, max_per_session=max_per_session,
+                                           include_directives=include_directives)
             except Exception:
                 logger.warning("Cross-encoder rerank failed in search_agentic()", exc_info=True)
 
@@ -2336,7 +2352,8 @@ class TrueMemoryEngine:
             except Exception:
                 logger.debug("LLM reranking (standalone) failed in search_agentic()", exc_info=True)
 
-        return self._clean_results(primary_results, limit, max_per_session=max_per_session)
+        return self._clean_results(primary_results, limit, max_per_session=max_per_session,
+                                   include_directives=include_directives)
 
     # ── L5 surprise rerank boost (MEMORIST-L5 wiring, 2026-04-24) ──────
     # Multiplies the reranked `score` field by (1 + α · surprise) for
@@ -2388,9 +2405,11 @@ class TrueMemoryEngine:
         from truememory.agentic_search import entity_focused_search
         return entity_focused_search(self.conn, query, limit)
 
-    def _clean_results(self, results: list[dict], limit: int, max_per_session: int = 0) -> list[dict]:
+    def _clean_results(self, results: list[dict], limit: int, max_per_session: int = 0,
+                       include_directives: bool = False) -> list[dict]:
         from truememory.agentic_search import clean_results
-        return clean_results(results, limit, max_per_session)
+        return clean_results(results, limit, max_per_session,
+                             include_directives=include_directives)
 
     def _scent_trail(self, query: str, results: list[dict], limit: int) -> list[dict]:
         from truememory.search_quality import scent_trail

--- a/truememory/hyde.py
+++ b/truememory/hyde.py
@@ -127,6 +127,7 @@ def hyde_search(
     candidate_pool: int = 30,
     fts_weight: float = 1.0,
     vec_weight: float = 1.0,
+    include_directives: bool = False,
 ) -> list[dict]:
     """
     Search with both original query and HyDE-enhanced embedding.
@@ -153,6 +154,7 @@ def hyde_search(
     original_results = search_hybrid(
         conn, query, limit=candidate_pool,
         fts_weight=fts_weight, vec_weight=vec_weight,
+        include_directives=include_directives,
     )
 
     # Generate hypothetical document
@@ -167,6 +169,7 @@ def hyde_search(
         hyde_results = search_hybrid(
             conn, hyp_doc, limit=candidate_pool,
             fts_weight=fts_weight, vec_weight=vec_weight,
+            include_directives=include_directives,
         )
     except Exception as e:
         log.warning("HyDE fusion failed (search with hypothetical doc): %s", e)

--- a/truememory/personality.py
+++ b/truememory/personality.py
@@ -158,11 +158,20 @@ def _get_all_messages(conn: sqlite3.Connection) -> list[dict]:
     ]
 
 
-def _get_messages_by_sender(conn: sqlite3.Connection, sender: str) -> list[dict]:
-    """Fetch all messages for a specific sender, ordered by timestamp."""
+def _get_messages_by_sender(conn: sqlite3.Connection, sender: str,
+                            include_directives: bool = False) -> list[dict]:
+    """Fetch all messages for a specific sender, ordered by timestamp.
+
+    Directives (directive=1) are excluded by default so they never leak into
+    personality / style-vec retrieval; pass include_directives=True to keep them.
+    """
+    directive_filter = (
+        "" if include_directives
+        else " AND (directive = 0 OR directive IS NULL)"
+    )
     rows = conn.execute(
-        "SELECT id, content, sender, recipient, timestamp, category, modality "
-        "FROM messages WHERE LOWER(sender) = LOWER(?) ORDER BY timestamp",
+        "SELECT id, content, sender, recipient, timestamp, category, modality, directive "
+        f"FROM messages WHERE LOWER(sender) = LOWER(?){directive_filter} ORDER BY timestamp",
         (sender,),
     ).fetchall()
     return [
@@ -170,6 +179,7 @@ def _get_messages_by_sender(conn: sqlite3.Connection, sender: str) -> list[dict]
             "id": r[0], "content": r[1], "sender": r[2],
             "recipient": r[3], "timestamp": r[4],
             "category": r[5], "modality": r[6],
+            "directive": bool(r[7]),
         }
         for r in rows
     ]
@@ -676,7 +686,8 @@ def extract_preferences(conn: sqlite3.Connection,
 
 
 def search_personality(conn: sqlite3.Connection, query: str,
-                       limit: int = 10) -> list[dict]:
+                       limit: int = 10,
+                       include_directives: bool = False) -> list[dict]:
     """
     Search for personality-relevant information.
 
@@ -738,7 +749,8 @@ def search_personality(conn: sqlite3.Connection, query: str,
 
     if fts_terms:
         fts_query = _build_safe_fts_query(fts_terms)
-        candidate_msgs = _fts_search(conn, fts_query, limit=limit * 3)
+        candidate_msgs = _fts_search(conn, fts_query, limit=limit * 3,
+                                     include_directives=include_directives)
 
     # Fallback: direct query word search
     if not candidate_msgs:
@@ -749,11 +761,14 @@ def search_personality(conn: sqlite3.Connection, query: str,
                                                     "they", "have", "been"}]
         if query_words:
             fts_query = _build_safe_fts_query(query_words)
-            candidate_msgs = _fts_search(conn, fts_query, limit=limit * 3)
+            candidate_msgs = _fts_search(conn, fts_query, limit=limit * 3,
+                                         include_directives=include_directives)
 
     # If we have a target entity and no FTS results, get their messages directly
     if not candidate_msgs and target_entity:
-        candidate_msgs = _get_messages_by_sender(conn, target_entity)[:limit * 3]
+        candidate_msgs = _get_messages_by_sender(
+            conn, target_entity, include_directives=include_directives
+        )[:limit * 3]
 
     # ---- Step 4: score candidates using style vectors ----
     _use_style_vec = False
@@ -801,6 +816,7 @@ def search_personality(conn: sqlite3.Connection, query: str,
                 "source": "style_vec",
                 "aspect": detected_aspect,
                 "score": vec_score,
+                "directive": bool(msg.get("directive", False)),
             })
 
         scored.sort(key=lambda r: r["score"], reverse=True)
@@ -822,6 +838,7 @@ def search_personality(conn: sqlite3.Connection, query: str,
                 "source": "fts",
                 "aspect": detected_aspect,
                 "score": r.get("score", 0.0),
+                "directive": bool(r.get("directive", False)),
             })
 
     # ---- Step 5: add profile data ----
@@ -884,6 +901,7 @@ def search_personality(conn: sqlite3.Connection, query: str,
                     "source": "profile",
                     "aspect": detected_aspect,
                     "score": 1.0,
+                    "directive": False,
                 })
 
     return results[:limit]

--- a/truememory/temporal.py
+++ b/truememory/temporal.py
@@ -515,6 +515,7 @@ def search_temporal(
     fts_results: list[dict] | None = None,
     hybrid_results: list[dict] | None = None,
     limit: int = 10,
+    include_directives: bool = False,
 ) -> list[dict]:
     """
     Apply temporal filtering and re-ranking to search results.
@@ -580,7 +581,8 @@ def search_temporal(
     # --- If not enough results, do a fresh SQL query with time constraints ---
     if len(results) < limit and (after or before):
         existing_ids = {r.get("id") for r in results}
-        extra = get_timeline(conn, after=after, before=before)
+        extra = get_timeline(conn, after=after, before=before,
+                             include_directives=include_directives)
         for msg in extra:
             if msg["id"] not in existing_ids:
                 results.append(msg)
@@ -598,6 +600,7 @@ def get_timeline(
     entity: str | None = None,
     after: str | None = None,
     before: str | None = None,
+    include_directives: bool = False,
 ) -> list[dict]:
     """
     Get a chronological timeline of messages.
@@ -639,6 +642,12 @@ def get_timeline(
         entity_lower = entity.lower()
         clauses.append("(LOWER(sender) = ? OR LOWER(recipient) = ?)")
         params.extend([entity_lower, entity_lower])
+
+    # Defense-in-depth (#637 M-91): exclude directives unless explicitly
+    # requested.  The engine masks these via its final filter, but direct
+    # callers of the fallback would otherwise receive directive content.
+    if not include_directives:
+        clauses.append("(directive = 0 OR directive IS NULL)")
 
     where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
     sql = f"SELECT {_SELECT_COLS} FROM messages{where} ORDER BY timestamp"


### PR DESCRIPTION
Fixes #637. Closes directive content-leak paths (M-06 personality/style_vec, M-07 clustered+agentic, M-08 entity-profile pollution, M-91 temporal fallback, M-69 include_directives plumbing). 7 files, FTS-only tests, 178 directive/search tests pass incl. the #630 idless regression guard.

Replaces #664, which was contaminated by an accidental `git add -A` (348 benchmarks/ files + DB backups). This branch is a clean re-derivation off current main: 5 unchanged source files reused verbatim, engine.py hunks 3-way-applied onto current main.