### PR TITLE
fix: per-exchange store coordination — route through pipeline dedup; tighten _STORABLE_RE (#635)

### DIFF
--- a/tests/test_issue_635_per_exchange_coordination.py
+++ b/tests/test_issue_635_per_exchange_coordination.py
@@ -1,0 +1,247 @@
+"""Tests for issue #635 — per-exchange store coordination.
+
+Three clusters in ``truememory/ingest/hooks/user_prompt_submit.py``:
+
+- M-39 (P2): the per-exchange store path used a bare ``m.add()``, bypassing
+  the pipeline's ``_dedup_store_lock`` + ``check_duplicate`` critical section,
+  so a fact stored per-exchange and later re-extracted (rephrased) by the Stop
+  pipeline got double-stored. We assert the store now routes through
+  ``check_duplicate`` and SKIPs when dedup says the fact already exists.
+- M-40 (P2): ``_STORABLE_RE`` flagged bare filler ("no", "actually", "I'm")
+  and questions/quotes. We assert it does NOT fire on those but still fires on
+  genuine preference/fact statements.
+- M-73 (P3): conversation-depth buffer-dir derivation + unlocked counter RMW.
+  We assert depth reads from the same dir buffer_message() writes, and the
+  counter increments monotonically.
+
+All tests mock the model/embedding layer (no real model loads).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+
+
+# ---------------------------------------------------------------------------
+# Fakes — fully model-free (mirrors test_issue_634_per_exchange_store.py)
+# ---------------------------------------------------------------------------
+
+class _FakeDecision:
+    def __init__(self, should_encode: bool):
+        self.should_encode = should_encode
+
+
+class _FakeGate:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def evaluate(self, fact, category=""):
+        return _FakeDecision(True)
+
+
+class _FakeMemory:
+    """Records add() calls; search()/search_vectors() return no dupes by default."""
+
+    instances: list["_FakeMemory"] = []
+
+    def __init__(self, path=None, **kwargs):
+        self.added: list[str] = []
+        self.closed = False
+        self.search_results: list[dict] = []
+        self.vector_results: list[dict] = []
+        _FakeMemory.instances.append(self)
+
+    def search(self, query, user_id=None, limit=10, **kwargs):
+        return list(self.search_results)
+
+    def search_vectors(self, query, limit=3, **kwargs):
+        return list(self.vector_results)
+
+    def add(self, content, user_id=None, **kwargs):
+        self.added.append(content)
+        return {"id": len(self.added), "content": content, "user_id": user_id or ""}
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_instances():
+    _FakeMemory.instances.clear()
+    yield
+    _FakeMemory.instances.clear()
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Patch the model-touching deps in the hook with fakes."""
+    import truememory.client as client
+    import truememory.ingest.encoding_gate as eg
+    import truememory.model_client as mc
+
+    monkeypatch.setattr(client, "Memory", _FakeMemory)
+    monkeypatch.setattr(eg, "EncodingGate", _FakeGate)
+    monkeypatch.setattr(mc, "set_request_timeout", lambda v: None)
+    return {"FakeMemory": _FakeMemory}
+
+
+# ---------------------------------------------------------------------------
+# M-39: per-exchange store routes through check_duplicate / dedup lock
+# ---------------------------------------------------------------------------
+
+class TestPerExchangeRoutesThroughDedup:
+    def test_store_calls_check_duplicate(self, patched, monkeypatch):
+        """The store path must invoke the pipeline's check_duplicate."""
+        import truememory.ingest.dedup as dedup
+        from truememory.ingest.dedup import DedupAction, DedupDecision
+
+        calls: list[str] = []
+
+        def fake_check(fact, memory, **kwargs):
+            calls.append(fact)
+            return DedupDecision(action=DedupAction.ADD, fact=fact, reason="new")
+
+        monkeypatch.setattr(dedup, "check_duplicate", fake_check)
+
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        ups._try_per_exchange_store(
+            "I prefer dark mode for all my editors and always use TypeScript",
+            "sess-639", "", "", "max",
+        )
+        assert calls, "store path must call check_duplicate"
+        adds = [c for m in patched["FakeMemory"].instances for c in m.added]
+        assert len(adds) == 1
+
+    def test_dedup_skip_prevents_double_store(self, patched, monkeypatch):
+        """When dedup says SKIP (pipeline already has the fact), do not add."""
+        import truememory.ingest.dedup as dedup
+        from truememory.ingest.dedup import DedupAction, DedupDecision
+
+        def fake_check(fact, memory, **kwargs):
+            return DedupDecision(action=DedupAction.SKIP, fact=fact, reason="dupe")
+
+        monkeypatch.setattr(dedup, "check_duplicate", fake_check)
+
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        ups._try_per_exchange_store(
+            "I prefer dark mode for all my editors and always use TypeScript",
+            "sess-skip", "", "", "max",
+        )
+        adds = [c for m in patched["FakeMemory"].instances for c in m.added]
+        assert adds == [], "a fact dedup marks as duplicate must not be re-stored"
+
+    def test_dedup_lock_is_held(self, patched, monkeypatch):
+        """The store must run inside the pipeline's _dedup_store_lock."""
+        import truememory.ingest.pipeline as pipeline
+        import truememory.ingest.dedup as dedup
+        from truememory.ingest.dedup import DedupAction, DedupDecision
+        import contextlib
+
+        entered = {"lock": False}
+
+        @contextlib.contextmanager
+        def fake_lock():
+            entered["lock"] = True
+            yield
+
+        monkeypatch.setattr(pipeline, "_dedup_store_lock", fake_lock)
+        monkeypatch.setattr(
+            dedup, "check_duplicate",
+            lambda fact, memory, **kw: DedupDecision(
+                action=DedupAction.ADD, fact=fact, reason="new"),
+        )
+
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        ups._try_per_exchange_store(
+            "I always use TypeScript over JavaScript for new projects",
+            "sess-lock", "", "", "max",
+        )
+        assert entered["lock"], "store must be wrapped in _dedup_store_lock"
+
+
+# ---------------------------------------------------------------------------
+# M-40: _STORABLE_RE / _detect_storable_content false positives
+# ---------------------------------------------------------------------------
+
+class TestStorableDetection:
+    @pytest.mark.parametrize("text", [
+        "no",
+        "no.",
+        "actually can you run the tests again",
+        "do you prefer tabs or spaces?",
+        "what is my favorite color?",
+        'the error said "I\'m deprecated" in the log',
+        "instead of that, what should we do?",
+    ])
+    def test_filler_and_questions_do_not_fire(self, text):
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        assert ups._detect_storable_content(text) is False, f"should NOT fire: {text!r}"
+
+    @pytest.mark.parametrize("text", [
+        "I prefer dark mode for all my editors",
+        "I always use TypeScript over JavaScript",
+        "my email is josh@example.com for the account",
+        "actually, I use bun instead of npm now",
+        "I'm a founder based in Austin Texas",
+        "we decided to ship the feature on Friday",
+        "remember that I hate trailing whitespace",
+    ])
+    def test_genuine_statements_fire(self, text):
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        assert ups._detect_storable_content(text) is True, f"should fire: {text!r}"
+
+    def test_bare_im_does_not_fire(self):
+        from truememory.ingest.hooks import user_prompt_submit as ups
+        # bare "I'm" with no identity/state predicate is filler.
+        assert ups._detect_storable_content("I'm not sure, can you check?") is False
+
+
+# ---------------------------------------------------------------------------
+# M-73: buffer-dir derivation + counter lock
+# ---------------------------------------------------------------------------
+
+class TestBufferDirAndCounter:
+    def test_depth_reads_custom_buffer_dir(self, tmp_path, monkeypatch):
+        """conversation depth must read the buffer from BUFFER_DIR, even when
+        TRUEMEMORY_BUFFER_DIR is not a ``.../buffers`` path."""
+        import importlib
+        custom = tmp_path / "custom_dir"
+        monkeypatch.setenv("TRUEMEMORY_BUFFER_DIR", str(custom))
+        import truememory.ingest.hooks.user_prompt_submit as ups
+        importlib.reload(ups)
+        try:
+            sid = "sess-depth"
+            # Seed prior on-topic buffer entries via the module's own writer.
+            for _ in range(3):
+                ups.buffer_message(sid, "we are building the truememory ingestion pipeline today")
+            # Current prompt shares >=3 meaningful words with prior entries.
+            ups.buffer_message(sid, "the truememory ingestion pipeline needs building")
+            assert ups._check_conversation_depth(
+                sid, "the truememory ingestion pipeline needs building") is True
+        finally:
+            monkeypatch.delenv("TRUEMEMORY_BUFFER_DIR", raising=False)
+            importlib.reload(ups)
+
+    def test_counter_increments_monotonically(self, tmp_path, monkeypatch):
+        import importlib
+        monkeypatch.setenv("TRUEMEMORY_BUFFER_DIR", str(tmp_path / "buffers"))
+        import truememory.ingest.hooks.user_prompt_submit as ups
+        importlib.reload(ups)
+        try:
+            sid = "sess-counter"
+            seen = [ups._increment_prompt_count(sid) for _ in range(5)]
+            assert seen == [1, 2, 3, 4, 5]
+            assert ups._get_prompt_count(sid) == 5
+        finally:
+            monkeypatch.delenv("TRUEMEMORY_BUFFER_DIR", raising=False)
+            importlib.reload(ups)

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -50,6 +50,18 @@ RETENTION_DAYS = int(os.environ.get("TRUEMEMORY_BUFFER_RETENTION_DAYS", "7"))
 MAX_BUFFER_SIZE = int(os.environ.get("TRUEMEMORY_BUFFER_MAX_BYTES", str(10 * 1024 * 1024)))
 
 
+def _safe_session_id_local(session_id: str) -> str:
+    """Sanitize a session_id for use in buffer/counter filenames.
+
+    Single source of truth so the prompt-counter, conversation-depth, and
+    buffer paths all derive the SAME on-disk name for a given session (issue
+    #635, M-73) — they previously inlined the same expression in three places,
+    risking drift. Mirrors ``buffer_message``'s scheme (alnum + ``-_``, 64-char
+    cap, ``unknown`` fallback).
+    """
+    return "".join(c for c in session_id if c.isalnum() or c in "-_")[:64] or "unknown"
+
+
 def _word_overlap(a: str, b: str) -> float:
     """Scale-free Jaccard similarity on word sets (issue #632).
 
@@ -142,18 +154,47 @@ _CODE_RE = re.compile(
 # Issue #396: Memory Intensity — per-exchange evaluator + proactive recall
 # ---------------------------------------------------------------------------
 
-# Storable content heuristics for per-exchange evaluator
+# Storable content heuristics for per-exchange evaluator.
+#
+# Issue #635 (M-40): the previous pattern used bare standalone-word
+# alternations ("no"/"actually"/"instead"/"I'm") with no awareness of
+# negation, questions, quotes, or code, flagging 17/19 adversarial filler
+# cases. Tightened here to clause-level anchors that need a real subject +
+# preference/fact predicate:
+#   - bare "no" is dropped entirely (it is overwhelmingly filler/answer);
+#   - "actually"/"instead"/"wrong" only fire as a *correction* of a stated
+#     fact, anchored to a following first-person clause or a copula, not as
+#     standalone discourse markers;
+#   - "I'm" only fires when followed by an identity/state predicate
+#     ("I'm a ...", "I'm using ...", "I'm based in ..."), not bare "I'm".
+# Interrogatives and quoted spans are stripped before matching in
+# _detect_storable_content() so a question or a quote that merely *contains*
+# these tokens does not trigger the expensive store path.
 _STORABLE_RE = re.compile(
     r'\b(?:'
     r'(?:i|my|we)\s+(?:prefer|like|dislike|hate|love|use|always|never|want)\b'
     r'|(?:i|my)\s+(?:name|email|phone|address|birthday|age|job|role|team)\s+(?:is|are)\b'
-    r"|(?:i(?:'m|\s+am)\s+)"
+    r"|i(?:'m|\s+am)\s+(?:a|an|the|using|on|in|at|based|from|currently|now|working|building)\b"
     r'|(?:we|i)\s+(?:decided|agreed|committed|chose|picked)\b'
-    r'|(?:actually|no|wrong|correction|not\s+right|instead)\b'
+    r"|(?:actually|instead|correction)\b[^?]*?\b(?:i|my|we|it(?:'s|\s+is)|that(?:'s|\s+is))\b"
+    r"|(?:that(?:'s|\s+is)|it(?:'s|\s+is)|you(?:'re|\s+are))\s+(?:wrong|not\s+right|incorrect)\b"
     r'|(?:remember\s+(?:that|this|to))\b'
     r'|(?:from\s+now\s+on|always\s+do|never\s+do|every\s+session)\b'
     r'|(?:my\s+(?:favorite|preferred|usual|default))\b'
     r')',
+    re.IGNORECASE,
+)
+
+# Strips double/single-quoted spans so a quoted token inside an otherwise
+# non-storable prompt cannot trigger the store path (issue #635, M-40).
+_QUOTED_SPAN_RE = re.compile(r'"[^"]*"' r"|'[^']*'" r'|`[^`]*`')
+
+# Prompts that OPEN with a question word are interrogatives (asks), even when
+# they lack a trailing "?" ("do you prefer tabs", "what is my default")
+# (issue #635, M-40).
+_INTERROGATIVE_RE = re.compile(
+    r'^(?:do|does|did|can|could|would|will|are|is|was|were|have|has|'
+    r'what|who|when|where|why|how|which)\b',
     re.IGNORECASE,
 )
 
@@ -207,7 +248,7 @@ def _get_intensity_config() -> tuple[str, str]:
 
 def _get_prompt_count(session_id: str) -> int:
     """Read the prompt counter for a session."""
-    safe_id = "".join(c for c in session_id if c.isalnum() or c in "-_")[:64] or "unknown"
+    safe_id = _safe_session_id_local(session_id)
     counter_file = _PROMPT_COUNTER_DIR / f"{safe_id}.count"
     try:
         if counter_file.exists():
@@ -218,25 +259,94 @@ def _get_prompt_count(session_id: str) -> int:
 
 
 def _increment_prompt_count(session_id: str) -> int:
-    """Increment and return the prompt counter for a session."""
-    safe_id = "".join(c for c in session_id if c.isalnum() or c in "-_")[:64] or "unknown"
+    """Increment and return the prompt counter for a session.
+
+    Issue #635 (M-73): the read-modify-write is serialized with ``flock`` so
+    two overlapping hook invocations for the same session cannot both read N
+    and both write N+1 (losing a tick, which would skew the every-5th proactive
+    recall cadence). Falls back to the unlocked path on Windows / lock failure
+    rather than crashing the hook.
+    """
+    safe_id = _safe_session_id_local(session_id)
     counter_file = _PROMPT_COUNTER_DIR / f"{safe_id}.count"
-    count = _get_prompt_count(session_id) + 1
     try:
         _PROMPT_COUNTER_DIR.mkdir(parents=True, exist_ok=True)
-        counter_file.write_text(str(count), encoding="utf-8")
     except OSError:
         pass
-    return count
+
+    if not _HAS_FCNTL:
+        count = _get_prompt_count(session_id) + 1
+        try:
+            counter_file.write_text(str(count), encoding="utf-8")
+        except OSError:
+            pass
+        return count
+
+    fd = -1
+    try:
+        fd = os.open(str(counter_file), os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except OSError:
+            pass
+        try:
+            raw = os.read(fd, 64).decode("utf-8", errors="replace").strip()
+            current = int(raw) if raw else 0
+        except (ValueError, OSError):
+            current = 0
+        count = current + 1
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            os.ftruncate(fd, 0)
+            os.write(fd, str(count).encode("utf-8"))
+        except OSError:
+            pass
+        return count
+    except OSError:
+        # Could not open the counter under lock — fall back to best-effort.
+        count = _get_prompt_count(session_id) + 1
+        try:
+            counter_file.write_text(str(count), encoding="utf-8")
+        except OSError:
+            pass
+        return count
+    finally:
+        if fd >= 0:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            try:
+                os.close(fd)
+            except OSError:
+                pass
 
 
 def _detect_storable_content(prompt: str) -> bool:
-    """Fast heuristic: does the prompt contain content worth storing?"""
+    """Fast heuristic: does the prompt contain content worth storing?
+
+    Issue #635 (M-40): exclude interrogatives and quoted spans before the
+    storable-pattern match. A question ("do you prefer X?") is a recall/ask,
+    not a statement of the user's own preference, and a token that only
+    appears inside a quote ("the docs say 'I'm deprecated'") is not the user
+    asserting a fact. Both used to spuriously trip the expensive store path.
+    """
     if len(prompt) < 15 or len(prompt) > 2000:
         return False
     if _CODE_RE.search(prompt):
         return False
-    return bool(_STORABLE_RE.search(prompt))
+    # Strip quoted spans so a quoted token cannot trigger storage.
+    stripped = _QUOTED_SPAN_RE.sub(" ", prompt)
+    # An interrogative is an ask, not a self-statement: a trailing question
+    # mark, or a prompt that opens with a question word ("do you prefer...",
+    # "what is my..."). We do NOT exclude every _RECALL_RE phrasing here —
+    # "we decided ..." is both a recall cue and a genuine decision worth
+    # storing — so we gate on interrogative *form* only (issue #635, M-40).
+    if stripped.rstrip().endswith("?"):
+        return False
+    if _INTERROGATIVE_RE.match(stripped.lstrip()):
+        return False
+    return bool(_STORABLE_RE.search(stripped))
 
 
 def _check_conversation_depth(session_id: str, prompt: str, window: int = 5) -> bool:
@@ -253,13 +363,16 @@ def _check_conversation_depth(session_id: str, prompt: str, window: int = 5) -> 
     M-17). This means a shallow/first-prompt exchange (no prior on-topic
     history) correctly does NOT fire under "enhanced".
     """
-    safe_id = "".join(c for c in session_id if c.isalnum() or c in "-_")[:64] or "unknown"
-    buffer_file = _PROMPT_COUNTER_DIR.parent / "buffers" / f"{safe_id}.jsonl"
-    if not buffer_file.exists():
-        buffer_file = Path(os.environ.get(
-            "TRUEMEMORY_BUFFER_DIR",
-            str(Path.home() / ".truememory" / "buffers"),
-        )) / f"{safe_id}.jsonl"
+    # Issue #635 (M-73): derive the buffer file from the buffer dir directly.
+    # The previous `_PROMPT_COUNTER_DIR.parent / "buffers"` was wrong whenever
+    # TRUEMEMORY_BUFFER_DIR pointed somewhere other than a ".../buffers" path
+    # (e.g. /custom/dir -> /custom/buffers), so depth never saw the buffer and
+    # "enhanced" silently degraded to never firing. The prompt counter and the
+    # message buffer share one directory (both default to TRUEMEMORY_BUFFER_DIR),
+    # so reading from _PROMPT_COUNTER_DIR points at the same place
+    # buffer_message() writes.
+    safe_id = _safe_session_id_local(session_id)
+    buffer_file = _PROMPT_COUNTER_DIR / f"{safe_id}.jsonl"
     if not buffer_file.exists():
         return False
 
@@ -356,8 +469,24 @@ def _try_per_exchange_store(prompt: str, session_id: str, user_id: str, db_path:
             if not decision.should_encode:
                 return
 
-            # Store the content
-            m.add(content=prompt, user_id=user_id or None)
+            # Issue #635 (M-39): route the actual store through the SAME
+            # dedup-store critical section the Stop pipeline uses, instead of
+            # a bare m.add(). The cheap novelty search above only sees full
+            # search() scores; check_duplicate() runs the authoritative
+            # vector + (optional) LLM dedup against existing memories. Holding
+            # _dedup_store_lock() across the check + add makes the per-exchange
+            # store atomic w.r.t. concurrent Stop-pipeline ingests, so a fact
+            # stored here and later re-extracted (rephrased) by the pipeline is
+            # SKIPped rather than double-stored, and vice versa.
+            from truememory.ingest.dedup import check_duplicate, DedupAction
+            from truememory.ingest.pipeline import _dedup_store_lock
+            with _dedup_store_lock():
+                dedup = check_duplicate(prompt, m, user_id=user_id or "")
+                if dedup.action == DedupAction.ADD:
+                    m.add(content=dedup.fact, user_id=user_id or None)
+                # UPDATE/SKIP: an equivalent memory already exists — the
+                # Stop pipeline owns merge/update semantics, so the
+                # per-exchange path simply declines to double-store.
     except Exception:
         pass  # Never crash the hook
 
@@ -651,10 +780,10 @@ def buffer_message(session_id: str, prompt: str):
     except OSError:
         pass
 
-    # Sanitize session_id to prevent path traversal (e.g., "../../etc/passwd")
-    safe_id = "".join(c for c in session_id if c.isalnum() or c in "-_")[:64]
-    if not safe_id:
-        safe_id = "unknown"
+    # Sanitize session_id to prevent path traversal (e.g., "../../etc/passwd").
+    # Shared helper keeps this name in lockstep with the counter/depth paths
+    # (issue #635, M-73).
+    safe_id = _safe_session_id_local(session_id)
 
     buffer_file = BUFFER_DIR / f"{safe_id}.jsonl"
 


### PR DESCRIPTION
Fixes #635.

All changes in `truememory/ingest/hooks/user_prompt_submit.py` (+ new test). Composes with #634/#636/#657 (per-exchange store, intensity validation, score_space) without regressing them.

## M-39 (P2) — route per-exchange store through the pipeline dedup critical section
The per-exchange store path did a bare `m.add()`, bypassing the pipeline's `_dedup_store_lock` + `check_duplicate`. A fact stored here and later re-extracted (rephrased) by the Stop pipeline got double-stored. Now, after the existing cheap novelty search + encoding gate, the actual store runs inside `_dedup_store_lock()` and calls `check_duplicate()` (the same authoritative vector/LLM dedup the pipeline uses): ADD stores `dedup.fact`, UPDATE/SKIP declines to double-store (the Stop pipeline owns merge semantics). Reuses pipeline helpers rather than duplicating them.

## M-40 (P2) — tighten `_STORABLE_RE` false positives
Replaced bare standalone-word alternations:
- dropped bare `no`;
- `actually`/`instead`/`correction` now only fire when anchored to a following first-person/copula clause, not as standalone discourse markers;
- `I'm` only fires with an identity/state predicate (`I'm a ...`, `I'm using ...`, `I'm based in ...`), not bare `I'm`;
- added `that's/it's/you're wrong|incorrect|not right` as a correction anchor.

`_detect_storable_content()` now strips quoted spans (`"..."`, `'...'`, `` `...` ``) and excludes interrogatives (trailing `?` or opening question word) before matching, so a question or quoted token no longer trips the expensive store path. Existing true-positive cases (preference/decision/fact statements, including `we decided ...`) still fire.

## M-73 (P3) — low-risk cluster
- **Buffer-dir derivation:** `_check_conversation_depth` read `_PROMPT_COUNTER_DIR.parent / "buffers"`, wrong whenever `TRUEMEMORY_BUFFER_DIR` was not a `.../buffers` path, so depth never saw the buffer and `enhanced` silently degraded. Now reads from the buffer dir directly (counter and buffer share one dir).
- **safe_id consistency:** added a single `_safe_session_id_local()` helper used by the buffer, counter, and depth paths so they always derive the same on-disk name (they previously inlined the same expression in three places, risking drift).
- **Counter lock:** `_increment_prompt_count` read-modify-write is now serialized with `flock` so overlapping invocations for one session can't lose a tick (which would skew the every-5th proactive-recall cadence). Falls back to the unlocked path on Windows / lock failure.

### Deferred (per issue scope)
- **Dead MCP intensity helpers** (`mcp_server.py:645-651`): NOT touched — `mcp_server.py` is being edited by other agents. Should be removed in a separate PR.
- **64-char safe_id truncation collision:** not changed. A real fix needs a hash-suffix naming scheme, which would break naming compatibility with existing on-disk buffers/counters and requires a coordinated migration — higher risk than this PR's scope. The names are now at least centralized via `_safe_session_id_local`, making a future scheme change a one-line edit.

## Tests
New `tests/test_issue_635_per_exchange_coordination.py` (model-free, `HF_HUB_OFFLINE=1`, no model loads):
- per-exchange store calls `check_duplicate`, stores exactly one row on ADD, stores nothing on SKIP, and runs inside `_dedup_store_lock`;
- `_STORABLE_RE`/`_detect_storable_content` does NOT fire on bare `no`, questions, or quoted text, DOES fire on genuine preference/fact/decision statements, and bare `I'm` is filler;
- depth reads from a custom `TRUEMEMORY_BUFFER_DIR`; counter increments monotonically.

All 56 tests across #634/#635/#636 pass; targeted run (`-k "per_exchange or storable or dedup or buffer or counter or intensity"`) 161 passed. `ruff check truememory/ tests/` clean.