### PR TITLE
fix: ingest/hooks adopt _platform primitives on Windows (pid_is_alive, spawn_kwargs, msvcrt locks) (#642)

### DIFF
--- a/tests/ingest/test_backlog_drain_no_unlink_422.py
+++ b/tests/ingest/test_backlog_drain_no_unlink_422.py
@@ -164,6 +164,10 @@ def _find_dead_pid() -> int:
     return 999999
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX os.kill EPERM/ESRCH semantics; win32 uses psutil via _platform.pid_is_alive",
+)
 def test_pid_alive_treats_eperm_as_alive_esrch_as_dead(monkeypatch):
     """The liveness check must not treat a live-but-EPERM process as dead.
 

--- a/tests/ingest/test_issue_558_async_stale_scan.py
+++ b/tests/ingest/test_issue_558_async_stale_scan.py
@@ -43,7 +43,12 @@ class TestSpawnStaleScan:
         assert captured["cmd"] == [
             sys.executable, "-m", "truememory.ingest.hooks.session_start", "--scan-stale",
         ]
-        assert captured["kwargs"]["start_new_session"] is hasattr(os, "setsid")
+        # Detach mechanism is platform-specific (_platform.spawn_kwargs):
+        # creationflags on Windows, start_new_session on POSIX.
+        if sys.platform == "win32":
+            assert captured["kwargs"].get("creationflags", 0) != 0
+        else:
+            assert captured["kwargs"]["start_new_session"] is hasattr(os, "setsid")
         assert captured["kwargs"]["stdin"] == subprocess.DEVNULL
 
     def test_spawn_failure_does_not_raise(self, monkeypatch):

--- a/tests/test_issue_461_stale_lock.py
+++ b/tests/test_issue_461_stale_lock.py
@@ -8,6 +8,7 @@ cleaned up.
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -22,6 +23,11 @@ _SKIP_NO_FCNTL = pytest.mark.skipif(
 )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX flock PID/mtime bookkeeping; Windows uses msvcrt byte-lock "
+    "(no PID/TTL stealing) — covered by test_issue_642_windows_platform.py",
+)
 class TestIssue461StaleLock:
     """Verify PID-based lock validation and TTL."""
 

--- a/tests/test_issue_557_async_drain.py
+++ b/tests/test_issue_557_async_drain.py
@@ -35,7 +35,12 @@ def test_maintenance_spawns_background_subprocess(tmp_path, monkeypatch):
     assert "_drain_backlog" in script
     assert "_scan_stale_sessions" in script
     # Must detach from parent session group so it survives hook exit.
-    assert spawned["kwargs"].get("start_new_session") is hasattr(os, "setsid")
+    # Detach mechanism is platform-specific (_platform.spawn_kwargs):
+    # creationflags on Windows, start_new_session on POSIX.
+    if sys.platform == "win32":
+        assert spawned["kwargs"].get("creationflags", 0) != 0
+    else:
+        assert spawned["kwargs"].get("start_new_session") is hasattr(os, "setsid")
     # stdout/stderr must be redirected (not inherited) to avoid blocking.
     assert spawned["kwargs"].get("stdin") == subprocess.DEVNULL
     assert spawned["kwargs"]["stdout"] is not None

--- a/tests/test_issue_642_windows_platform.py
+++ b/tests/test_issue_642_windows_platform.py
@@ -1,0 +1,228 @@
+"""Issue #642 — ingest/hooks adopt _platform primitives on Windows.
+
+The ingest/hooks layer historically used bare ``os.kill(pid, 0)`` liveness
+checks and ``start_new_session``-only spawns, both of which are wrong on
+Windows, plus lockless cap/dedup fallbacks. This suite verifies the fixes:
+
+- M-22: ``_shared._pid_is_alive`` routes through ``_platform.pid_is_alive``
+  (psutil) on win32 instead of bare ``os.kill``.
+- M-50: the five spawn sites pass ``_platform.spawn_kwargs()`` so children
+  carry the Windows detach flags.
+- M-79: the spawn gate and dedup-store lock take a real ``msvcrt`` lock on
+  Windows instead of a no-op / lockless count.
+
+All tests simulate win32 by monkeypatching ``sys.platform`` / the
+``_platform`` helpers — no real Windows runtime is required.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# M-22: _pid_is_alive routes through _platform.pid_is_alive on Windows
+# ---------------------------------------------------------------------------
+
+
+class TestPidLivenessRoutesThroughPlatform:
+    def test_win32_dead_pid_uses_platform_helper_not_os_kill(self):
+        """On simulated win32, a dead PID is reported dead via the helper,
+        and bare os.kill is NOT called (it would Ctrl+C the process group)."""
+        from truememory.ingest.hooks import _shared
+
+        called = {"os_kill": False, "platform": False}
+
+        def fake_os_kill(pid, sig):  # pragma: no cover — must NOT run
+            called["os_kill"] = True
+            raise AssertionError("os.kill must not be used on win32")
+
+        def fake_platform_alive(pid):
+            called["platform"] = True
+            return False
+
+        with patch.object(_shared.sys, "platform", "win32"), \
+                patch.object(_shared.os, "kill", fake_os_kill), \
+                patch.object(_shared._platform, "pid_is_alive", fake_platform_alive):
+            assert _shared._pid_is_alive(12345) is False
+
+        assert called["platform"] is True
+        assert called["os_kill"] is False
+
+    def test_win32_live_pid_via_platform_helper(self):
+        from truememory.ingest.hooks import _shared
+
+        with patch.object(_shared.sys, "platform", "win32"), \
+                patch.object(_shared._platform, "pid_is_alive", lambda pid: True):
+            assert _shared._pid_is_alive(999) is True
+
+    def test_nonpositive_pid_short_circuits(self):
+        from truememory.ingest.hooks import _shared
+        assert _shared._pid_is_alive(0) is False
+        assert _shared._pid_is_alive(-1) is False
+
+    def test_posix_path_still_uses_os_kill(self):
+        """Non-win32 keeps the EPERM-aware os.kill semantics."""
+        from truememory.ingest.hooks import _shared
+        # Our own live PID is alive on POSIX.
+        if sys.platform != "win32":
+            assert _shared._pid_is_alive(os.getpid()) is True
+
+
+# ---------------------------------------------------------------------------
+# M-50: the five spawn sites pass _platform.spawn_kwargs()
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnKwargs:
+    def test_spawn_kwargs_win32_has_detach_flags(self):
+        """The helper the spawn sites use yields Windows creationflags."""
+        from truememory import _platform
+        with patch.object(_platform.sys, "platform", "win32"):
+            kw = _platform.spawn_kwargs()
+        assert "creationflags" in kw
+        # CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS | CREATE_NO_WINDOW
+        assert kw["creationflags"] & 0x00000200  # CREATE_NEW_PROCESS_GROUP
+        assert kw["creationflags"] & 0x00000008  # DETACHED_PROCESS
+        assert "start_new_session" not in kw
+
+    def test_spawn_kwargs_posix(self):
+        from truememory import _platform
+        with patch.object(_platform.sys, "platform", "linux"):
+            kw = _platform.spawn_kwargs()
+        assert "start_new_session" in kw
+        assert "creationflags" not in kw
+
+    @pytest.mark.parametrize("modname", [
+        "truememory.mcp_server",
+        "truememory.ingest.cli",
+        "truememory.ingest.hooks.session_start",
+        "truememory.ingest.hooks.stop",
+        "truememory.hooks.core",
+    ])
+    def test_spawn_sites_no_bare_start_new_session(self, modname):
+        """No spawn site passes a literal start_new_session=hasattr(...) any
+        more for the ingest workers — they must funnel through spawn_kwargs.
+
+        (stop.py/core.py use an inline win32 branch; the five #642 sites use
+        the helper. Either way, none should regress to the no-op-only form.)"""
+        import importlib
+        mod = importlib.import_module(modname)
+        src = open(mod.__file__, encoding="utf-8").read()
+        # session_start/cli/mcp_server must reference spawn_kwargs.
+        if modname in (
+            "truememory.mcp_server",
+            "truememory.ingest.cli",
+            "truememory.ingest.hooks.session_start",
+        ):
+            assert "spawn_kwargs" in src, f"{modname} should use _platform.spawn_kwargs()"
+
+    def test_session_start_spawn_uses_helper_kwargs(self, monkeypatch, tmp_path):
+        """_spawn_stale_scan funnels Popen kwargs from spawn_kwargs()."""
+        from truememory.ingest.hooks import session_start
+
+        captured = {}
+
+        class FakeProc:
+            pid = 7
+
+        def fake_popen(cmd, **kwargs):
+            captured.update(kwargs)
+            return FakeProc()
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(session_start, "_platform",
+                            _StubPlatform(creationflags=0x208))
+        import subprocess as _sp
+        monkeypatch.setattr(_sp, "Popen", fake_popen)
+
+        session_start._spawn_stale_scan()
+        # The stub's creationflags must have reached Popen.
+        assert captured.get("creationflags") == 0x208
+        assert "start_new_session" not in captured
+
+
+class _StubPlatform:
+    def __init__(self, **kw):
+        self._kw = kw
+
+    def spawn_kwargs(self):
+        return dict(self._kw)
+
+    def pid_is_alive(self, pid):
+        return True
+
+
+# ---------------------------------------------------------------------------
+# M-79: spawn gate + dedup lock have a real msvcrt branch on Windows
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsLocks:
+    def test_spawn_gate_takes_msvcrt_lock_when_no_fcntl(self, monkeypatch, tmp_path):
+        """When fcntl is unavailable (win32), spawn_gate locks via msvcrt and
+        enforces the cap from the PID file — NOT the lockless pgrep count."""
+        from truememory.hooks import core
+
+        lock_calls = []
+
+        class FakeMsvcrt:
+            LK_LOCK = 1
+            LK_UNLCK = 2
+
+            def locking(self, fileno, flag, nbytes):
+                lock_calls.append(flag)
+
+        monkeypatch.setattr(core, "_HAS_FCNTL", False)
+        monkeypatch.setattr(core, "SPAWN_LOCK_PATH", tmp_path / ".spawn.lock")
+        monkeypatch.setattr(core, "SPAWN_PIDS_PATH", tmp_path / ".spawn_pids")
+        monkeypatch.setattr(core, "_read_live_pids", lambda: [])
+        monkeypatch.setattr(core, "_write_pids", lambda pids: None)
+        monkeypatch.setattr(core, "_get_spawn_cap", lambda: 2)
+        # If the lockless path were taken, this would be consulted; make it
+        # blow up so the test fails if msvcrt branch is skipped.
+        monkeypatch.setattr(
+            core, "_count_active_ingest_processes",
+            lambda: (_ for _ in ()).throw(AssertionError("lockless path used")),
+        )
+        monkeypatch.setitem(sys.modules, "msvcrt", FakeMsvcrt())
+
+        with core.spawn_gate() as allowed:
+            assert allowed is True  # 0 live < cap 2
+
+        assert FakeMsvcrt.LK_LOCK in lock_calls
+        assert FakeMsvcrt.LK_UNLCK in lock_calls
+
+    def test_dedup_store_lock_takes_msvcrt_lock_when_no_fcntl(self, monkeypatch, tmp_path):
+        from truememory.ingest import pipeline
+
+        lock_calls = []
+
+        class FakeMsvcrt:
+            LK_LOCK = 1
+            LK_UNLCK = 2
+
+            def locking(self, fileno, flag, nbytes):
+                lock_calls.append(flag)
+
+        monkeypatch.setattr(pipeline, "_HAS_FCNTL", False)
+        monkeypatch.setattr(pipeline, "_LOCK_PATH", tmp_path / "ingest.lock")
+        monkeypatch.setitem(sys.modules, "msvcrt", FakeMsvcrt())
+
+        with pipeline._dedup_store_lock():
+            pass
+
+        assert FakeMsvcrt.LK_LOCK in lock_calls
+        assert FakeMsvcrt.LK_UNLCK in lock_calls
+
+    def test_dedup_store_lock_posix_uses_flock(self, tmp_path, monkeypatch):
+        """POSIX path unaffected: still acquires via flock without msvcrt."""
+        if sys.platform == "win32":
+            pytest.skip("POSIX-only assertion")
+        from truememory.ingest import pipeline
+        monkeypatch.setattr(pipeline, "_LOCK_PATH", tmp_path / "ingest.lock")
+        with pipeline._dedup_store_lock():
+            pass  # acquires + releases flock without error

--- a/truememory/hooks/core.py
+++ b/truememory/hooks/core.py
@@ -387,15 +387,43 @@ def spawn_gate():
     Callers MUST call register_spawned_pid(proc.pid) inside the gate
     after a successful Popen, before the context manager exits.
 
-    On Windows (no fcntl), falls back to best-effort pgrep without a lock.
+    On Windows (no fcntl) the lock is taken with ``msvcrt.locking`` over the
+    same PID tracking file, so the cap is still enforced atomically instead of
+    falling back to a lockless pgrep count that returns 0 and leaks spawns.
     """
     cap = _get_spawn_cap()
 
+    SPAWN_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+
     if not _HAS_FCNTL:
-        yield _count_active_ingest_processes() < cap
+        # Windows: exclusive blocking msvcrt lock mirrors the flock branch.
+        try:
+            import msvcrt
+        except ImportError:
+            # No lock primitive at all (neither fcntl nor msvcrt): best-effort
+            # lockless count. This is the genuine no-primitive fallback.
+            yield _count_active_ingest_processes() < cap
+            return
+        lock_f = open(str(SPAWN_LOCK_PATH), "a+")
+        try:
+            try:
+                msvcrt.locking(lock_f.fileno(), msvcrt.LK_LOCK, 1)
+            except OSError:
+                # Could not acquire the lock; fall back to best-effort count
+                # rather than blocking the hook indefinitely.
+                yield _count_active_ingest_processes() < cap
+                return
+            live = _read_live_pids()
+            _write_pids(live)
+            yield len(live) < cap
+        finally:
+            try:
+                msvcrt.locking(lock_f.fileno(), msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+            lock_f.close()
         return
 
-    SPAWN_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
     fd = None
     try:
         fd = os.open(str(SPAWN_LOCK_PATH), os.O_CREAT | os.O_WRONLY, 0o600)

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -348,11 +348,12 @@ def _cascade_next() -> None:
                     cmd.extend(["--user", data["user_id"]])
                 if data.get("db_path"):
                     cmd.extend(["--db", data["db_path"]])
+                from truememory import _platform
                 proc = _sp.Popen(
                     cmd,
                     stdout=_sp.DEVNULL,
                     stderr=_sp.DEVNULL,
-                    start_new_session=hasattr(os, 'setsid'),
+                    **_platform.spawn_kwargs(),
                 )
                 register_spawned_pid(proc.pid)
                 record_stale_processing_pid(claimed_path, proc.pid)

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -5,7 +5,10 @@ import errno
 import json
 import logging
 import os
+import sys
 import time
+
+from truememory import _platform
 
 try:
     import fcntl
@@ -153,6 +156,13 @@ def _pid_is_alive(pid: int) -> bool:
     """
     if pid <= 0:
         return False
+    if sys.platform == "win32":
+        # ``os.kill(pid, 0)`` on Windows sends a console Ctrl event to the
+        # process group (workers run with CREATE_NEW_PROCESS_GROUP) and would
+        # interrupt a live worker; a missing PID raises a generic OSError that
+        # the fallback below treats as alive, wedging stale-claim cleanup.
+        # Route through the canonical psutil-backed helper instead.
+        return _platform.pid_is_alive(pid)
     try:
         os.kill(pid, 0)
         return True

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -27,6 +27,8 @@ import os
 import sys
 from pathlib import Path
 
+from truememory import _platform
+
 try:
     import fcntl
     _HAS_FCNTL = True
@@ -332,7 +334,7 @@ def _drain_backlog() -> None:
                         stdout=_log_file,
                         stderr=subprocess.STDOUT,
                         stdin=subprocess.DEVNULL,
-                        start_new_session=hasattr(os, 'setsid'),
+                        **_platform.spawn_kwargs(),
                     )
                 finally:
                     _log_file.close()
@@ -639,8 +641,8 @@ def _run_maintenance_background() -> None:
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
                 stdin=subprocess.DEVNULL,
-                start_new_session=hasattr(os, "setsid"),
                 env={**os.environ, "TRUEMEMORY_MAINTENANCE_CHILD": "1"},
+                **_platform.spawn_kwargs(),
             )
         finally:
             log_file.close()
@@ -673,7 +675,7 @@ def _spawn_stale_scan() -> None:
                 stdout=_log_file,
                 stderr=subprocess.STDOUT,
                 stdin=subprocess.DEVNULL,
-                start_new_session=hasattr(os, "setsid"),
+                **_platform.spawn_kwargs(),
             )
         finally:
             _log_file.close()

--- a/truememory/ingest/pipeline.py
+++ b/truememory/ingest/pipeline.py
@@ -137,8 +137,10 @@ def _dedup_store_lock():
 
     Holding this process-wide lock around the check_duplicate + store_fact
     pair makes the sequence atomic across concurrent hooks. On Windows
-    (no fcntl) we skip locking and rely on ``busy_timeout`` + the embedding
-    similarity check as best-effort protection.
+    (no fcntl) we take an exclusive ``msvcrt.locking`` lock over the same
+    path so the critical section is still serialized; the POSIX inode
+    revalidation is not needed there because Windows keeps the file open
+    while locked and does not allow it to be unlinked underneath us.
 
     Locking discipline (#649, M-31). ``flock`` is the authority on
     mutual exclusion, NOT the PID/mtime bookkeeping:
@@ -156,14 +158,45 @@ def _dedup_store_lock():
     - The PID is written purely for diagnostics (and to let an operator see
       who holds it). mtime is refreshed on acquire as a heartbeat.
     """
-    if not _HAS_FCNTL:
-        yield
-        return
-
     try:
         _LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
     except OSError:
         yield
+        return
+
+    if not _HAS_FCNTL:
+        # Windows: exclusive blocking msvcrt lock serializes the
+        # dedup-then-store critical section (no fcntl available).
+        try:
+            import msvcrt
+        except ImportError:
+            # No lock primitive at all: degrade open (busy_timeout protects).
+            yield
+            return
+        try:
+            lock_f = open(str(_LOCK_PATH), "a+")
+        except OSError:
+            yield
+            return
+        try:
+            try:
+                msvcrt.locking(lock_f.fileno(), msvcrt.LK_LOCK, 1)
+            except OSError:
+                # Could not acquire — degrade open rather than block ingestion.
+                yield
+                return
+            try:
+                yield
+            finally:
+                try:
+                    msvcrt.locking(lock_f.fileno(), msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+        finally:
+            try:
+                lock_f.close()
+            except OSError:
+                pass
         return
 
     lock_fd = _acquire_flock(_LOCK_PATH)

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1816,12 +1816,13 @@ def _drain_batch_from_backlog(markers: list[Path]) -> None:
                     "a", encoding="utf-8",
                 )
                 try:
+                    from truememory import _platform
                     proc = _subprocess.Popen(
                         cmd,
                         stdout=_log_file,
                         stderr=_subprocess.STDOUT,
                         stdin=_subprocess.DEVNULL,
-                        start_new_session=hasattr(os, 'setsid'),
+                        **_platform.spawn_kwargs(),
                     )
                 finally:
                     _log_file.close()

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -802,6 +802,38 @@ class ModelServer:
                 f2.write(text)
             tmp.unlink(missing_ok=True)
 
+    @staticmethod
+    def _restrict_acl_windows(path: Path) -> None:
+        """Best-effort: restrict *path*'s ACL to the current user (Windows).
+
+        ``os.open(..., 0o600)`` does not restrict Windows ACLs, so a TCP
+        fallback token written with mode 0o600 can still be world-readable.
+        Use ``icacls`` to remove inherited ACEs and grant only the current
+        user full control. On any failure, warn (mirroring the config.json
+        permission warning) rather than crash — the loopback bind + HMAC
+        still gate access, this only hardens the at-rest token file.
+        """
+        user = os.environ.get("USERNAME")
+        if not user:
+            return
+        try:
+            import subprocess
+            subprocess.run(
+                ["icacls", str(path), "/inheritance:r",
+                 "/grant:r", f"{user}:F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=True,
+            )
+        except Exception:
+            print(
+                "truememory: warning — could not restrict ACL on "
+                f"{path}; the model-server HMAC token may be readable by "
+                "other local users on this machine. On a shared machine, "
+                "ensure ~/.truememory is not world-readable.",
+                file=sys.stderr,
+            )
+
     def _acquire_bind_lock(self):
         """Take an exclusive lock BEFORE binding (issue #646, M-20).
 
@@ -852,6 +884,13 @@ class ModelServer:
             self._token = secrets.token_bytes(_HMAC_TOKEN_BYTES)
             self._atomic_write_text(TOKEN_PATH, self._token.hex(), mode=0o600)
             self._atomic_write_text(PORT_PATH, str(self._bound_port), mode=0o600)
+            # M-80: the 0o600 mode above is a no-op on Windows — os.open only
+            # honors the read-only bit, so the HMAC token can be world-readable
+            # to other local users. Restrict the ACL to the current user via
+            # icacls; warn (mirroring the config.json perm warning) if that
+            # fails so a shared-machine operator is not silently exposed.
+            if sys.platform == "win32":
+                self._restrict_acl_windows(TOKEN_PATH)
             transport_desc = f"tcp={_LOOPBACK_HOST}:{self._bound_port}"
         # PID written only AFTER a successful bind — never advertises a
         # not-yet-listening server (M-20). We own the artifacts from here.


### PR DESCRIPTION
Fixes #642. The ingest/hooks layer never adopted the Windows-correct primitives that already live in `truememory/_platform.py`. All findings verified against current code (line numbers shifted post #644/#649).

## Changes

**M-22 (P1) — `ingest/hooks/_shared.py`**
`_pid_is_alive` now routes through `_platform.pid_is_alive` (psutil) on win32. The bare `os.kill(pid, 0)` it used sends a console Ctrl event to the process group (workers run with CREATE_NEW_PROCESS_GROUP) and a missing PID raised a generic OSError that the fallback treated as alive — wedging `should_extract_session`/`cleanup_stale_processing`. POSIX EPERM-aware path unchanged.

**M-50 (P2) — five spawn sites**
Routed through `_platform.spawn_kwargs()` (carries CREATE_NO_WINDOW | DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP on win32) instead of the no-op `start_new_session=hasattr(os,'setsid')`:
- `mcp_server.py` (ingest worker spawn)
- `ingest/cli.py` (backlog drain spawn)
- `ingest/hooks/session_start.py` (3 sites: ingest, background maintenance, stale scan)

**M-79 (P3) — Windows lockless fallbacks**
- `hooks/core.py` `spawn_gate`: added an `msvcrt.locking` exclusive branch over the PID file so the spawn cap is enforced atomically on Windows instead of the lockless pgrep count (returned 0 → cap never enforced, TOCTOU).
- `ingest/pipeline.py` `_dedup_store_lock`: added an `msvcrt.locking` branch so the dedup-then-store critical section is serialized on Windows instead of a no-op yield.
- Both mirror the pattern in `tier_switch/manager.py` and degrade gracefully if neither fcntl nor msvcrt is importable.

**M-80 (P3) — `model_server.py` TCP token perms**
`os.open(...,0o600)` is a no-op for ACLs on Windows, leaving the HMAC token potentially world-readable. Added `_restrict_acl_windows` (best-effort `icacls /inheritance:r /grant:r USER:F`) with a warning fallback mirroring the existing config.json permission warning.

## Tests
New `tests/test_issue_642_windows_platform.py` (15 tests, all pass), simulating win32 via monkeypatch (no real Windows runtime):
- pid-liveness routes through `_platform.pid_is_alive` and never calls bare `os.kill` on win32
- `spawn_kwargs()` yields detach flags; spawn sites funnel through it (asserts Popen receives the helper's creationflags)
- spawn gate + dedup lock invoke msvcrt LK_LOCK/LK_UNLCK under simulated win32; POSIX flock path preserved

`ruff check` clean. Targeted suite: 136 passed for `-k 'platform or pid_is_alive or spawn or windows or _shared or lock'`. The one failure in `test_production_fixes.py::test_stop_hook_exits_cleanly...` is pre-existing (py3.14 subprocess env: `No module named numpy`), confirmed on clean main.