### PR TITLE
fix: DB corruption UX — backup rotation/restore, quick_check, actionable WAL/permission errors (#650)

### DIFF
--- a/tests/test_issue_650_db_corruption.py
+++ b/tests/test_issue_650_db_corruption.py
@@ -1,0 +1,212 @@
+"""Regression locks for issue #650 — DB corruption UX hardening.
+
+Covers:
+- M-24: pre-migration backups are rotated (keep <= N); a migration-failing DB
+  does NOT accumulate unbounded backups across repeated opens.
+- M-55: opening a corrupt DB yields an actionable DatabaseOpenError naming a
+  backup, not a raw DatabaseError swallowed silently.
+- M-57: a read-only DB dir yields a message naming the directory.
+- M-84: the L4 entity_profile purge runs via _ensure_connection (not only the
+  deprecated open()).
+
+All tests use tmp dirs/copies. No model loads (HF_HUB_OFFLINE handled by the
+suite); these tests never embed.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+
+import pytest
+
+from truememory import storage
+from truememory.storage import (
+    DatabaseOpenError,
+    _MAX_PRE_MIGRATION_BACKUPS,
+    create_db,
+    newest_backup,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_legacy_db(path) -> None:
+    """Create a pre-migration ``messages`` table missing the new columns."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "content TEXT NOT NULL, sender TEXT DEFAULT '')"
+    )
+    conn.execute("INSERT INTO messages (content) VALUES ('hello')")
+    conn.commit()
+    conn.close()
+
+
+def _count_backups(db_path) -> int:
+    parent = db_path.parent
+    prefix = f"{db_path.name}.backup-pre-migration-"
+    return len(
+        [
+            p
+            for p in parent.glob(f"{prefix}*")
+            if not p.name.endswith("-wal") and not p.name.endswith("-shm")
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# M-24: backup rotation
+# ---------------------------------------------------------------------------
+
+def test_backup_rotation_keeps_at_most_n(tmp_path):
+    """Repeated _backup_database calls keep only the newest N backups."""
+    db = tmp_path / "memories.db"
+    _make_legacy_db(db)
+
+    # Force more backups than the cap. Each call writes a uniquely-named copy.
+    for _ in range(_MAX_PRE_MIGRATION_BACKUPS + 4):
+        storage._backup_database(db)
+
+    assert _count_backups(db) <= _MAX_PRE_MIGRATION_BACKUPS
+
+
+def test_failing_migration_does_not_accumulate_backups(tmp_path, monkeypatch):
+    """A DB that fails migration must not re-back-up on every open (M-24).
+
+    We force the ALTER to fail, which writes the 'migration-failed' marker.
+    Subsequent create_db opens must skip the backup entirely (the marker is
+    honored), so the backup count stays bounded across many opens.
+    """
+    db = tmp_path / "memories.db"
+    # Build a DB that already has the full real schema, then inject one extra
+    # "expected" column whose typedef is invalid SQL. The migration sees only
+    # the bogus column as missing, the ALTER fails, the transaction rolls back
+    # (leaving the real schema intact and usable), and the 'migration-failed'
+    # marker is written.
+    create_db(db).close()
+    bad_columns = dict(storage._EXPECTED_COLUMNS)
+    bad_columns["bogus"] = "NOT A VALID TYPE ("
+    monkeypatch.setattr(storage, "_EXPECTED_COLUMNS", bad_columns)
+
+    # First open: backup taken, ALTER fails, marker written.
+    conn = create_db(db)
+    conn.close()
+    marker = db.parent / f"{db.name}.migration-failed"
+    assert marker.exists(), "expected migration-failed marker after ALTER failure"
+    count_after_first = _count_backups(db)
+
+    # Many more opens: must NOT re-back-up (marker present).
+    for _ in range(6):
+        create_db(db).close()
+
+    assert _count_backups(db) == count_after_first, (
+        "failing-migration DB re-backed-up on subsequent opens (disk-fill bug)"
+    )
+    assert _count_backups(db) <= _MAX_PRE_MIGRATION_BACKUPS
+
+
+# ---------------------------------------------------------------------------
+# M-55: corrupt DB -> actionable error naming a backup
+# ---------------------------------------------------------------------------
+
+def test_corrupt_db_raises_actionable_error_naming_backup(tmp_path):
+    """A corrupted DB yields DatabaseOpenError pointing at the newest backup."""
+    db = tmp_path / "memories.db"
+    # Build a healthy DB and a backup of it, then corrupt the live file.
+    create_db(db).close()
+    backup = storage._backup_database(db)
+    assert backup is not None
+
+    # Flip bytes in the middle of the page region to corrupt the image while
+    # keeping the SQLite magic header intact (so it parses as a DB, then fails
+    # integrity).
+    data = bytearray(db.read_bytes())
+    for i in range(100, min(len(data), 4000)):
+        data[i] ^= 0xFF
+    db.write_bytes(bytes(data))
+
+    with pytest.raises(DatabaseOpenError) as exc_info:
+        create_db(db).close()
+
+    msg = str(exc_info.value)
+    assert "corrupt" in msg.lower()
+    # Must name a restore candidate.
+    assert backup.name in msg
+    # And it is a DatabaseError subclass so legacy callers still catch it.
+    assert isinstance(exc_info.value, sqlite3.DatabaseError)
+
+
+def test_newest_backup_returns_latest(tmp_path):
+    db = tmp_path / "memories.db"
+    create_db(db).close()
+    assert newest_backup(db) is None
+    b1 = storage._backup_database(db)
+    assert b1 is not None
+    assert newest_backup(db) == b1
+
+
+# ---------------------------------------------------------------------------
+# M-57: read-only directory -> message naming the directory
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="chmod semantics differ on Windows"
+)
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses dir permissions")
+def test_readonly_dir_raises_error_naming_directory(tmp_path):
+    ro_dir = tmp_path / "readonly"
+    ro_dir.mkdir()
+    db = ro_dir / "memories.db"
+    os.chmod(ro_dir, 0o555)
+    try:
+        with pytest.raises(DatabaseOpenError) as exc_info:
+            create_db(db).close()
+        msg = str(exc_info.value)
+        assert str(ro_dir) in msg
+        assert "writable" in msg.lower()
+    finally:
+        os.chmod(ro_dir, 0o755)
+
+
+# ---------------------------------------------------------------------------
+# M-84: L4 purge runs via _ensure_connection
+# ---------------------------------------------------------------------------
+
+def test_l4_purge_runs_via_ensure_connection(tmp_path, monkeypatch):
+    """entity_profile summary rows are purged on the production open path."""
+    monkeypatch.delenv("TRUEMEMORY_ENTITY_SHEETS", raising=False)
+    db = tmp_path / "memories.db"
+
+    # Seed a DB with a legacy entity_profile summary row.
+    conn = create_db(db)
+    conn.execute(
+        "INSERT INTO summaries (period, summary) VALUES ('entity_profile', 'x')"
+    )
+    conn.execute(
+        "INSERT INTO summaries (period, summary) VALUES ('daily', 'keep me')"
+    )
+    conn.commit()
+    conn.close()
+
+    from truememory.engine import TrueMemoryEngine
+
+    eng = TrueMemoryEngine(db)
+    eng._ensure_connection()
+    try:
+        rows = eng.conn.execute(
+            "SELECT period FROM summaries ORDER BY period"
+        ).fetchall()
+        periods = [r[0] for r in rows]
+        assert "entity_profile" not in periods, "L4 purge did not run via _ensure_connection"
+        assert "daily" in periods, "purge removed non-entity_profile rows"
+        # Migration flag recorded for idempotency.
+        flag = eng.conn.execute(
+            "SELECT value FROM metadata WHERE key = 'l4_entity_profile_migration_done'"
+        ).fetchone()
+        assert flag is not None and flag[0] == "1"
+    finally:
+        if eng.conn is not None:
+            eng.conn.close()

--- a/tests/test_issue_650_db_corruption.py
+++ b/tests/test_issue_650_db_corruption.py
@@ -155,7 +155,10 @@ def test_newest_backup_returns_latest(tmp_path):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="chmod semantics differ on Windows"
 )
-@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses dir permissions")
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root bypasses dir permissions",
+)
 def test_readonly_dir_raises_error_naming_directory(tmp_path):
     ro_dir = tmp_path / "readonly"
     ro_dir.mkdir()

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -532,8 +532,85 @@ class TrueMemoryEngine:
                         exc_info=True,
                     )
 
+            # MEMORIST-L4 migration: purge legacy entity_profile summary rows.
+            # M-84: previously this only ran in the deprecated open() path, so
+            # production (which uses _ensure_connection) never purged them.
+            self._purge_legacy_entity_profile_summaries()
+
             self.ready = True
             self._maybe_startup_consolidate()
+
+    def _purge_legacy_entity_profile_summaries(self) -> None:
+        """Delete legacy ``period='entity_profile'`` summary rows once.
+
+        As of 2026-04-24 build_entity_summary_sheets is disabled by default,
+        but existing databases may contain entity_profile rows that
+        search_consolidated still surfaces. Removing them gives the measured
+        +5.3pt L4 lift on upgrade. Idempotent (guarded by a metadata flag) and
+        skipped when the user re-enables sheets via TRUEMEMORY_ENTITY_SHEETS=1.
+        """
+        if self.conn is None:
+            return
+        try:
+            tables = {
+                row[0]
+                for row in self.conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+        except Exception:
+            return
+
+        if "summaries" not in tables:
+            return
+
+        if "metadata" in tables:
+            try:
+                _row = self.conn.execute(
+                    "SELECT value FROM metadata WHERE key = ?",
+                    ("l4_entity_profile_migration_done",),
+                ).fetchone()
+                if _row is not None and _row[0] == "1":
+                    return
+            except Exception:
+                pass
+
+        if os.environ.get("TRUEMEMORY_ENTITY_SHEETS", "").strip().lower() in {
+            "1", "true", "yes", "on"
+        }:
+            return
+
+        try:
+            cur = self.conn.execute(
+                "DELETE FROM summaries WHERE period = 'entity_profile'"
+            )
+            deleted = cur.rowcount
+            cur.close()
+            if deleted > 0:
+                self.conn.commit()
+                logger.info(
+                    "MEMORIST-L4 migration: purged %d legacy entity_profile "
+                    "summary rows (disabled by default; set "
+                    "TRUEMEMORY_ENTITY_SHEETS=1 to re-enable)",
+                    deleted,
+                )
+            if "metadata" in tables:
+                try:
+                    self.conn.execute(
+                        "INSERT OR REPLACE INTO metadata (key, value) "
+                        "VALUES (?, ?)",
+                        ("l4_entity_profile_migration_done", "1"),
+                    )
+                    self.conn.commit()
+                except Exception:
+                    logger.debug("failed to record l4 migration flag", exc_info=True)
+        except Exception:
+            logger.warning(
+                "MEMORIST-L4 entity_profile migration failed; legacy rows may "
+                "remain. Set TRUEMEMORY_ENTITY_SHEETS=1 to revert to legacy "
+                "behavior if this is blocking.",
+                exc_info=True,
+            )
 
     def _maybe_startup_consolidate(self) -> None:
         """Trigger background consolidation on startup if data looks stale."""
@@ -1170,79 +1247,10 @@ class TrueMemoryEngine:
         }
 
         # ── MEMORIST-L4 migration: purge legacy entity_profile summary rows ─
-        # As of 2026-04-24, build_entity_summary_sheets is disabled by
-        # default (see consolidate() step 12). Existing v0.5.0 databases
-        # may contain `period='entity_profile'` rows that continue to be
-        # surfaced by search_consolidated (no period filter). Delete them
-        # once on open() so upgraders get the research's measured +5.3pt
-        # lift on day one rather than after their next consolidation run.
-        # Idempotent — re-running is a cheap no-op.
-        #
-        # Skipped if the user explicitly re-enables via
-        # TRUEMEMORY_ENTITY_SHEETS=1 (the next consolidate() will rewrite
-        # these rows, so deleting them here is pointless).
-        # Skip if migration flag already set (idempotency + perf:
-        # avoids a full-table scan of `summaries` on every open()).
-        if "metadata" in tables:
-            try:
-                _cur = self.conn.execute(
-                    "SELECT value FROM metadata WHERE key = ?",
-                    ("l4_entity_profile_migration_done",),
-                )
-                _row = _cur.fetchone()
-                _cur.close()
-                _migration_done = _row is not None and _row[0] == "1"
-            except Exception:
-                _migration_done = False
-        else:
-            _migration_done = False
-
-        _entity_sheets_re_enabled = (
-            os.environ.get("TRUEMEMORY_ENTITY_SHEETS", "")
-            .strip().lower() in {"1", "true", "yes", "on"}
-        )
-
-        if (
-            "summaries" in tables
-            and not _migration_done
-            and not _entity_sheets_re_enabled
-        ):
-            try:
-                cur = self.conn.execute(
-                    "DELETE FROM summaries WHERE period = 'entity_profile'"
-                )
-                deleted = cur.rowcount
-                cur.close()
-                if deleted > 0:
-                    self.conn.commit()
-                    logger.info(
-                        "MEMORIST-L4 migration: purged %d legacy "
-                        "entity_profile summary rows (disabled by default; "
-                        "set TRUEMEMORY_ENTITY_SHEETS=1 to re-enable)",
-                        deleted,
-                    )
-                # Record the migration as done so subsequent opens skip
-                # the scan (even if 0 rows were deleted).
-                if "metadata" in tables:
-                    try:
-                        self.conn.execute(
-                            "INSERT OR REPLACE INTO metadata (key, value) "
-                            "VALUES (?, ?)",
-                            ("l4_entity_profile_migration_done", "1"),
-                        )
-                        self.conn.commit()
-                    except Exception:
-                        logger.debug(
-                            "failed to record l4 migration flag",
-                            exc_info=True,
-                        )
-            except Exception:
-                logger.warning(
-                    "MEMORIST-L4 entity_profile migration failed; "
-                    "legacy rows may remain. Set TRUEMEMORY_ENTITY_SHEETS=1 "
-                    "to revert to legacy behavior if this is blocking.",
-                    exc_info=True,
-                )
+        # Shared with _ensure_connection (M-84): the purge logic lives in one
+        # idempotent helper so both the production path and this deprecated
+        # open() path behave identically.
+        self._purge_legacy_entity_profile_summaries()
 
         # Style vector hash migration: Python's hash() was replaced with a
         # stable hashlib-based hash in v0.6.3. Existing style vectors were

--- a/truememory/ingest/cli.py
+++ b/truememory/ingest/cli.py
@@ -422,17 +422,27 @@ def _preflight_writable_target(target: str | None, *, kind: str) -> bool:
         except OSError:
             pass
 
-    # For DBs, also confirm we can actually open/create the sqlite file.
-    # This catches corrupted existing DBs, bad permissions on an existing
-    # file, and any other OperationalError that would surface later deep
-    # in the storage layer — BEFORE we spend an LLM call.
-    if kind == "db":
+    # For DBs, validate an EXISTING file only. M-85: the previous probe called
+    # sqlite3.connect(path) unconditionally, which CREATES an empty file as a
+    # side effect when the path does not exist (and validated only the header
+    # via PRAGMA user_version). Creatability of a missing file is already
+    # covered by the parent-dir writability probe above, so here we only open
+    # files that already exist, and we run a real integrity check.
+    if kind == "db" and path.exists():
         import sqlite3
         try:
             conn = sqlite3.connect(str(path))
-            conn.execute("PRAGMA user_version")
-            conn.close()
-        except sqlite3.OperationalError as e:
+            try:
+                qc = conn.execute("PRAGMA quick_check(1)").fetchone()
+            finally:
+                conn.close()
+            if qc is not None and qc[0] != "ok":
+                print(
+                    f"ERROR: {kind} at {path} failed integrity check: {qc[0]}",
+                    file=sys.stderr,
+                )
+                return False
+        except sqlite3.DatabaseError as e:
             print(
                 f"ERROR: cannot open {kind} at {path}: {e}",
                 file=sys.stderr,

--- a/truememory/instrumentation/reader.py
+++ b/truememory/instrumentation/reader.py
@@ -13,6 +13,7 @@ import time
 from pathlib import Path
 
 from truememory.instrumentation.writer import _resolve_db_path
+from truememory.storage import DEFAULT_BUSY_TIMEOUT_MS
 
 
 def query_telemetry(
@@ -41,6 +42,9 @@ def query_telemetry(
         return []
 
     try:
+        # M-86: align busy_timeout with the single-source constant used by the
+        # writer so a concurrent prune/insert does not immediately error out.
+        conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
         cutoff = time.time() - (since_hours * 3600)
         if signal:
             rows = conn.execute(

--- a/truememory/instrumentation/writer.py
+++ b/truememory/instrumentation/writer.py
@@ -21,6 +21,7 @@ import time
 from pathlib import Path
 
 from truememory.instrumentation.log import dlog
+from truememory.storage import DEFAULT_BUSY_TIMEOUT_MS
 
 _DEFAULT_INSTRUMENTATION_DB = Path.home() / ".truememory" / "instrumentation.db"
 
@@ -52,10 +53,14 @@ def _get_connection() -> sqlite3.Connection:
             return _conn
         db_path = _resolve_db_path()
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(db_path, timeout=5.0, check_same_thread=False)
+        conn = sqlite3.connect(
+            db_path,
+            timeout=DEFAULT_BUSY_TIMEOUT_MS / 1000.0,
+            check_same_thread=False,
+        )
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA wal_autocheckpoint=1000")
-        conn.execute("PRAGMA busy_timeout=5000")
+        conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
         conn.execute("PRAGMA synchronous=NORMAL")
         conn.execute("""
             CREATE TABLE IF NOT EXISTS telemetry (

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -250,6 +250,61 @@ CREATE INDEX IF NOT EXISTS idx_rebuild_status_active
 DEFAULT_BUSY_TIMEOUT_MS = 10_000
 
 
+class DatabaseOpenError(sqlite3.DatabaseError):
+    """Raised by :func:`create_db` with an actionable, user-facing message.
+
+    Subclasses ``sqlite3.DatabaseError`` so existing ``except DatabaseError``
+    callers still catch it, but the message tells the user exactly what to do
+    (restore from a named backup, fix directory permissions, or restart all
+    TrueMemory processes) instead of surfacing a raw "database disk image is
+    malformed" / "disk I/O error" string.
+    """
+
+
+def _check_dir_writable(db_path: str | Path) -> None:
+    """Preflight: WAL needs to create ``-wal``/``-shm`` in the DB directory.
+
+    A read-only directory yields a misleading raw error deep in the first
+    write (M-57). Catch it early and name the directory.
+    """
+    import os
+
+    if str(db_path) == ":memory:":
+        return
+    db_dir = Path(str(db_path)).parent
+    if not db_dir:
+        db_dir = Path(".")
+    if db_dir.exists() and not os.access(db_dir, os.W_OK):
+        raise DatabaseOpenError(
+            f"TrueMemory database directory is not writable: {db_dir}\n"
+            "SQLite WAL mode must create -wal/-shm files alongside the "
+            "database. Fix the directory permissions (e.g. "
+            f"`chmod u+w {db_dir}`) and retry."
+        )
+
+
+def _integrity_message(db_path: str | Path, raw: str) -> str:
+    """Build an actionable corruption message naming the newest backup."""
+    backup = newest_backup(db_path)
+    lines = [
+        f"TrueMemory database appears corrupt: {db_path}",
+        f"  (sqlite reported: {raw})",
+    ]
+    if backup is not None:
+        lines.append(
+            f"Restore from the most recent pre-migration backup:\n"
+            f"  cp '{backup}' '{db_path}'\n"
+            "(also copy the matching -wal/-shm files if present, after "
+            "stopping all TrueMemory processes)."
+        )
+    else:
+        lines.append(
+            "No pre-migration backup was found next to the database. "
+            "Restore from your own backup if you have one."
+        )
+    return "\n".join(lines)
+
+
 # ---------------------------------------------------------------------------
 # Database creation
 # ---------------------------------------------------------------------------
@@ -265,10 +320,79 @@ _EXPECTED_COLUMNS = {
 }
 
 
+# How many pre-migration backups to keep per database file. Older ones are
+# pruned (M-24). Without this the degraded-legacy path re-backed-up on every
+# hook open (4+ per session) with zero rotation, filling the disk.
+_MAX_PRE_MIGRATION_BACKUPS = 3
+
+# Marker file written next to the DB once a migration has been attempted and
+# failed. Its presence means "do NOT re-back-up this DB on every open" — a DB
+# that keeps failing migration would otherwise accumulate unbounded backups
+# (M-24). The migration itself is still retried (it is additive/transactional),
+# but the expensive 3-file backup is skipped.
+_MIGRATION_FAILED_MARKER_SUFFIX = ".migration-failed"
+
+
+def _backup_glob_prefix(db_path: Path) -> str:
+    return f"{db_path.name}.backup-pre-migration-"
+
+
+def _prune_old_backups(db_path: Path, keep: int = _MAX_PRE_MIGRATION_BACKUPS) -> None:
+    """Keep only the newest ``keep`` pre-migration backups for ``db_path``.
+
+    Each backup is a set of up to three files (the base copy plus optional
+    ``-wal``/``-shm`` siblings). We rank by the base file's mtime and delete
+    the whole set for anything beyond the newest ``keep``.
+    """
+    try:
+        parent = db_path.parent if str(db_path.parent) else Path(".")
+        prefix = _backup_glob_prefix(db_path)
+        # Base backups only (exclude the -wal/-shm siblings from the ranking).
+        bases = [
+            p for p in parent.glob(f"{prefix}*")
+            if not p.name.endswith("-wal") and not p.name.endswith("-shm")
+        ]
+        if len(bases) <= keep:
+            return
+        bases.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        for stale in bases[keep:]:
+            for ext in ("", "-wal", "-shm"):
+                sibling = Path(f"{stale}{ext}")
+                try:
+                    if sibling.exists():
+                        sibling.unlink()
+                except OSError:
+                    pass
+            log.info("Pruned old pre-migration backup: %s", stale)
+    except Exception:
+        log.debug("Backup pruning skipped", exc_info=True)
+
+
+def newest_backup(db_path: str | Path) -> Path | None:
+    """Return the newest pre-migration backup for ``db_path``, or None.
+
+    Used to point users at a restore candidate when corruption is detected.
+    """
+    db_path = Path(str(db_path))
+    try:
+        parent = db_path.parent if str(db_path.parent) else Path(".")
+        prefix = _backup_glob_prefix(db_path)
+        bases = [
+            p for p in parent.glob(f"{prefix}*")
+            if not p.name.endswith("-wal") and not p.name.endswith("-shm")
+        ]
+        if not bases:
+            return None
+        return max(bases, key=lambda p: p.stat().st_mtime)
+    except Exception:
+        return None
+
+
 def _backup_database(db_path: Path) -> Path | None:
     """Create a complete backup of the database including WAL/SHM files.
 
-    Returns the backup path on success, None on failure.
+    Rotates old backups so the degraded-legacy re-backup path cannot fill the
+    disk (M-24). Returns the backup path on success, None on failure.
     """
     import shutil
     import uuid
@@ -286,6 +410,7 @@ def _backup_database(db_path: Path) -> Path | None:
             if wal_path.exists():
                 shutil.copy2(str(wal_path), str(backup) + ext)
         log.info("Legacy DB backup created: %s", backup)
+        _prune_old_backups(db_path)
         return backup
     except Exception as e:
         log.warning("Could not back up database before migration: %s", e)
@@ -316,7 +441,19 @@ def _migrate_messages_schema(conn: sqlite3.Connection, db_path: str | Path) -> N
     if not missing:
         return
 
+    _marker = Path(f"{db_path}{_MIGRATION_FAILED_MARKER_SUFFIX}")
+    _skip_backup = False
     if str(db_path) != ":memory:":
+        # If a previous migration attempt failed, a marker exists. Do NOT
+        # re-back-up on every open — that is the disk-fill bug (M-24). The
+        # migration is still retried below (additive/transactional), but we
+        # skip the expensive 3-file backup.
+        try:
+            _skip_backup = _marker.exists()
+        except OSError:
+            _skip_backup = False
+
+    if str(db_path) != ":memory:" and not _skip_backup:
         backup = _backup_database(Path(str(db_path)))
         if backup is None:
             # Do NOT skip the migration: an unmigrated DB is unusable by
@@ -341,12 +478,31 @@ def _migrate_messages_schema(conn: sqlite3.Connection, db_path: str | Path) -> N
             conn.execute(f"ALTER TABLE messages ADD COLUMN {col} {typedef}")
             log.info("Migrated legacy DB: added column messages.%s", col)
         conn.execute("COMMIT")
+        # Success — clear any stale "migration failed" marker so a future
+        # legitimate schema bump can take a fresh backup.
+        if str(db_path) != ":memory:":
+            try:
+                if _marker.exists():
+                    _marker.unlink()
+            except OSError:
+                pass
     except Exception as e:
         try:
             conn.execute("ROLLBACK")
         except Exception:
             pass
         log.warning("Legacy migration failed and was rolled back: %s", e)
+        # Write a marker so the next open does NOT re-back-up this DB (M-24).
+        # A DB that keeps failing migration would otherwise accumulate one
+        # 3-file backup per hook open (4+ per session) until the disk fills.
+        if str(db_path) != ":memory:":
+            try:
+                _marker.write_text(
+                    f"migration attempted and failed at {int(time.time())}: {e}\n",
+                    encoding="utf-8",
+                )
+            except OSError:
+                pass
 
 
 def create_db(db_path: str | Path) -> sqlite3.Connection:
@@ -368,13 +524,63 @@ def create_db(db_path: str | Path) -> sqlite3.Connection:
         An open ``sqlite3.Connection`` with row_factory left at default
         (callers choose their own access pattern).
     """
+    # M-57: preflight directory writability before SQLite produces a
+    # misleading raw error on the first WAL write.
+    _check_dir_writable(db_path)
+
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
-    conn.execute("PRAGMA foreign_keys=ON")
-    conn.execute("PRAGMA synchronous=NORMAL")
-    conn.execute("PRAGMA cache_size=-64000")
-    conn.execute("PRAGMA mmap_size=268435456")
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA cache_size=-64000")
+        conn.execute("PRAGMA mmap_size=268435456")
+
+        # M-55: cheap integrity check at open. quick_check(1) returns the
+        # single string "ok" on a healthy DB; anything else means corruption.
+        if str(db_path) != ":memory:":
+            try:
+                qc = conn.execute("PRAGMA quick_check(1)").fetchone()
+            except sqlite3.DatabaseError as e:
+                # "disk I/O error" here is the classic stale-WAL case (M-56):
+                # the -wal file was deleted/truncated while connections were
+                # live. The fix is to stop every process, not to restore.
+                msg = str(e).lower()
+                if "disk i/o error" in msg or "i/o error" in msg:
+                    raise DatabaseOpenError(
+                        "TrueMemory could not open the database due to a disk "
+                        f"I/O error: {db_path}\n"
+                        "This usually means the SQLite WAL file is "
+                        "inconsistent (e.g. a -wal/-shm file was removed while "
+                        "a connection was still open). Close ALL TrueMemory "
+                        "processes (hooks, MCP server, CLI) and retry."
+                    ) from e
+                raise DatabaseOpenError(_integrity_message(db_path, str(e))) from e
+            if qc is not None and qc[0] != "ok":
+                raise DatabaseOpenError(_integrity_message(db_path, str(qc[0])))
+    except DatabaseOpenError:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        raise
+    except sqlite3.DatabaseError as e:
+        # Corruption can also surface from the journal_mode pragma itself.
+        try:
+            conn.close()
+        except Exception:
+            pass
+        msg = str(e).lower()
+        if "disk i/o error" in msg or "i/o error" in msg:
+            raise DatabaseOpenError(
+                "TrueMemory could not open the database due to a disk I/O "
+                f"error: {db_path}\n"
+                "The SQLite WAL file is likely inconsistent. Close ALL "
+                "TrueMemory processes (hooks, MCP server, CLI) and retry."
+            ) from e
+        raise DatabaseOpenError(_integrity_message(db_path, str(e))) from e
+
     _migrate_messages_schema(conn, db_path)
     conn.executescript(_SCHEMA_SQL)
     # The directive index lives outside _SCHEMA_SQL on purpose: if a legacy


### PR DESCRIPTION
Fixes #650. DB corruption UX hardening (theme T7). Minimal, scoped changes to `storage.py`, `engine.py`, instrumentation, and the ingest preflight.

## Per-finding

- **M-24 (P1):** `_backup_database` now rotates pre-migration backups, keeping the newest `N=3` (`_prune_old_backups`). `_migrate_messages_schema` writes a `.migration-failed` marker when an ALTER rolls back, and **skips the 3-file backup on subsequent opens** while the marker exists — killing the degraded-legacy disk-fill (4+ backups/session). Marker is cleared on a later successful migration. Added `newest_backup()` as a restore helper.
- **M-55 (P2):** `create_db` runs `PRAGMA quick_check(1)` at open. On corruption it raises `DatabaseOpenError` (a `sqlite3.DatabaseError` subclass, so existing `except DatabaseError` callers still catch it) with an actionable message naming the newest backup + a `cp` restore line.
- **M-56 (P2):** `disk I/O error` at open now raises a specific message: WAL inconsistent → close ALL TrueMemory processes and retry.
- **M-57 (P2):** `_check_dir_writable` preflights `os.access(db_dir, W_OK)` before SQLite's misleading raw error, naming the directory + a `chmod` hint.
- **M-84 (P3):** L4 `entity_profile` purge extracted to `_purge_legacy_entity_profile_summaries()` and called from `_ensure_connection` (previously only in the deprecated `open()`); `open()` now delegates to the same helper.
- **M-85 (P3):** ingest preflight (`ingest/cli.py`) no longer `sqlite3.connect`s a non-existent path (which created an empty file as a side effect); it validates **existing** files only, via `quick_check(1)` instead of header-only `PRAGMA user_version`. Creatability of a missing file is already covered by the parent-dir writability probe.
- **M-86 (P3):** instrumentation `writer.py` (was 5s) and `reader.py` (had none) now use the single-source `DEFAULT_BUSY_TIMEOUT_MS` (10s).

## Tests

New `tests/test_issue_650_db_corruption.py`:
- backup rotation keeps <= N
- a migration-failing DB does **not** accumulate backups across repeated opens (marker honored)
- corrupt DB (flipped bytes) → `DatabaseOpenError` naming a backup, not a swallowed raw error
- read-only dir → message naming the directory
- L4 purge runs via `_ensure_connection`

`ruff check truememory/ tests/` passes. Targeted suite (`-k "storage or backup or migrat or corrupt or integrity or wal or create_db"`): **74 passed**, including the existing `test_l4_entity_sheets_disabled.py` (exercises the refactored L4 purge). The 2 `test_upgrade_path.py` failures are pre-existing env-only HuggingFace model-download (`LocalEntryNotFoundError` under `HF_HUB_OFFLINE`), unrelated to these changes.

Do not merge.