### PR TITLE
fix: extraction quality — multi-paragraph loss, strip recall blocks from transcripts (echo loop) (#652)

### DIFF
--- a/tests/test_issue_652_extraction.py
+++ b/tests/test_issue_652_extraction.py
@@ -1,0 +1,176 @@
+"""Tests for issue #652 — extraction quality fixes.
+
+Covers:
+1. M-65: a multi-paragraph user message keeps ALL paragraphs through the
+   no-LLM (Edge-tier) heuristic extraction path — not just paragraph 1.
+2. M-19: TrueMemory's own injected <truememory-recall>/<truememory-context>/
+   <truememory-directives> blocks are stripped before extraction and do NOT
+   become new memories (the echo-amplification loop is closed).
+
+M-47 (reranker skip on hook call sites) was DEFERRED — the Memory.search
+passthrough already exists (#632) and the remaining work is in hook files
+owned by other agents, so it is out of scope for this PR.
+"""
+
+from truememory.ingest.extractor import (
+    _extract_user_lines,
+    extract_facts_simple,
+)
+from truememory.ingest.transcript import (
+    Message,
+    format_for_extraction,
+    strip_truememory_blocks,
+)
+
+
+# ── M-65: multi-paragraph user messages survive role-scoping ────────────
+
+
+def test_multi_paragraph_user_message_keeps_all_paragraphs():
+    """Continuation paragraphs of a user message must be kept, not dropped.
+
+    A single multi-paragraph user message is formatted with internal blank
+    lines. _extract_user_lines splits on "\\n\\n", so only the first block
+    carries the "User:" prefix; the rest are continuation blocks that must
+    be attributed to the same user turn.
+    """
+    transcript = (
+        "User: I prefer dark mode for my editor.\n\n"
+        "I also like the bun runtime over npm.\n\n"
+        "And my favorite language is Rust."
+    )
+    user_only = _extract_user_lines(transcript)
+    assert "dark mode" in user_only
+    assert "bun runtime" in user_only  # paragraph 2 survives
+    assert "Rust" in user_only         # paragraph 3 survives
+
+
+def test_multi_paragraph_facts_extracted_no_llm_path():
+    """All paragraphs of a multi-paragraph user turn yield facts (Edge tier)."""
+    transcript = (
+        "User: I prefer dark mode for my editor.\n\n"
+        "I prefer the bun runtime over npm.\n\n"
+        "I use Rust for systems work."
+    )
+    facts = extract_facts_simple(transcript)
+    joined = " ".join(f.content.lower() for f in facts)
+    assert "dark mode" in joined
+    assert "bun runtime" in joined  # paragraph 2 — lost before the M-65 fix
+    assert "rust" in joined         # paragraph 3 — lost before the M-65 fix
+
+
+def test_continuation_after_assistant_not_attributed_to_user():
+    """A continuation block after an Assistant turn must NOT count as user."""
+    transcript = (
+        "User: I like dark mode.\n\n"
+        "Assistant: Here is a long answer.\n\n"
+        "I am a large language model and I prefer helping.\n\n"
+        "User: Thanks."
+    )
+    user_only = _extract_user_lines(transcript)
+    assert "dark mode" in user_only
+    # The assistant's continuation paragraph must be excluded.
+    assert "large language model" not in user_only
+
+
+# ── M-19: strip injected TrueMemory blocks before extraction ────────────
+
+
+def test_strip_truememory_blocks_removes_recall_wrapper():
+    text = (
+        "User: what do you remember about me?\n"
+        "<truememory-recall>\n"
+        "- Prefers dark mode (truncated near-dup...)\n"
+        "- Uses bun over npm\n"
+        "</truememory-recall>"
+    )
+    cleaned = strip_truememory_blocks(text)
+    assert "truememory-recall" not in cleaned
+    assert "Prefers dark mode" not in cleaned
+    assert "what do you remember" in cleaned
+
+
+def test_strip_truememory_blocks_removes_context_and_directives():
+    text = (
+        "<truememory-context>\nstale cached fact\n</truememory-context>\n"
+        "real content\n"
+        "<truememory-directives>\nalways do X\n</truememory-directives>"
+    )
+    cleaned = strip_truememory_blocks(text)
+    assert "truememory-context" not in cleaned
+    assert "truememory-directives" not in cleaned
+    assert "stale cached fact" not in cleaned
+    assert "always do X" not in cleaned
+    assert "real content" in cleaned
+
+
+def test_strip_truememory_blocks_handles_stray_tags():
+    """A block split across a chunk boundary leaves a lone tag — sweep it."""
+    text = "User: hi\n<truememory-recall>\ndangling injected line"
+    cleaned = strip_truememory_blocks(text)
+    assert "<truememory-recall>" not in cleaned
+
+
+def test_format_for_extraction_strips_injected_recall():
+    """Injected recall in message content must not reach the extractor."""
+    messages = [
+        Message(
+            role="human",
+            content=(
+                "actually my name is Josh.\n"
+                "<truememory-recall>\n"
+                "- User prefers dark mode\n"
+                "- User uses bun over npm\n"
+                "</truememory-recall>"
+            ),
+        ),
+    ]
+    formatted = format_for_extraction(messages)
+    assert "truememory-recall" not in formatted
+    assert "prefers dark mode" not in formatted.lower()
+    assert "Josh" in formatted
+
+
+def test_echo_loop_closed_no_new_memories_from_recall():
+    """Injected recall block must not be re-extracted as fresh facts.
+
+    Before the fix, the truncated near-duplicate memories inside the recall
+    block would be mined back out as new facts (generational copy growth).
+    """
+    messages = [
+        Message(
+            role="human",
+            content=(
+                "<truememory-recall>\n"
+                "I prefer dark mode for my editor.\n"
+                "I prefer bun over npm.\n"
+                "My favorite color is teal.\n"
+                "</truememory-recall>"
+            ),
+        ),
+    ]
+    formatted = format_for_extraction(messages)
+    facts = extract_facts_simple(formatted)
+    # None of the echoed "preferences" should have become facts.
+    joined = " ".join(f.content.lower() for f in facts)
+    assert "dark mode" not in joined
+    assert "bun over npm" not in joined
+    assert "teal" not in joined
+
+
+def test_real_user_facts_still_extracted_alongside_stripped_recall():
+    """Stripping recall must not suppress genuine new user facts."""
+    messages = [
+        Message(
+            role="human",
+            content=(
+                "<truememory-recall>\nI prefer dark mode.\n</truememory-recall>\n"
+                "actually, I prefer light mode now."
+            ),
+        ),
+    ]
+    formatted = format_for_extraction(messages)
+    facts = extract_facts_simple(formatted)
+    joined = " ".join(f.content.lower() for f in facts)
+    assert "light mode" in joined  # the genuine new statement survives
+    assert "dark mode" not in joined  # the echoed old one is gone

--- a/truememory/ingest/extractor.py
+++ b/truememory/ingest/extractor.py
@@ -505,12 +505,33 @@ def _extract_user_lines(transcript: str) -> str:
     lines.  We keep only lines that belong to a ``User:`` block so the
     heuristic extractor never fires on the assistant's own text (which
     would produce spurious facts like "I'm an AI assistant").
+
+    A single message can itself contain blank lines (a multi-paragraph
+    message), so splitting on ``"\n\n"`` produces *continuation* blocks that
+    carry no ``Role:`` prefix. Those belong to whichever role last opened a
+    block — we must track the current role and keep continuation paragraphs
+    of a user message rather than silently dropping everything after the
+    first paragraph (issue #652, M-65). Without this, the entire no-LLM
+    (Edge-tier) extraction path loses all but paragraph 1 of every
+    multi-paragraph user turn.
     """
     blocks = transcript.split("\n\n")
     user_blocks: list[str] = []
+    # None until we've seen a role-labelled block; tracks which role the
+    # current (and any following unlabelled continuation) blocks belong to.
+    current_is_user = False
     for block in blocks:
         stripped = block.strip()
-        if stripped.startswith("User:") or stripped.startswith("user:"):
+        if not stripped:
+            continue
+        lowered = stripped.lower()
+        if lowered.startswith("user:"):
+            current_is_user = True
+            user_blocks.append(stripped)
+        elif lowered.startswith("assistant:"):
+            current_is_user = False
+        elif current_is_user:
+            # Continuation paragraph of the in-progress user message.
             user_blocks.append(stripped)
     return "\n\n".join(user_blocks)
 

--- a/truememory/ingest/transcript.py
+++ b/truememory/ingest/transcript.py
@@ -310,20 +310,67 @@ def _parse_plain_text(text: str) -> list[Message]:
     return messages
 
 
+# TrueMemory injects context into the live conversation via XML-wrapped
+# blocks (the session_start / user_prompt_submit hooks emit
+# <truememory-recall>, <truememory-context>, <truememory-directives>,
+# <truememory-update>, <truememory-email-request>, <truememory-first-run>,
+# ...). When that injected text lands back in the transcript and is fed to
+# the extractor, the truncated near-duplicate memories get re-extracted as
+# *new* memories — an echo-amplification loop that grows generational copies
+# of the same fact (issue #652, M-19). We strip every <truememory-...>...
+# </truememory-...> wrapper (and any stray unclosed opener) before extraction
+# so our own injected context can never be mined back into the store.
+_TRUEMEMORY_BLOCK_RE = re.compile(
+    r"<truememory-[a-z0-9-]+\b[^>]*>.*?</truememory-[a-z0-9-]+>",
+    re.IGNORECASE | re.DOTALL,
+)
+_TRUEMEMORY_STRAY_TAG_RE = re.compile(
+    r"</?truememory-[a-z0-9-]+\b[^>]*>",
+    re.IGNORECASE,
+)
+
+
+def strip_truememory_blocks(text: str) -> str:
+    """Remove TrueMemory's own injected ``<truememory-*>`` context blocks.
+
+    These blocks are injected into the conversation by the recall hooks
+    (``session_start`` / ``user_prompt_submit``). Left in the transcript they
+    would be re-extracted as fresh memories, creating an echo loop of
+    truncated near-duplicates (issue #652). We drop whole wrapped blocks
+    first, then sweep any stray unbalanced opener/closer tags that survived
+    (e.g. a block split across a chunk boundary).
+    """
+    if "<truememory-" not in text.lower():
+        return text
+    cleaned = _TRUEMEMORY_BLOCK_RE.sub("", text)
+    cleaned = _TRUEMEMORY_STRAY_TAG_RE.sub("", cleaned)
+    return cleaned
+
+
 def format_for_extraction(messages: list[Message]) -> str:
     """
     Format parsed messages into a clean transcript for LLM extraction.
     Filters out tool calls and system messages — focuses on human conversation.
+
+    TrueMemory's own injected ``<truememory-*>`` recall/context blocks are
+    stripped from each message before formatting so they can't be re-mined
+    back into the store (issue #652, M-19).
     """
     lines = []
     for msg in messages:
         if msg.role in ("tool_use", "tool_result", "system"):
             continue
         role_label = "User" if msg.role == "human" else "Assistant"
+        # Drop any TrueMemory-injected context blocks before we consider
+        # length / truncation, so echoed recall never reaches the extractor.
+        content = strip_truememory_blocks(msg.content)
         # Truncate very long assistant responses (code output, etc.)
-        content = msg.content
         if msg.role == "assistant" and len(content) > 500:
             content = content[:500] + "... [truncated]"
+        # Stripping a block may leave a message empty — skip it entirely so we
+        # don't emit a bare "User:" / "Assistant:" label with no content.
+        if not content.strip():
+            continue
         lines.append(f"{role_label}: {content}")
 
     return "\n\n".join(lines)


### PR DESCRIPTION
Fixes #652.

## M-65 (P2) — multi-paragraph user messages lose all but paragraph 1
`_extract_user_lines` (extractor.py) splits the formatted transcript on `"\n\n"` and kept only blocks starting with `User:`. A single multi-paragraph user message contains internal blank lines, so its continuation paragraphs (which carry no `Role:` prefix) were silently dropped — the entire no-LLM (Edge-tier) extraction path lost everything after paragraph 1.

**Fix:** track the current role while iterating blocks; attribute unlabelled continuation blocks to the in-progress role. Assistant continuation paragraphs are still excluded.

## M-19 (P1) — echo-amplification loop
The recall hooks inject `<truememory-recall>`/`<truememory-context>`/`<truememory-directives>` (and `-update`/`-email-request`/`-first-run`) blocks into the live conversation. The transcript extractor had zero filtering, so truncated near-duplicate memories got re-extracted as *new* memories (generational copy growth).

**Fix:** new `strip_truememory_blocks()` in transcript.py removes any `<truememory-...>...</truememory-...>` wrapper (plus stray unbalanced tags from chunk-boundary splits). `format_for_extraction` calls it per message before formatting, protecting **both** the LLM and heuristic paths. Messages emptied by stripping are skipped (no bare `User:` label).

## M-47 (P2) — DEFERRED
The `Memory.search` `_skip_reranker` passthrough already exists (landed in #632). The only remaining work is threading the flag at the hook call sites (`hooks/core.py`, `user_prompt_submit.py`), which other agents / recent merges are actively changing. Per the conflict-avoidance guidance, deferred to a follow-up to keep this PR clean and localized.

## Scope
Touches only `truememory/ingest/extractor.py`, `truememory/ingest/transcript.py`, and the new test file.

## Tests
New `tests/test_issue_652_extraction.py` (9 cases): multi-paragraph paragraphs survive role-scoping + extract via the no-LLM path; assistant continuation excluded; recall/context/directives blocks stripped; echo loop closed (injected recall yields no new facts); genuine new facts still extracted alongside stripped recall.

`HF_HUB_OFFLINE=1 pytest tests/test_issue_652_extraction.py tests/ -k "extract or transcript or heuristic or recall_block or paragraph"` → **97 passed**, 2 pre-existing py3.14 env-only failures (subprocess spawns py3.14 lacking numpy — unrelated). `ruff check` clean.