### PR TITLE
fix: input/platform mop-up — create_db type guard + .gitignore, store cap, transcript validation, misc (#653)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,20 @@ benchmarks/gate_eval/run_weight_threshold_sweep.py
 benchmarks/locomo/results/truememory_pro_v3_modal.json
 benchmarks/locomo/scripts/modal_benchmark.py
 benchmarks/longmemeval/data/*.json
+
+# M-33: stray DB files from a Connection object stringified into a path
+# (e.g. `<sqlite3.Connection object at 0x10abc>`). Now guarded in code; ignore
+# any that pre-date the fix so they can never be committed.
+<sqlite3.Connection object*
+
+# DB backups + migration artifacts — never commit
+*.db.backup-*
+*.db.backup-pre-migration-*
+truememory.db.backup-*
+
+# Build/loop scratch docs — local only, never commit
+BUILD_PROMPT*.md
+DRAIN_REPORT*.md
+
+# M-96: orphan dashboard build (17MB node_modules) — never tracked, never commit
+truememory/dashboard/

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -109,9 +109,17 @@ class TestEdgeCaseInputs:
         eng.close()
 
     def test_very_long_content_add(self):
+        # Issue #653 (M-60): Engine.add enforces a 50KB content cap so all
+        # entry points (client/hook/library) are protected from poison-large
+        # rows, not just the MCP layer. Oversized content must raise cleanly.
         eng, td = _make_engine()
-        long_content = "x" * 100_000
-        result = eng.add(content=long_content, sender="alice")
+        from truememory.engine import MAX_CONTENT_LENGTH
+
+        with pytest.raises(ValueError, match="too large"):
+            eng.add(content="x" * 100_000, sender="alice")
+
+        # Content right at the cap is still accepted.
+        result = eng.add(content="x" * MAX_CONTENT_LENGTH, sender="alice")
         assert result is not None
         eng.close()
 

--- a/tests/test_issue_653_input_mopup.py
+++ b/tests/test_issue_653_input_mopup.py
@@ -1,0 +1,174 @@
+"""Regression locks for issue #653 — input/platform mop-up.
+
+Covers:
+- M-33: create_db() rejects a non-path object (e.g. a sqlite3.Connection)
+  with TypeError instead of stringifying it into a stray file.
+- M-60: Engine.add() enforces the 50KB content cap at the engine level.
+- M-90: a transcript_path outside the expected transcripts root is rejected
+  by the compact hook (never read into the store).
+- M-95: the compact hook tolerates non-string stdin fields (int session_id /
+  transcript_path) without raising TypeError.
+- M-70: empty-timestamp rows are excluded by the temporal filter.
+- M-97: the param-safety shim matches context-window-suffixed IDs like
+  ``claude-fable-5[1m]``.
+
+All tests use tmp dirs and never load models (HF_HUB_OFFLINE handled by the
+suite). No network, no embeddings required for the assertions.
+"""
+from __future__ import annotations
+
+import io
+import os
+import sqlite3
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# M-33 — create_db type guard
+# ---------------------------------------------------------------------------
+
+def test_create_db_rejects_connection_object(tmp_path):
+    from truememory.storage import create_db
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        with pytest.raises(TypeError):
+            create_db(conn)
+    finally:
+        conn.close()
+
+    # No stray "<sqlite3.Connection object at 0x...>" file was created.
+    strays = [p for p in os.listdir(".") if p.startswith("<sqlite3.Connection")]
+    assert not strays, f"stray connection file(s) created: {strays}"
+
+
+def test_create_db_accepts_str_and_pathlike(tmp_path):
+    from truememory.storage import create_db
+
+    p = tmp_path / "ok.db"
+    conn = create_db(str(p))
+    conn.close()
+    conn2 = create_db(p)  # PathLike
+    conn2.close()
+    assert p.exists()
+
+
+# ---------------------------------------------------------------------------
+# M-60 — Engine.add content cap
+# ---------------------------------------------------------------------------
+
+def test_engine_add_rejects_oversize_content(tmp_path):
+    from truememory.engine import TrueMemoryEngine, MAX_CONTENT_LENGTH
+
+    eng = TrueMemoryEngine(db_path=str(tmp_path / "m.db"))
+    big = "x" * (MAX_CONTENT_LENGTH + 1)
+    with pytest.raises(ValueError):
+        eng.add(content=big)
+
+
+def test_engine_add_accepts_boundary_content(tmp_path):
+    from truememory.engine import TrueMemoryEngine, MAX_CONTENT_LENGTH
+
+    eng = TrueMemoryEngine(db_path=str(tmp_path / "m.db"))
+    ok = "y" * MAX_CONTENT_LENGTH
+    res = eng.add(content=ok)
+    assert res.get("id")
+
+
+# ---------------------------------------------------------------------------
+# M-90 / M-95 — compact hook transcript validation + non-string stdin
+# ---------------------------------------------------------------------------
+
+def test_compact_rejects_transcript_outside_root(tmp_path, monkeypatch):
+    from truememory.ingest.hooks import compact
+
+    # An attacker-chosen file outside the transcripts root.
+    evil = tmp_path / "secret.txt"
+    evil.write_text("password=hunter2", encoding="utf-8")
+    # Point the root somewhere else entirely.
+    monkeypatch.setenv("TRUEMEMORY_TRANSCRIPT_DIR", str(tmp_path / "allowed"))
+    assert compact._is_allowed_transcript(str(evil)) is False
+
+
+def test_compact_allows_transcript_inside_root(tmp_path, monkeypatch):
+    from truememory.ingest.hooks import compact
+
+    root = tmp_path / "allowed"
+    root.mkdir()
+    good = root / "t.jsonl"
+    good.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("TRUEMEMORY_TRANSCRIPT_DIR", str(root))
+    assert compact._is_allowed_transcript(str(good)) is True
+
+
+def test_compact_hook_tolerates_non_string_stdin(monkeypatch):
+    from truememory.ingest.hooks import compact
+
+    # int session_id and transcript_path would crash a naive str/Path op.
+    payload = '{"session_id": 12345, "transcript_path": 67890}'
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+    # Must not raise TypeError; non-existent transcript path -> early return.
+    compact.main()
+
+
+# ---------------------------------------------------------------------------
+# M-70 — empty-timestamp rows excluded by temporal filter
+# ---------------------------------------------------------------------------
+
+def test_temporal_filter_excludes_empty_timestamp(tmp_path):
+    from truememory.storage import create_db, insert_message
+    from truememory.fts_search import search_fts_in_range
+
+    conn = create_db(str(tmp_path / "fts.db"))
+    try:
+        insert_message(conn, {
+            "content": "alpha widget report",
+            "sender": "u", "recipient": "", "timestamp": "2026-01-15",
+            "category": "", "modality": "", "directive": False, "metadata": None,
+        })
+        insert_message(conn, {
+            "content": "alpha widget summary",
+            "sender": "u", "recipient": "", "timestamp": "",
+            "category": "", "modality": "", "directive": False, "metadata": None,
+        })
+        conn.commit()
+
+        # Upper-bound-only filter: the empty-timestamp row must NOT pass.
+        out = search_fts_in_range(conn, "alpha", after=None, before="2026-12-31")
+        ts = [r["timestamp"] for r in out]
+        assert "" not in ts, f"empty-timestamp row leaked through: {ts}"
+        assert "2026-01-15" in ts
+
+        # Lower-bound-only filter: still excluded.
+        out2 = search_fts_in_range(conn, "alpha", after="2026-01-01", before=None)
+        assert "" not in [r["timestamp"] for r in out2]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# M-97 — param shim matches context-window-suffixed model IDs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("model_id", [
+    "claude-fable-5[1m]",
+    "claude-fable-5",
+    "claude-fable-5-20260101",
+    "anthropic/claude-fable-5[1m]",
+    "claude-opus-4-8[1m]",
+])
+def test_param_shim_strips_for_strict_models(model_id):
+    from truememory.ingest.models import sanitize_model_params
+
+    out = sanitize_model_params(model_id, {"temperature": 0.5, "top_p": 0.9})
+    assert "temperature" not in out
+    assert "top_p" not in out
+
+
+def test_param_shim_passthrough_for_other_models():
+    from truememory.ingest.models import sanitize_model_params
+
+    out = sanitize_model_params("gpt-4o-mini", {"temperature": 0.5})
+    assert out.get("temperature") == 0.5

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -66,6 +66,10 @@ _ALLOWED_COLUMNS = frozenset({
 
 _SQLITE_IN_CHUNK = 500
 
+# M-60: maximum stored content length (chars). Enforced in Engine.add so every
+# entry point inherits the cap. Kept in sync with mcp_server's value.
+MAX_CONTENT_LENGTH = 50_000
+
 
 def _resolve_vec_tables(conn: sqlite3.Connection) -> tuple[str, str]:
     """Resolve the active tier's (vec, sep) table names for delete/update.
@@ -381,7 +385,12 @@ class TrueMemoryEngine:
             # Create parent directory if using a real path
             db_str = str(self.db_path)
             if db_str != ":memory:":
+                # M-89: the DB dir holds real memories/PII — owner-only (0700).
                 self.db_path.parent.mkdir(parents=True, exist_ok=True)
+                try:
+                    self.db_path.parent.chmod(0o700)
+                except OSError:
+                    pass
 
             self.conn = create_db(self.db_path)
 
@@ -679,6 +688,16 @@ class TrueMemoryEngine:
         """
         if not isinstance(content, str):
             raise TypeError(f"content must be a string, got {type(content).__name__}")
+
+        # M-60: enforce the store size cap at the engine level so ALL entry
+        # points (client.add, hooks, direct Engine.add) inherit it — not just
+        # mcp_server. Unbounded content means unbounded embed latency and
+        # poison-large rows. Mirror the mcp_server limit.
+        if len(content) > MAX_CONTENT_LENGTH:
+            raise ValueError(
+                f"Content too large ({len(content)} chars). "
+                f"Maximum is {MAX_CONTENT_LENGTH}."
+            )
 
         self._ensure_connection()
 
@@ -1246,7 +1265,10 @@ class TrueMemoryEngine:
         if not self.db_path.exists():
             raise FileNotFoundError(f"Database not found: {self.db_path}")
 
-        self.conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        from truememory.storage import _validate_db_path
+        self.conn = sqlite3.connect(
+            _validate_db_path(self.db_path), check_same_thread=False
+        )
         self.conn.row_factory = None  # Use default tuple rows
         self.conn.execute("PRAGMA journal_mode=WAL")
         self.conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")

--- a/truememory/fts_search.py
+++ b/truememory/fts_search.py
@@ -256,6 +256,12 @@ def search_fts_in_range(
     after = _validate_iso_date(after)
     before = _validate_iso_date(before)
 
+    # M-70: empty-timestamp rows have no comparable date. ``"" < before`` is
+    # True and ``"" >= after`` is False, so an upper-bound-only filter would
+    # silently let them through. Drop them uniformly whenever any temporal
+    # bound is active.
+    if after is not None or before is not None:
+        results = [r for r in results if r["timestamp"]]
     if after is not None:
         results = [r for r in results if r["timestamp"] >= after]
     if before is not None:

--- a/truememory/ingest/hooks/compact.py
+++ b/truememory/ingest/hooks/compact.py
@@ -29,6 +29,41 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 
+def _transcript_roots() -> list[Path]:
+    """Directories a transcript_path is allowed to live under (M-90).
+
+    Defaults to Claude Code's ``~/.claude/projects``. An explicit
+    ``TRUEMEMORY_TRANSCRIPT_DIR`` override (e.g. for tests or non-default
+    installs) is honored when set.
+    """
+    roots = [Path.home() / ".claude" / "projects"]
+    override = os.environ.get("TRUEMEMORY_TRANSCRIPT_DIR", "")
+    if override:
+        roots.insert(0, Path(override))
+    return roots
+
+
+def _is_allowed_transcript(transcript_path: str) -> bool:
+    """Return True only if *transcript_path* is inside an expected root (M-90).
+
+    The hook's stdin / backlog is attacker-influenceable in a local-control
+    scenario; ``parse_transcript`` would otherwise read any user-readable file
+    into the memory store via its plaintext fallback. Resolve symlinks and
+    require containment under a known transcripts root.
+    """
+    try:
+        resolved = Path(transcript_path).resolve()
+    except (OSError, ValueError):
+        return False
+    for root in _transcript_roots():
+        try:
+            if resolved.is_relative_to(root.resolve()):
+                return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
 def _parse_args() -> argparse.Namespace:
     """Parse command-line overrides for user_id and db_path.
 
@@ -53,8 +88,11 @@ def main():
     except (json.JSONDecodeError, EOFError):
         input_data = {}
 
-    transcript_path = input_data.get("transcript_path", "")
-    session_id = input_data.get("session_id", "unknown")
+    # M-95: stdin fields may be non-strings (e.g. an int session_id) from a
+    # misbehaving / hostile caller. Coerce to str before any str/Path op so the
+    # hook never crashes with TypeError.
+    transcript_path = str(input_data.get("transcript_path", "") or "")
+    session_id = str(input_data.get("session_id", "unknown") or "unknown")
 
     # Sanitize session_id to prevent injection (consistent with user_prompt_submit.py)
     safe_id = "".join(c for c in session_id if c.isalnum() or c in "-_")[:64]
@@ -63,6 +101,12 @@ def main():
     session_id = safe_id
 
     if not transcript_path or not Path(transcript_path).exists():
+        return
+
+    # M-90: reject transcript paths outside the expected transcripts root so an
+    # attacker-chosen arbitrary file is never read into the memory store.
+    if not _is_allowed_transcript(transcript_path):
+        log.warning("Rejecting transcript_path outside transcripts root: %r", transcript_path)
         return
 
     try:

--- a/truememory/ingest/models.py
+++ b/truememory/ingest/models.py
@@ -37,8 +37,11 @@ log = logging.getLogger(__name__)
 # budget_tokens, or explicit ``thinking: {type: disabled}``.  Covers both
 # Anthropic-direct IDs (``claude-fable-5-…``, ``claude-opus-4-8-…``) and
 # OpenRouter-prefixed variants (``anthropic/claude-fable-5-…``).
+# M-97: also match context-window-suffixed IDs like ``claude-fable-5[1m]``
+# (the ``[`` follows the family token directly), alongside ``-``-suffixed and
+# bare IDs.
 _STRICT_PARAM_MODEL_RE = re.compile(
-    r"(?:^|/)claude-(?:fable-5|opus-4-8)(?:-|$)", re.IGNORECASE,
+    r"(?:^|/)claude-(?:fable-5|opus-4-8)(?:-|\[|$)", re.IGNORECASE,
 )
 
 # Keys that must be stripped from the request body for strict-param models.

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -1038,7 +1038,7 @@ def truememory_store(
     # content is what gets stored, so whitespace-padded real text is preserved.
     if content is None or not content.strip():
         return json.dumps({"error": "Content is empty or whitespace-only; nothing stored."})
-    MAX_CONTENT_LENGTH = 50_000
+    from truememory.engine import MAX_CONTENT_LENGTH
     if len(content) > MAX_CONTENT_LENGTH:
         return json.dumps({"error": f"Content too large ({len(content)} chars). Maximum is {MAX_CONTENT_LENGTH}."})
     MAX_METADATA_LENGTH = 10_000

--- a/truememory/model_client.py
+++ b/truememory/model_client.py
@@ -220,7 +220,13 @@ def _start_server(wait_timeout: float | None = None) -> bool:
     """
     if os.environ.get("TRUEMEMORY_NO_MODEL_SERVER", "") == "1":
         return False
+    # M-89: ~/.truememory holds real memories/PII — keep it owner-only (0700),
+    # never the default-umask 0755.
     _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        _TRUEMEMORY_DIR.chmod(0o700)
+    except OSError:
+        pass
 
     alive = _server_is_alive()
     if not alive:

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -862,7 +862,12 @@ class ModelServer:
         return fd
 
     def run(self):
+        # M-89: keep ~/.truememory owner-only (0700) — it holds memories/PII.
         _TRUEMEMORY_DIR.mkdir(parents=True, exist_ok=True)
+        try:
+            _TRUEMEMORY_DIR.chmod(0o700)
+        except OSError:
+            pass
 
         # Exclusive bind lock BEFORE touching socket/pid artifacts (M-20).
         self._lock_fd = self._acquire_bind_lock()

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -15,6 +15,7 @@ Schema overview:
 
 import json
 import logging
+import os
 import sqlite3
 import time
 from pathlib import Path
@@ -260,6 +261,28 @@ class DatabaseOpenError(sqlite3.DatabaseError):
     TrueMemory processes) instead of surfacing a raw "database disk image is
     malformed" / "disk I/O error" string.
     """
+
+
+def _validate_db_path(db_path) -> str:
+    """Validate that *db_path* is a real filesystem path, not a misused object.
+
+    M-33: ``sqlite3.connect(str(db_path))`` will happily stringify ANY object.
+    Passing a live ``sqlite3.Connection`` (a common copy/paste slip) produced a
+    file literally named ``<sqlite3.Connection object at 0x...>`` in the repo
+    root. Reject anything that is not a ``str``/``os.PathLike`` up front with a
+    clear ``TypeError`` instead of silently creating a garbage file.
+
+    Returns the path coerced to ``str`` (via ``os.fspath``) for connect().
+    """
+    if isinstance(db_path, str):
+        return db_path
+    if isinstance(db_path, os.PathLike):
+        return os.fspath(db_path)
+    raise TypeError(
+        f"db_path must be a str or os.PathLike, got {type(db_path).__name__}. "
+        "Passing a sqlite3.Connection (or other object) here would stringify "
+        "into a bogus filename like '<sqlite3.Connection object at 0x...>'."
+    )
 
 
 def _check_dir_writable(db_path: str | Path) -> None:
@@ -526,6 +549,10 @@ def create_db(db_path: str | Path) -> sqlite3.Connection:
         An open ``sqlite3.Connection`` with row_factory left at default
         (callers choose their own access pattern).
     """
+    # M-33: reject non-path objects (e.g. a sqlite3.Connection) before they
+    # stringify into a bogus filename.
+    db_path = _validate_db_path(db_path)
+
     # M-57: preflight directory writability before SQLite produces a
     # misleading raw error on the first WAL write.
     _check_dir_writable(db_path)

--- a/truememory/tier_switch/manager.py
+++ b/truememory/tier_switch/manager.py
@@ -56,10 +56,10 @@ def _get_db_path() -> Path:
 
 def _open_db(db_path: Path | None = None) -> sqlite3.Connection:
     """Open a new SQLite connection (thread-safe: each thread gets its own)."""
-    from truememory.storage import DEFAULT_BUSY_TIMEOUT_MS
+    from truememory.storage import DEFAULT_BUSY_TIMEOUT_MS, _validate_db_path
 
     path = db_path or _get_db_path()
-    conn = sqlite3.connect(str(path), check_same_thread=False)
+    conn = sqlite3.connect(_validate_db_path(path), check_same_thread=False)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
     conn.execute("PRAGMA foreign_keys=ON")


### PR DESCRIPTION
Fixes #653. Input/platform mop-up — a cluster of small input-handling fixes.

## Changes per finding

- **M-33 (create_db type guard / stray-file root cause):** Added `_validate_db_path()` in `storage.py` (os.fspath/isinstance) — raises `TypeError` if given a `sqlite3.Connection` or any non-path, instead of stringifying it into a `<sqlite3.Connection object at 0x...>` file. Routed `create_db`, `engine.py`'s `_ensure_connection` connect, and `tier_switch/manager._open_db` through it. Added `.gitignore` patterns for the stray files, `*.db.backup-*` / `*.db.backup-pre-migration-*` / `truememory.db.backup-*`, `BUILD_PROMPT*.md`, `DRAIN_REPORT*.md`, and `truememory/dashboard/`.
- **M-60 (store cap):** Moved the 50KB cap into `Engine.add` as module constant `MAX_CONTENT_LENGTH` (raises `ValueError` on oversize), so `client.add`/hook paths inherit it. `mcp_server` now imports the shared constant for its existing check (kept in sync, minimal edit).
- **M-90 (transcript_path validation):** `compact.py` validates `transcript_path` is contained under `~/.claude/projects` (or `TRUEMEMORY_TRANSCRIPT_DIR`) via resolved `is_relative_to` before reading; rejects outside paths.
- **M-95 (non-string stdin):** `compact.py` `str()`-coerces `session_id`/`transcript_path` from stdin so an int field no longer crashes with `TypeError`.
- **M-70 (empty-timestamp temporal filter):** `fts_search.search_fts_in_range` now drops empty-timestamp rows uniformly whenever any temporal bound is active (previously `"" < before` leaked them through).
- **M-89 (dir perms):** `~/.truememory`/DB dir creators (`engine.py`, `model_client.py`, `model_server.py`) now `chmod(0o700)` after mkdir, mirroring the existing `mcp_server` pattern.
- **M-97 (param regex):** `ingest/models.py` `_STRICT_PARAM_MODEL_RE` extended to `(?:-|\[|$)` so context-window-suffixed IDs like `claude-fable-5[1m]` are matched and params stripped.
- **M-96 (orphan dashboard):** `truememory/dashboard/` is untracked (nothing in git tree); added to `.gitignore`, not committed.

## Tests
New `tests/test_issue_653_input_mopup.py` (14 tests, all pass): create_db rejects a Connection (no stray file) + accepts str/PathLike; Engine.add rejects oversize / accepts boundary; compact rejects/allows transcript by root; compact tolerates non-string stdin; temporal filter excludes empty-timestamp rows; param shim strips for `claude-fable-5[1m]`-style IDs and passes through others.

`ruff check truememory/ tests/` passes. Targeted suite: 363 passed; the 2 failures (`test_cli_preflight`, `test_production_fixes`) are pre-existing py3.14 numpy-missing env issues, unrelated to this change.