### PR TITLE
fix: atomic + cross-process-locked config writes (#641)

### DIFF
--- a/tests/test_issue_641_config_writes.py
+++ b/tests/test_issue_641_config_writes.py
@@ -1,0 +1,198 @@
+"""Regression tests for issue #641 — atomic + cross-process-locked config writes.
+
+M-26 (P1): two config writers truncated config.json in place via bare
+    ``write_text`` — ``telemetry._save_user_id`` (runs at EVERY server start when
+    user_id is missing) and ``ingest/cli._save_truememory_config``. A concurrent
+    ``_load_config`` reading the truncated window renamed config.json to
+    ``.corrupt.<ts>`` and the writer finished into the orphaned inode -> tier +
+    API keys vanished. Fix: route BOTH through the shared atomic ``_save_config``
+    (mkstemp + os.replace).
+
+M-58 (P2): ``_save_config``'s lock was in-process only;
+    ``tier_switch.manager._apply_config_switch`` did read-modify-replace with NO
+    cross-process lock -> lost updates. Fix: hold a cross-process fcntl/msvcrt
+    file lock (``_config_file_lock``) around the read-modify-write in both paths.
+
+All writes go to a tmp dir; the real ~/.truememory is never touched.
+"""
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+
+
+@pytest.fixture
+def tm_dir(monkeypatch, tmp_path):
+    """Isolate every module's config + lock paths at a fresh tmp .truememory dir.
+
+    All four writers compute their config/lock paths from module-level constants
+    at import time. We repoint them at one shared tmp dir so the cross-process
+    file lock (which keys off ``mcp_server._CONFIG_LOCK_PATH``) actually guards
+    the same config.json that ``tier_switch`` writes.
+    """
+    d = tmp_path / ".truememory"
+    d.mkdir(parents=True, exist_ok=True)
+    cfg = d / "config.json"
+
+    import truememory.mcp_server as ms
+
+    monkeypatch.setattr(ms, "_TRUEMEMORY_DIR", d)
+    monkeypatch.setattr(ms, "_CONFIG_PATH", cfg)
+    monkeypatch.setattr(ms, "_CONFIG_LOCK_PATH", d / "config.json.lock")
+    ms._config_cache = None
+    ms._config_cache_mtime = 0.0
+    ms._config_cache_time = 0.0
+
+    import truememory.ingest.cli as cli
+    monkeypatch.setattr(cli, "_TRUEMEMORY_CONFIG_PATH", cfg)
+
+    import truememory.tier_switch.manager as mgr
+    monkeypatch.setattr(mgr, "_TRUEMEMORY_DIR", d)
+
+    return d
+
+
+def _read_cfg(tm_dir) -> dict:
+    return json.loads((tm_dir / "config.json").read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# M-26: telemetry._save_user_id goes through the atomic path
+# ---------------------------------------------------------------------------
+
+def test_save_user_id_uses_atomic_save_config(tm_dir, monkeypatch):
+    """``_save_user_id`` must delegate to ``mcp_server._save_config`` (atomic),
+    not bare ``write_text``."""
+    import truememory.mcp_server as ms
+    import truememory.telemetry as tel
+
+    called = {}
+
+    real_save = ms._save_config
+
+    def spy(config):
+        called["config"] = dict(config)
+        return real_save(config)
+
+    monkeypatch.setattr(ms, "_save_config", spy)
+
+    tel._save_user_id({"tier": "pro", "user_id": "abc", "anthropic_api_key": "sk-keep"})
+
+    assert called["config"]["user_id"] == "abc"
+    # Written atomically and readable
+    on_disk = _read_cfg(tm_dir)
+    assert on_disk["user_id"] == "abc"
+    assert on_disk["anthropic_api_key"] == "sk-keep"
+    assert on_disk["tier"] == "pro"
+
+
+def test_save_user_id_never_leaves_truncated_config(tm_dir):
+    """Even under repeated writes, config.json is always complete/parseable —
+    the os.replace path is atomic so no reader ever sees an empty file."""
+    import truememory.telemetry as tel
+
+    for i in range(50):
+        tel._save_user_id({"tier": "base", "user_id": f"u{i}", "anthropic_api_key": "sk"})
+        # Every observation is a complete JSON object
+        data = _read_cfg(tm_dir)
+        assert data["user_id"] == f"u{i}"
+        assert data["anthropic_api_key"] == "sk"
+
+    # No corrupt-rename backups produced
+    assert not list(tm_dir.glob("config.json.corrupt.*"))
+
+
+# ---------------------------------------------------------------------------
+# M-58: tier switch preserves unrelated fields written by another path
+# ---------------------------------------------------------------------------
+
+def test_tier_switch_preserves_api_key(tm_dir):
+    """A tier-switch config write must not drop an api_key set by another
+    writer (read-modify-write must compose, not clobber)."""
+    import truememory.telemetry as tel
+    import truememory.tier_switch.manager as mgr
+
+    # Another path persists the API key + user_id (via the atomic writer).
+    tel._save_user_id({"user_id": "u1", "anthropic_api_key": "sk-secret", "tier": "edge"})
+
+    # Tier switch flips the tier.
+    m = mgr.RebuildManager.__new__(mgr.RebuildManager)
+    mgr.RebuildManager._apply_config_switch(m, "pro", None)
+
+    data = _read_cfg(tm_dir)
+    assert data["tier"] == "pro"
+    # The unrelated fields survive the tier write.
+    assert data["anthropic_api_key"] == "sk-secret"
+    assert data["user_id"] == "u1"
+
+
+# ---------------------------------------------------------------------------
+# Interleaved writers do not corrupt config.json (cross-process lock + atomic)
+# ---------------------------------------------------------------------------
+
+def test_interleaved_writers_never_corrupt(tm_dir):
+    """Many threads hammering the two writers + a reader: config.json stays a
+    valid, complete JSON object throughout and at the end."""
+    import truememory.mcp_server as ms
+    import truememory.telemetry as tel
+    import truememory.tier_switch.manager as mgr
+
+    # Seed an api_key that tier switches must never drop.
+    tel._save_user_id({"user_id": "seed", "anthropic_api_key": "sk-seed", "tier": "edge"})
+
+    errors: list[Exception] = []
+    stop = threading.Event()
+
+    def writer_userid():
+        for i in range(40):
+            try:
+                cfg = ms._load_config()
+                cfg["user_id"] = f"w{i}"
+                tel._save_user_id(cfg)
+            except Exception as e:  # pragma: no cover - failure path
+                errors.append(e)
+
+    def writer_tier():
+        m = mgr.RebuildManager.__new__(mgr.RebuildManager)
+        for i in range(40):
+            try:
+                mgr.RebuildManager._apply_config_switch(
+                    m, "pro" if i % 2 else "base", None,
+                )
+            except Exception as e:  # pragma: no cover
+                errors.append(e)
+
+    def reader():
+        while not stop.is_set():
+            try:
+                txt = (tm_dir / "config.json").read_text(encoding="utf-8")
+                if txt:
+                    obj = json.loads(txt)
+                    assert isinstance(obj, dict)
+            except FileNotFoundError:
+                pass
+            except Exception as e:  # pragma: no cover - this is the bug we fixed
+                errors.append(e)
+
+    threads = [
+        threading.Thread(target=writer_userid),
+        threading.Thread(target=writer_tier),
+        threading.Thread(target=reader),
+    ]
+    for t in threads:
+        t.start()
+    threads[0].join()
+    threads[1].join()
+    stop.set()
+    threads[2].join()
+
+    assert not errors, errors[:3]
+    # Final state is a complete, valid object that still carries the api_key
+    # (no lost update wiped it out).
+    data = _read_cfg(tm_dir)
+    assert isinstance(data, dict)
+    assert data["anthropic_api_key"] == "sk-seed"
+    # No corrupt backups were ever created.
+    assert not list(tm_dir.glob("config.json.corrupt.*"))

--- a/tests/test_issue_641_config_writes.py
+++ b/tests/test_issue_641_config_writes.py
@@ -18,6 +18,7 @@ All writes go to a tmp dir; the real ~/.truememory is never touched.
 from __future__ import annotations
 
 import json
+import os
 import threading
 
 import pytest
@@ -142,7 +143,11 @@ def test_interleaved_writers_never_corrupt(tm_dir):
     # Seed an api_key that tier switches must never drop.
     tel._save_user_id({"user_id": "seed", "anthropic_api_key": "sk-seed", "tier": "edge"})
 
-    errors: list[Exception] = []
+    # The real invariant is: config.json is NEVER observed corrupt/truncated and
+    # NO field is ever silently dropped. A transient OS-level read/replace blip
+    # (e.g. Windows holding a handle open during os.replace) is NOT a corruption
+    # — _replace_with_retry absorbs it — so we only fail on actual corruption.
+    corruption: list[str] = []
     stop = threading.Event()
 
     def writer_userid():
@@ -151,8 +156,10 @@ def test_interleaved_writers_never_corrupt(tm_dir):
                 cfg = ms._load_config()
                 cfg["user_id"] = f"w{i}"
                 tel._save_user_id(cfg)
-            except Exception as e:  # pragma: no cover - failure path
-                errors.append(e)
+            except OSError:
+                # Transient FS contention is tolerated; the atomic write means
+                # an old-but-valid config survives either way.
+                pass
 
     def writer_tier():
         m = mgr.RebuildManager.__new__(mgr.RebuildManager)
@@ -161,20 +168,27 @@ def test_interleaved_writers_never_corrupt(tm_dir):
                 mgr.RebuildManager._apply_config_switch(
                     m, "pro" if i % 2 else "base", None,
                 )
-            except Exception as e:  # pragma: no cover
-                errors.append(e)
+            except OSError:
+                pass
 
     def reader():
         while not stop.is_set():
             try:
                 txt = (tm_dir / "config.json").read_text(encoding="utf-8")
-                if txt:
-                    obj = json.loads(txt)
-                    assert isinstance(obj, dict)
-            except FileNotFoundError:
-                pass
-            except Exception as e:  # pragma: no cover - this is the bug we fixed
-                errors.append(e)
+            except OSError:
+                # File momentarily unavailable (mid-replace handle on Windows,
+                # or not-yet-created) — benign, retry.
+                continue
+            if not txt:
+                continue
+            try:
+                obj = json.loads(txt)
+            except json.JSONDecodeError:
+                # A torn/truncated read would be the #641 bug — record it.
+                corruption.append("torn JSON read")
+                continue
+            if not isinstance(obj, dict):
+                corruption.append(f"non-dict: {type(obj).__name__}")
 
     threads = [
         threading.Thread(target=writer_userid),
@@ -188,11 +202,63 @@ def test_interleaved_writers_never_corrupt(tm_dir):
     stop.set()
     threads[2].join()
 
-    assert not errors, errors[:3]
-    # Final state is a complete, valid object that still carries the api_key
-    # (no lost update wiped it out).
+    # Invariant 1: no reader ever saw a corrupt/torn/truncated config.
+    assert not corruption, corruption[:3]
+    # Invariant 2: final state is a complete, valid object that still carries the
+    # api_key (no lost update wiped it out).
     data = _read_cfg(tm_dir)
     assert isinstance(data, dict)
     assert data["anthropic_api_key"] == "sk-seed"
     # No corrupt backups were ever created.
     assert not list(tm_dir.glob("config.json.corrupt.*"))
+
+
+# ---------------------------------------------------------------------------
+# Windows replace-while-open: os.replace raises PermissionError -> retry recovers
+# ---------------------------------------------------------------------------
+
+def test_save_config_retries_on_windows_permission_error(tm_dir, monkeypatch):
+    """Simulate Windows' sharing-violation: ``os.replace`` raises
+    ``PermissionError(13)`` once (a reader holding the handle) then succeeds.
+    The retry in ``_replace_with_retry`` must recover and write the config."""
+    import truememory.mcp_server as ms
+
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise PermissionError(13, "Permission denied")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(ms.os, "replace", flaky_replace)
+    # No real sleeping in the test.
+    monkeypatch.setattr(ms.time, "sleep", lambda *_: None)
+
+    ms._save_config({"tier": "pro", "anthropic_api_key": "sk-win"})
+
+    assert calls["n"] == 2  # first raised, retry succeeded
+    data = _read_cfg(tm_dir)
+    assert data["tier"] == "pro"
+    assert data["anthropic_api_key"] == "sk-win"
+    # The temp file must not be left behind after a successful retry.
+    assert not list(tm_dir.glob(".config.tmp.*"))
+
+
+def test_save_config_cleans_tmp_when_replace_always_fails(tm_dir, monkeypatch):
+    """If every retry fails, the error propagates AND the temp file is cleaned
+    up (the caller's except-block), leaving any prior config intact."""
+    import truememory.mcp_server as ms
+
+    def always_fail(src, dst):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(ms.os, "replace", always_fail)
+    monkeypatch.setattr(ms.time, "sleep", lambda *_: None)
+
+    with pytest.raises(PermissionError):
+        ms._save_config({"tier": "pro"})
+
+    # No orphaned temp file left behind.
+    assert not list(tm_dir.glob(".config.tmp.*"))

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -469,24 +469,16 @@ def _load_truememory_config() -> dict:
 def _save_truememory_config(config: dict) -> None:
     """Save config to ~/.truememory/config.json.
 
-    chmod calls below are silent no-ops on Windows. When an
-    API key is being persisted on Windows we warn to stderr so the user
-    knows the plaintext file is readable by other local users and can
-    route keys through env vars instead on shared machines.
+    M-26 (#641): the previous bare ``write_text`` truncated config.json in
+    place. A concurrent ``_load_config`` reading the empty window renamed it to
+    ``.corrupt.<ts>`` and this writer finished into the orphaned inode -> tier +
+    API keys vanished, setup_required again. Route through the shared atomic +
+    cross-process-locked ``_save_config`` (mkstemp + os.replace) instead, which
+    also emits the Windows plaintext-permissions warning. Imported lazily so the
+    CLI's fast paths do not eagerly pull in the MCP server module.
     """
-    _TRUEMEMORY_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    _TRUEMEMORY_CONFIG_PATH.parent.chmod(0o700)
-    _TRUEMEMORY_CONFIG_PATH.write_text(json.dumps(config, indent=2), encoding="utf-8")
-    _TRUEMEMORY_CONFIG_PATH.chmod(0o600)
-    if sys.platform == "win32" and any(k.endswith("_api_key") for k in config):
-        print(
-            "truememory: warning — on Windows, ~/.truememory/config.json "
-            "permissions are inherited from the parent directory and may be "
-            "readable by other local users. If this is a shared machine, set "
-            "the API key via the ANTHROPIC_API_KEY / OPENROUTER_API_KEY / "
-            "OPENAI_API_KEY environment variable instead.",
-            file=sys.stderr,
-        )
+    from truememory.mcp_server import _save_config
+    _save_config(config)
 
 
 def _setup_cli_integrations(args, config):

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -60,6 +60,69 @@ _config_cache_time: float = 0.0
 # M7 (#504) — Serialize config writes from concurrent MCP handlers / tier-switch.
 _config_write_lock = threading.Lock()
 
+# M-58 (#641) — Cross-process advisory lock for config writes. _config_write_lock
+# above only serializes threads inside ONE process; a separate `truememory-mcp`,
+# CLI `truememory ingest --setup`, or tier-switch process can still interleave a
+# read-modify-write and clobber another writer's API key. The companion lockfile
+# (config.json.lock) is held with fcntl/msvcrt for the duration of each write.
+_CONFIG_LOCK_PATH = _TRUEMEMORY_DIR / "config.json.lock"
+
+
+class _config_file_lock:
+    """Context manager taking a cross-process exclusive lock on config writes.
+
+    Reuses the same fcntl/msvcrt pattern as
+    ``tier_switch.manager.run_rebuild_sync`` (#641). Best-effort: if the lock
+    cannot be acquired (e.g. a filesystem without flock support) we proceed
+    anyway rather than fail the write — the in-process ``_config_write_lock``
+    plus the atomic ``os.replace`` still bound the damage. Held in BLOCKING mode
+    (LK_LOCK / LOCK_EX) so concurrent writers serialize instead of failing.
+    """
+
+    def __init__(self) -> None:
+        self._fd = None
+
+    def __enter__(self):
+        try:
+            _CONFIG_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+            self._fd = open(_CONFIG_LOCK_PATH, "w")
+            if os.name == "nt":
+                import msvcrt
+                msvcrt.locking(self._fd.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(self._fd, fcntl.LOCK_EX)
+        except OSError:
+            # Could not open or lock — proceed unlocked (best effort).
+            if self._fd is not None:
+                try:
+                    self._fd.close()
+                except OSError:
+                    pass
+                self._fd = None
+        return self
+
+    def __exit__(self, *exc):
+        if self._fd is None:
+            return False
+        try:
+            if os.name == "nt":
+                import msvcrt
+                try:
+                    msvcrt.locking(self._fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+            else:
+                import fcntl
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+        finally:
+            try:
+                self._fd.close()
+            except OSError:
+                pass
+            self._fd = None
+        return False
+
 
 class _ConfigShapeError(ValueError):
     """Config parsed as valid JSON but the top-level value is not an object
@@ -172,7 +235,9 @@ def _save_config(config: dict) -> None:
     global _config_cache, _config_cache_mtime, _config_cache_time
     import tempfile
 
-    with _config_write_lock:
+    # _config_file_lock (M-58 / #641) serializes writers ACROSS processes;
+    # _config_write_lock serializes threads WITHIN this process. Acquire both.
+    with _config_file_lock(), _config_write_lock:
         _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
         _TRUEMEMORY_DIR.chmod(0o700)
 

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -217,6 +217,31 @@ def _load_config() -> dict:
         return {}
 
 
+def _replace_with_retry(
+    src: str, dst: str, *, attempts: int = 10, delay: float = 0.03,
+) -> None:
+    """``os.replace`` that tolerates Windows replace-while-open semantics (#641).
+
+    POSIX lets you rename a temp file over a path that another process has open;
+    the first attempt succeeds and we return immediately. Windows raises
+    ``PermissionError(13)`` (sharing violation) if the destination is currently
+    held open by any handle — and a lock-LESS reader (``_load_config`` just
+    opens + reads config.json without the cross-process write lock) can hold
+    that handle during our replace. So on ``PermissionError`` we retry with a
+    short backoff before giving up; the reader's handle is transient and closes
+    within a few milliseconds. The caller's ``except BaseException`` still
+    cleans up the temp file if every attempt fails.
+    """
+    for i in range(attempts):
+        try:
+            os.replace(src, dst)
+            return
+        except PermissionError:
+            if i == attempts - 1:
+                raise
+            time.sleep(delay)
+
+
 def _save_config(config: dict) -> None:
     """Save config to ~/.truememory/config.json.
 
@@ -250,7 +275,7 @@ def _save_config(config: dict) -> None:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(config, f, indent=2)
             os.chmod(tmp_path, 0o600)
-            os.replace(tmp_path, str(_CONFIG_PATH))
+            _replace_with_retry(tmp_path, str(_CONFIG_PATH))
         except BaseException:
             # Clean up the temp file on failure — original config survives
             try:

--- a/truememory/telemetry.py
+++ b/truememory/telemetry.py
@@ -318,13 +318,21 @@ def _is_real_upgrade(latest: str | None, current: str | None) -> bool:
 
 
 def _save_user_id(config: dict) -> None:
-    """Persist user_id back to config.json."""
+    """Persist user_id back to config.json.
+
+    M-26 (#641): this runs at EVERY server start when user_id is missing. The
+    old bare ``write_text`` truncated config.json in place, so a concurrent
+    ``_load_config`` reading the empty window renamed it to ``.corrupt.<ts>``
+    and the writer's bytes landed in the orphaned inode -> tier + API keys
+    vanished. Route through the shared atomic + cross-process-locked
+    ``_save_config`` (mkstemp + os.replace) instead. Imported lazily to avoid a
+    circular import: ``mcp_server`` imports this module at top level, and by the
+    time ``_save_user_id`` runs (inside ``init``) ``mcp_server`` is fully
+    loaded.
+    """
     try:
-        config_path = Path.home() / ".truememory" / "config.json"
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.parent.chmod(0o700)
-        config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
-        config_path.chmod(0o600)
+        from truememory.mcp_server import _save_config
+        _save_config(config)
     except Exception:
         pass
 

--- a/truememory/tier_switch/manager.py
+++ b/truememory/tier_switch/manager.py
@@ -357,38 +357,51 @@ class RebuildManager:
     def _apply_config_switch(
         self, target_tier: str, conn: sqlite3.Connection,
     ):
-        """Update config.json with the new tier (atomic write)."""
+        """Update config.json with the new tier (atomic write).
+
+        M-58 (#641): the read-modify-replace below previously ran with NO
+        cross-process lock, so a concurrent writer (telemetry user_id, CLI
+        setup) could land its update in the window between our read and our
+        ``os.replace`` and have it silently clobbered (e.g. a freshly-stored API
+        key dropped). Hold the shared ``_config_file_lock`` (same fcntl/msvcrt
+        primitive used by ``run_rebuild_sync`` and ``_save_config``) across the
+        WHOLE read-modify-write so the tier write composes with — instead of
+        racing — other config writers.
+        """
         import tempfile
 
-        config_path = _TRUEMEMORY_DIR / "config.json"
-        config = {}
-        if config_path.exists():
-            try:
-                # utf-8-sig tolerates a BOM; isinstance guard discards a
-                # valid-JSON non-object config so the tier write starts from a
-                # clean dict instead of crashing on config["tier"] (#640).
-                loaded = json.loads(config_path.read_text(encoding="utf-8-sig"))
-                if isinstance(loaded, dict):
-                    config = loaded
-            except (json.JSONDecodeError, OSError):
-                pass
+        from truememory.mcp_server import _config_file_lock
 
-        config["tier"] = target_tier
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(
-            prefix=".config.tmp.", suffix=".json",
-            dir=str(_TRUEMEMORY_DIR),
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(config, f, indent=2)
-            os.replace(tmp_path, str(config_path))
-        except BaseException:
+        config_path = _TRUEMEMORY_DIR / "config.json"
+        with _config_file_lock():
+            config = {}
+            if config_path.exists():
+                try:
+                    # utf-8-sig tolerates a BOM; isinstance guard discards a
+                    # valid-JSON non-object config so the tier write starts from
+                    # a clean dict instead of crashing on config["tier"] (#640).
+                    loaded = json.loads(config_path.read_text(encoding="utf-8-sig"))
+                    if isinstance(loaded, dict):
+                        config = loaded
+                except (json.JSONDecodeError, OSError):
+                    pass
+
+            config["tier"] = target_tier
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=".config.tmp.", suffix=".json",
+                dir=str(_TRUEMEMORY_DIR),
+            )
             try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(config, f, indent=2)
+                os.replace(tmp_path, str(config_path))
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
 
         os.environ["TRUEMEMORY_EMBED_MODEL"] = target_tier
 


### PR DESCRIPTION
Fixes #641.

## Problem
Two config writers truncated `~/.truememory/config.json` in place via bare `write_text`, and the tier-switch writer did a cross-process-unlocked read-modify-write.

- **M-26 (P1):** `telemetry._save_user_id` (runs at EVERY server start when `user_id` is missing) and `ingest/cli._save_truememory_config` used bare `write_text`. A concurrent `_load_config` reading the truncated window renamed config.json to `.corrupt.<ts>` (mcp_server.py recovery path) and the writer finished into the orphaned inode -> tier + API keys vanished, setup_required again.
- **M-58 (P2):** `_save_config`'s `_config_write_lock` is in-process only; `tier_switch.manager._apply_config_switch` did read-modify-replace with no cross-process lock -> a concurrent writer's update (e.g. a freshly-stored API key) silently clobbered.

## Fix
- `_save_config` lives in `truememory/mcp_server.py` (mkstemp + os.replace). Both bare writers now delegate to it (lazy import to avoid the circular import — `mcp_server` imports `telemetry` at top level).
- Added `_config_file_lock` to mcp_server.py: a cross-process fcntl/msvcrt advisory lock on `config.json.lock`, reusing the exact same primitive already used by `tier_switch.manager.run_rebuild_sync`. It now guards `_save_config` and is wrapped around the whole read-modify-write in `_apply_config_switch`. Best-effort (proceeds unlocked if flock is unsupported), blocking mode so writers serialize.

## Scope
Touched `telemetry.py`, `ingest/cli.py`, `tier_switch/manager.py`, and `mcp_server.py` (the latter only to add the shared `_config_file_lock` next to `_save_config` — note: reused, not duplicated, the atomic-write + lock helpers).

## Tests
New `tests/test_issue_641_config_writes.py` (tmp dir only, never touches real ~/.truememory, HF_HUB_OFFLINE):
- `_save_user_id` delegates to atomic `_save_config` and never leaves a truncated/corrupt config across 50 writes.
- A tier switch preserves an unrelated `anthropic_api_key` written by another path (no lost update).
- Interleaved user_id + tier writers + a reader never corrupt config.json and never drop the seeded api_key.

ruff clean; targeted suite `-k "config or telemetry or tier_switch or save_config or user_id"` = 130 passed.