### PR TITLE
fix: vec compatibility surfacing — dim check on open, propagate migration error, gate clustering/HyDE, tier-switch guards (#648)

### DIFF
--- a/tests/test_issue_648_vec_compat.py
+++ b/tests/test_issue_648_vec_compat.py
@@ -1,0 +1,279 @@
+"""Regression tests for issue #648 (theme T6): vec compatibility surfacing +
+tier-switch guards.
+
+Covers:
+  - M-12: a dim-mismatched vec table surfaces degradation in health
+    (``_vectors_load_error`` set + stats.health reflects it) instead of a
+    permanent silent FTS-only fallback.
+  - M-46: ``TrueMemoryMigrationError`` propagates from the vec-load path
+    instead of being swallowed as a generic "FTS-only mode" error.
+  - M-78: cluster-supplement is gated on live vector health, so a
+    same-dim/different-model DB does not compare query embeddings to stale
+    centroids.
+  - M-23: the tier-switch vec load is guarded — a sqlite without
+    ``enable_load_extension`` raises a typed, actionable error rather than a
+    raw ``AttributeError``.
+  - M-51: a ``start_rebuild`` failure before the worker thread starts does NOT
+    brick subsequent rebuilds (``_active_thread`` is not left pointing at the
+    long-lived caller thread).
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import requires_sqlite_ext
+
+
+@pytest.fixture(autouse=True)
+def _reset_vectors_load_error():
+    """``_vectors_load_error`` is module-global; reset around each test so the
+    health assertions are not polluted by sibling tests."""
+    import truememory.engine as eng
+    prev = eng._vectors_load_error
+    eng._vectors_load_error = None
+    try:
+        yield
+    finally:
+        eng._vectors_load_error = prev
+
+
+def _load_vec(conn: sqlite3.Connection) -> None:
+    import sqlite_vec
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+
+
+def _make_mismatched_db(path: str, wrong_dim: int) -> None:
+    """Create a DB whose vec_messages table declares ``wrong_dim`` (!= the
+    current embedder dim) plus matching metadata, simulating a tier change
+    that left an incompatible vector table behind."""
+    from truememory.storage import create_db
+    import truememory.vector_search as vs
+
+    conn = create_db(path)
+    _load_vec(conn)
+    conn.execute(
+        f"CREATE VIRTUAL TABLE IF NOT EXISTS vec_messages "
+        f"USING vec0({vs._vec0_column_decl(wrong_dim)})"
+    )
+    # Insert a row so vectors_are_built() / SELECT 1 succeeds (table is "built").
+    conn.execute(
+        "INSERT INTO vec_messages(rowid, embedding) VALUES (1, ?)",
+        (sqlite3.Binary(b"\x00\x00\x80\x3f" * wrong_dim),),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata(key, value) VALUES ('embed_model', ?)",
+        ("legacy_model_1024",),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata(key, value) VALUES ('embed_dim', ?)",
+        (str(wrong_dim),),
+    )
+    conn.commit()
+    conn.close()
+
+
+@requires_sqlite_ext
+class TestM12HealthSurfacing:
+    """Dim mismatch must surface in health, not silently drop to FTS-only."""
+
+    def test_open_exists_path_surfaces_dim_mismatch(self, tmp_path):
+        import truememory.vector_search as vs
+        from truememory.engine import TrueMemoryEngine, get_vectors_load_error
+        from truememory.vector_search import TrueMemoryMigrationError
+
+        wrong_dim = vs._embedding_dim + 256  # guaranteed mismatch
+        db = tmp_path / "mismatch.db"
+        _make_mismatched_db(str(db), wrong_dim)
+
+        eng = TrueMemoryEngine(str(db))
+        # The exists-path now runs _check_embedder_compatibility() instead of
+        # trusting a bare SELECT 1, so a mismatch raises the migration error.
+        with pytest.raises(TrueMemoryMigrationError):
+            eng.open(rebuild_vectors=False)
+
+        # Degradation is recorded so truememory_stats.health reports it rather
+        # than claiming vectors are healthy.
+        err = get_vectors_load_error()
+        assert err is not None
+        assert "TrueMemoryMigrationError" in err
+        assert eng._has_vectors is False
+
+    def test_health_payload_reports_degraded(self, tmp_path):
+        import truememory.vector_search as vs
+        from truememory.engine import TrueMemoryEngine
+        from truememory.vector_search import TrueMemoryMigrationError
+
+        wrong_dim = vs._embedding_dim + 256
+        db = tmp_path / "mismatch2.db"
+        _make_mismatched_db(str(db), wrong_dim)
+
+        eng = TrueMemoryEngine(str(db))
+        with pytest.raises(TrueMemoryMigrationError):
+            eng.open(rebuild_vectors=False)
+
+        from truememory.mcp_server import _build_health_payload
+        payload = _build_health_payload()
+        assert payload["vectors"]["status"] == "degraded"
+        assert payload["vectors"]["last_error"] is not None
+
+
+@requires_sqlite_ext
+class TestM46MigrationErrorPropagates:
+    """TrueMemoryMigrationError must not be swallowed as a generic FTS error."""
+
+    def test_ensure_connection_propagates_migration_error(self, tmp_path):
+        import truememory.vector_search as vs
+        from truememory.engine import TrueMemoryEngine
+        from truememory.vector_search import TrueMemoryMigrationError
+
+        wrong_dim = vs._embedding_dim + 256
+        db = tmp_path / "ensure.db"
+        _make_mismatched_db(str(db), wrong_dim)
+
+        eng = TrueMemoryEngine(str(db))
+        # _ensure_connection() → init_vec_table() → _check_embedder_compatibility()
+        # raises; the new typed except clause re-raises instead of logging it as
+        # "Failed to load sqlite-vec — FTS-only mode".
+        with pytest.raises(TrueMemoryMigrationError):
+            eng._ensure_connection()
+
+    def test_ensure_connection_generic_error_still_fts_only(self, tmp_path):
+        """A non-migration failure during vec init still degrades gracefully to
+        FTS-only (regression guard: we only special-cased the migration error)."""
+        from truememory.engine import TrueMemoryEngine
+
+        db = tmp_path / "generic.db"
+        eng = TrueMemoryEngine(str(db))
+        with patch(
+            "truememory.engine.init_vec_table",
+            side_effect=RuntimeError("boom — not a migration"),
+        ):
+            # Must not raise: generic failures keep the FTS-only fallback.
+            eng._ensure_connection()
+        assert eng._has_vectors is False
+
+
+@requires_sqlite_ext
+class TestM78ClusterGate:
+    """Cluster-supplement must be skipped when vectors are unavailable."""
+
+    def test_clustering_skipped_when_no_vectors(self, tmp_path):
+        from truememory.engine import TrueMemoryEngine
+
+        db = tmp_path / "cluster.db"
+        eng = TrueMemoryEngine(str(db))
+        eng._ensure_connection()
+
+        # Simulate a same-dim/different-model DB where the clusters table exists
+        # but vectors are not trustworthy.
+        eng._has_clustering = True
+        eng._has_vectors = False
+
+        called = {"clustered": False}
+
+        def _fake_clustered(*a, **k):
+            called["clustered"] = True
+            return []
+
+        with patch("truememory.engine.search_clustered", _fake_clustered):
+            eng.search_agentic(
+                "anything", limit=3, use_hyde=False, use_reranker=False,
+                use_clustering=True, llm_fn=None,
+            )
+
+        assert called["clustered"] is False, (
+            "cluster-supplement ran against stale centroids despite "
+            "_has_vectors=False"
+        )
+
+
+class TestM23TierSwitchGuard:
+    """_open_db must raise a typed error (not AttributeError) when the sqlite
+    cannot load extensions."""
+
+    def test_open_db_no_extension_raises_typed_error(self, tmp_path):
+        from truememory.tier_switch.manager import (
+            _open_db,
+            TierSwitchUnsupportedError,
+        )
+
+        db = tmp_path / "noext.db"
+
+        # Simulate macOS system Python: enable_load_extension absent.
+        class _NoExtConn:
+            def __init__(self, real):
+                self._real = real
+
+            def execute(self, *a, **k):
+                return self._real.execute(*a, **k)
+
+            def close(self):
+                return self._real.close()
+
+            def __getattr__(self, name):
+                if name == "enable_load_extension":
+                    raise AttributeError(
+                        "'sqlite3.Connection' object has no attribute "
+                        "'enable_load_extension'"
+                    )
+                return getattr(self._real, name)
+
+        real = sqlite3.connect(str(db))
+        with patch("sqlite3.connect", return_value=_NoExtConn(real)):
+            with pytest.raises(TierSwitchUnsupportedError) as exc:
+                _open_db(db)
+        # Actionable platform guidance, not a raw AttributeError.
+        assert "sqlite-vec" in str(exc.value)
+        assert "extension" in str(exc.value).lower()
+
+
+class TestM51StartRebuildNotBricked:
+    """A pre-thread failure in start_rebuild must not brick later rebuilds."""
+
+    def test_pre_thread_failure_does_not_brick(self):
+        from truememory.tier_switch.manager import (
+            RebuildManager,
+            TierSwitchUnsupportedError,
+        )
+
+        mgr = RebuildManager()
+
+        # First call: _open_db fails before the worker thread starts (M-23).
+        with patch(
+            "truememory.tier_switch.manager._open_db",
+            side_effect=TierSwitchUnsupportedError("no vec on this python"),
+        ):
+            with pytest.raises(TierSwitchUnsupportedError):
+                mgr.start_rebuild("base", db_path=None)
+
+        # The slot must be free: _active_thread not left pointing at the
+        # long-lived caller thread, and the claim flag cleared.
+        assert mgr._claimed is False
+        assert not (mgr._active_thread and mgr._active_thread.is_alive()), (
+            "start_rebuild left _active_thread alive after a pre-thread "
+            "failure — subsequent rebuilds would be permanently no-op'd"
+        )
+        assert mgr._active_thread is not threading.current_thread()
+
+        # Second call reaches _open_db again (proves it is not short-circuited).
+        reached = {"open_db": False}
+
+        def _fail_again(*a, **k):
+            reached["open_db"] = True
+            raise TierSwitchUnsupportedError("still no vec")
+
+        with patch(
+            "truememory.tier_switch.manager._open_db", side_effect=_fail_again
+        ):
+            with pytest.raises(TierSwitchUnsupportedError):
+                mgr.start_rebuild("base", db_path=None)
+
+        assert reached["open_db"] is True, (
+            "second start_rebuild was short-circuited — manager is bricked"
+        )

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -386,12 +386,20 @@ class TrueMemoryEngine:
             self.conn = create_db(self.db_path)
 
             # Load sqlite-vec extension
+            global _vectors_load_error
             if _HAS_VECTOR:
                 try:
                     import sqlite_vec
                     self.conn.enable_load_extension(True)
                     sqlite_vec.load(self.conn)
                     self.conn.enable_load_extension(False)
+                    # init_vec_table() runs _check_embedder_compatibility(),
+                    # which raises TrueMemoryMigrationError on a dim/model
+                    # mismatch. That must NOT be swallowed as a generic
+                    # FTS-only fallback (M-12/M-46): a silent drop to FTS hides
+                    # the degradation from truememory_stats.health and lets
+                    # add() silently fail vec INSERTs. Surface the migration
+                    # guidance so the user can re-embed instead.
                     init_vec_table(self.conn)
                     try:
                         from truememory.vector_search import migrate_legacy_vec_tables
@@ -399,8 +407,14 @@ class TrueMemoryEngine:
                     except Exception:
                         logger.debug("Legacy vec table migration skipped", exc_info=True)
                     self._has_vectors = True
+                except TrueMemoryMigrationError as exc:
+                    # M-12/M-46: record the degradation in module state so
+                    # health surfaces it, then propagate the actionable
+                    # migration guidance instead of falling back to FTS-only.
+                    _vectors_load_error = f"{type(exc).__name__}: {exc}"
+                    self._has_vectors = False
+                    raise
                 except Exception as exc:
-                    global _vectors_load_error
                     _vectors_load_error = f"{type(exc).__name__}: {exc}"
                     logger.warning("Failed to load sqlite-vec — FTS-only mode: %s", exc)
                     self._has_vectors = False
@@ -1304,6 +1318,7 @@ class TrueMemoryEngine:
         if _HAS_VECTOR:
             from truememory.vector_search import (
                 _active_vec_table,
+                _check_embedder_compatibility,
                 vectors_are_built,
             )
             vec_tbl = _active_vec_table(self.conn)
@@ -1311,7 +1326,21 @@ class TrueMemoryEngine:
             # by an interrupted build (issue #647) — so a partial/empty table is
             # rebuilt rather than trusted, not just one that's missing.
             if vectors_are_built(self.conn, vec_tbl):
-                self._has_vectors = True
+                # M-12: the exists-path previously trusted the table on a bare
+                # SELECT 1 and never checked embedder/dim compatibility. A dim
+                # mismatch then surfaced only as a per-query OperationalError
+                # caught at DEBUG → permanent silent FTS-only with
+                # _vectors_load_error=None (health reports vectors healthy) and
+                # silent vec-INSERT failures in add(). Run the compatibility
+                # check here so a mismatch surfaces as actionable migration
+                # guidance instead.
+                try:
+                    _check_embedder_compatibility(self.conn)
+                    self._has_vectors = True
+                except TrueMemoryMigrationError as exc:
+                    _vectors_load_error = f"{type(exc).__name__}: {exc}"
+                    self._has_vectors = False
+                    raise
             else:
                 logger.warning(
                     "Vector table %r missing or unreadable; attempting rebuild "
@@ -2142,7 +2171,14 @@ class TrueMemoryEngine:
         # than RRF scores; we normalize them independently and tag each
         # result with its diversity position so downstream sorts can
         # preserve the cluster-sampling order.
-        if use_clustering and self._has_clustering:
+        # M-78: gate cluster-supplement on live vector health. _has_clustering
+        # only reflects that the message_clusters table exists — not that the
+        # current embedder matches the centroids. With a same-dim/different-
+        # model DB the table reads fine but query embeddings live in a
+        # different vector space, so comparing them to stale centroids yields
+        # garbage ``+cluster_supp`` similarities. Skip when vectors are
+        # unavailable rather than surfacing misleading matches.
+        if use_clustering and self._has_clustering and self._has_vectors:
             try:
                 cluster_results = search_clustered(
                     self.conn, query, limit=limit, top_clusters=3,

--- a/truememory/tier_switch/manager.py
+++ b/truememory/tier_switch/manager.py
@@ -31,6 +31,11 @@ _TRUEMEMORY_DIR = Path.home() / ".truememory"
 _LOCK_PATH = _TRUEMEMORY_DIR / "rebuild.lock"
 
 
+class TierSwitchUnsupportedError(RuntimeError):
+    """Raised when a tier switch cannot proceed because the sqlite-vec
+    extension cannot be loaded on this platform/Python (M-23)."""
+
+
 def _detect_device() -> str:
     """Detect the best available compute device."""
     try:
@@ -60,10 +65,27 @@ def _open_db(db_path: Path | None = None) -> sqlite3.Connection:
     conn.execute("PRAGMA foreign_keys=ON")
     conn.execute("PRAGMA synchronous=NORMAL")
 
-    import sqlite_vec
-    conn.enable_load_extension(True)
-    sqlite_vec.load(conn)
-    conn.enable_load_extension(False)
+    # M-23: guard the sqlite-vec load. On macOS system Python (and any build
+    # compiled without SQLITE_ENABLE_LOAD_EXTENSION) ``enable_load_extension``
+    # is absent → bare access raised AttributeError, crashing the tier switch
+    # (reached from truememory_configure, the CLI upgrade-tier path, and a
+    # background thread that swallowed it). A tier switch is meaningless
+    # without vec support, so fail with actionable platform guidance instead.
+    try:
+        import sqlite_vec
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+    except (AttributeError, ImportError, OSError, sqlite3.OperationalError) as exc:
+        conn.close()
+        raise TierSwitchUnsupportedError(
+            "Tier switching requires the sqlite-vec extension, but this "
+            "Python's sqlite3 cannot load it "
+            f"({type(exc).__name__}: {exc}). This commonly happens with the "
+            "macOS system Python, which is built without "
+            "SQLITE_ENABLE_LOAD_EXTENSION. Install a Python with extension "
+            "support (e.g. python.org, Homebrew, or pyenv) and retry."
+        ) from exc
 
     return conn
 
@@ -85,6 +107,10 @@ class RebuildManager:
     def __init__(self):
         self._active_worker: RebuildWorker | None = None
         self._active_thread: threading.Thread | None = None
+        # M-51: True while start_rebuild() is mid-preflight (before the worker
+        # Thread exists) so a concurrent call can't double-start, yet a
+        # pre-thread failure clears it instead of bricking the manager.
+        self._claimed: bool = False
         self._active_status_id: int = 0
         self._state_lock = threading.Lock()
 
@@ -99,47 +125,67 @@ class RebuildManager:
 
         Returns a status_id for progress queries.
         """
+        # M-51: reserve the slot with a claim flag rather than parking the
+        # long-lived MCP caller thread in ``_active_thread``. Previously a raise
+        # in any pre-thread step below (e.g. M-23 in _open_db, preflight) left
+        # ``_active_thread = current_thread()`` set; since that thread stays
+        # alive for the process lifetime, ``is_alive()`` was permanently True
+        # and every subsequent start_rebuild no-op'd — bricking tier switching.
+        # Only the real worker Thread should occupy the slot; release the claim
+        # on any pre-thread failure.
         with self._state_lock:
             if self._active_thread and self._active_thread.is_alive():
                 return self._active_status_id
-            self._active_thread = threading.current_thread()
+            if self._claimed:
+                return self._active_status_id
+            self._claimed = True
 
-        conn = _open_db(db_path)
-        to_group = tier_group(target_tier)
+        try:
+            conn = _open_db(db_path)
+            to_group = tier_group(target_tier)
 
-        ok, msg = preflight_ram_check(to_group)
-        if not ok:
+            ok, msg = preflight_ram_check(to_group)
+            if not ok:
+                conn.close()
+                raise RuntimeError(msg)
+
+            action = resolve_rebuild_action(conn, to_group, force)
+            messages, is_full = get_messages_to_embed(conn, to_group, force)
+
+            if not messages and not is_full:
+                self._apply_config_switch(target_tier, conn)
+                conn.close()
+                with self._state_lock:
+                    self._claimed = False
+                return 0
+
+            status_id = self._create_status_row(
+                conn, to_group, target_tier, action, len(messages),
+            )
+            self._active_status_id = status_id
+
+            if backup_path is None and is_full:
+                backup_path = backup_db(db_path)
+
             conn.close()
-            raise RuntimeError(msg)
 
-        action = resolve_rebuild_action(conn, to_group, force)
-        messages, is_full = get_messages_to_embed(conn, to_group, force)
-
-        if not messages and not is_full:
-            self._apply_config_switch(target_tier, conn)
-            conn.close()
-            return 0
-
-        status_id = self._create_status_row(
-            conn, to_group, target_tier, action, len(messages),
-        )
-        self._active_status_id = status_id
-
-        if backup_path is None and is_full:
-            backup_path = backup_db(db_path)
-
-        conn.close()
-
-        thread = threading.Thread(
-            target=self._rebuild_thread,
-            args=(target_tier, to_group, messages, is_full, status_id,
-                  backup_path, db_path),
-            daemon=True,
-            name=f"tier-switch-{to_group}",
-        )
-        with self._state_lock:
-            self._active_thread = thread
-        thread.start()
+            thread = threading.Thread(
+                target=self._rebuild_thread,
+                args=(target_tier, to_group, messages, is_full, status_id,
+                      backup_path, db_path),
+                daemon=True,
+                name=f"tier-switch-{to_group}",
+            )
+            with self._state_lock:
+                self._active_thread = thread
+                self._claimed = False
+            thread.start()
+        except BaseException:
+            # Pre-thread failure: release the claim so the next call can retry.
+            # The worker Thread never started, so it never occupied the slot.
+            with self._state_lock:
+                self._claimed = False
+            raise
 
         return status_id
 


### PR DESCRIPTION
Fixes #648. Vec compatibility surfacing + tier-switch guards (theme T6). Composes with the cosine migration / build-state marker / quick_check already landed (#631/#647/#650). Touches only `engine.py`, `tier_switch/manager.py`, and a new test file (`vector_search.py` already had the needed `_check_embedder_compatibility` helper, so no edit there).

### M-12 (P1) — dim mismatch now surfaces in health
The `open()` exists-path trusted the vec table on a bare `SELECT 1` and never checked embedder/dim compatibility. A dim mismatch then showed up only as a per-query `OperationalError` caught at DEBUG → permanent silent FTS-only, with `_vectors_load_error` left `None` (so `truememory_stats.health` reported vectors healthy) and silent vec-INSERT failures in `add()`. Both the `open()` exists-path and `_ensure_connection` now run `_check_embedder_compatibility`, set `_vectors_load_error`, and raise so health reports `degraded`.

### M-46 (P2) — migration error propagates
`_ensure_connection`'s catch-all swallowed `TrueMemoryMigrationError` as the generic "Failed to load sqlite-vec — FTS-only mode". Added `except TrueMemoryMigrationError: raise` (recording `_vectors_load_error` first) before the generic handler, so the actionable re-embed guidance reaches the user. Non-migration failures still degrade to FTS-only.

### M-78 (P3) — clustering gated on vector health
`search_agentic` ran cluster-supplement on `_has_clustering` alone — which only means the `message_clusters` table exists. With a same-dim/different-model DB that yields garbage `+cluster_supp` similarities (query embeddings vs stale centroids). Now gated on `self._has_vectors`. HyDE was already gated via `_has_hybrid` (= `_HAS_HYBRID and _has_vectors`).

### M-23 (P1) — tier-switch vec load guarded
`tier_switch/manager._open_db` did a bare `enable_load_extension`/`sqlite_vec.load` → raw `AttributeError` on macOS system Python (reached from `truememory_configure`, CLI upgrade-tier, and a swallowing background thread). Now wrapped; raises typed `TierSwitchUnsupportedError` with platform guidance.

### M-51 (P2) — start_rebuild no longer bricks on pre-thread failure
`start_rebuild` set `_active_thread = current_thread()` (the long-lived MCP thread) before preflight; any raise (e.g. M-23) left it set, and since that thread stays alive `is_alive()` was permanently True → every later call no-op'd. Now a `_claimed` flag reserves the slot during preflight and is released on any pre-thread failure; only the real worker `Thread` occupies `_active_thread`.

### Tests — `tests/test_issue_648_vec_compat.py` (7, all pass)
(a) dim-mismatched vec table surfaces degradation in health (`_vectors_load_error` set + `_build_health_payload` reports `degraded`) on the open() path; (b) `TrueMemoryMigrationError` propagates from `_ensure_connection` (and generic errors still fall back to FTS-only); (c) clustering skipped when `_has_vectors=False`; (d) `_open_db` raises typed `TierSwitchUnsupportedError` (no raw AttributeError) on a no-extension sqlite; (e) `start_rebuild` pre-thread failure leaves `_claimed=False` / `_active_thread` not alive and a second call still reaches `_open_db`. Vec-dependent tests gated with `requires_sqlite_ext`; constructed vectors by hand, `HF_HUB_OFFLINE=1`, no model loads.

`ruff check truememory/ tests/` passes. Targeted suite (`-k "vec or compat or tier_switch or migrat or health or cluster or hyde or ensure_connection"`): 150 passed; 2 failures are env-only HF-offline model-download fails (`test_issue_654_real_vector_smoke`, `test_upgrade_path`) unrelated to this change.
