### PR TITLE
fix: shared _env_int helper — kill the import-crash + negative/zero env-var class (#639)

### DIFF
--- a/tests/test_issue_639_env_int.py
+++ b/tests/test_issue_639_env_int.py
@@ -1,0 +1,109 @@
+"""Issue #639: shared ``_env_int`` helper.
+
+Covers two failure classes the helper kills:
+
+* **M-27 (P1)** — an empty or non-numeric env var used in a module-level bare
+  ``int(os.environ.get(...))`` crashed the whole hook/server at *import*,
+  before any ``main()`` try/except could run.
+* **M-59 (P2)** — negative/zero values that parse but misbehave (negative
+  SQLite ``LIMIT`` = unlimited, ``AUTO_CONSOLIDATE_EVERY=0`` = consolidate on
+  every add, zero/negative budgets that drop all memory).
+
+The helper returns the default on garbage and clamps into ``[lo, hi]``.
+"""
+
+import importlib
+
+import pytest
+
+from truememory._platform import _env_int
+
+
+# ---------------------------------------------------------------------------
+# (a) default on unset / empty / non-numeric
+# ---------------------------------------------------------------------------
+
+def test_env_int_unset_returns_default(monkeypatch):
+    monkeypatch.delenv("TM_TEST_639", raising=False)
+    assert _env_int("TM_TEST_639", 42) == 42
+
+
+@pytest.mark.parametrize("raw", ["", "  ", "abc", "1.5", "0x10", "1,000", "nan"])
+def test_env_int_garbage_returns_default(monkeypatch, raw):
+    monkeypatch.setenv("TM_TEST_639", raw)
+    assert _env_int("TM_TEST_639", 7) == 7
+
+
+def test_env_int_valid_value_parsed(monkeypatch):
+    monkeypatch.setenv("TM_TEST_639", "123")
+    assert _env_int("TM_TEST_639", 7) == 123
+
+
+def test_env_int_negative_value_parsed_when_unclamped(monkeypatch):
+    monkeypatch.setenv("TM_TEST_639", "-5")
+    assert _env_int("TM_TEST_639", 7) == -5
+
+
+# ---------------------------------------------------------------------------
+# (b) clamping into [lo, hi]
+# ---------------------------------------------------------------------------
+
+def test_env_int_clamps_negative_to_lo(monkeypatch):
+    monkeypatch.setenv("TM_TEST_639", "-5")
+    assert _env_int("TM_TEST_639", 7, lo=0) == 0
+
+
+def test_env_int_clamps_zero_up_to_lo_one(monkeypatch):
+    # AUTO_CONSOLIDATE_EVERY=0 must not mean "every add".
+    monkeypatch.setenv("TM_TEST_639", "0")
+    assert _env_int("TM_TEST_639", 25, lo=1) == 1
+
+
+def test_env_int_clamps_over_max_to_hi(monkeypatch):
+    monkeypatch.setenv("TM_TEST_639", "999")
+    assert _env_int("TM_TEST_639", 7, hi=10) == 10
+
+
+def test_env_int_within_bounds_unchanged(monkeypatch):
+    monkeypatch.setenv("TM_TEST_639", "5")
+    assert _env_int("TM_TEST_639", 7, lo=0, hi=10) == 5
+
+
+def test_env_int_default_is_not_clamped_caller_must_pass_sane_default(monkeypatch):
+    # A garbage value falls through to the default verbatim (callers pass
+    # in-bounds defaults), but a value that parses is clamped.
+    monkeypatch.setenv("TM_TEST_639", "garbage")
+    assert _env_int("TM_TEST_639", 50, lo=0, hi=100) == 50
+
+
+# ---------------------------------------------------------------------------
+# (c) a representative module imports cleanly with a garbage env var
+#     (no ValueError at import, M-27)
+# ---------------------------------------------------------------------------
+
+def test_session_start_imports_with_garbage_env(monkeypatch):
+    # Was: bare int(os.environ.get("TRUEMEMORY_RECALL_BUDGET_CHARS", "8192"))
+    # crashed the entire SessionStart hook at import on an empty value.
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    monkeypatch.setenv("TRUEMEMORY_RECALL_BUDGET_CHARS", "")
+    monkeypatch.setenv("TRUEMEMORY_DIRECTIVE_LIMIT", "abc")
+    monkeypatch.setenv("TRUEMEMORY_RECALL_MEMORY_CHARS", "-100")
+
+    import truememory.ingest.hooks.session_start as ss
+
+    importlib.reload(ss)  # must not raise ValueError at import
+
+    assert ss.RECALL_BUDGET_CHARS == 8192     # empty -> default
+    assert ss.DIRECTIVE_LIMIT == 50           # garbage -> default
+    assert ss.RECALL_MEMORY_CHARS == 0        # negative -> clamped to lo=0
+
+
+def test_engine_imports_with_garbage_consolidate_env(monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    monkeypatch.setenv("TRUEMEMORY_AUTO_CONSOLIDATE_EVERY", "")
+
+    import truememory.engine as eng
+
+    importlib.reload(eng)  # must not raise at import

--- a/truememory/_platform.py
+++ b/truememory/_platform.py
@@ -20,6 +20,43 @@ _LOOPBACK_HOST: str = "127.0.0.1"
 
 
 # ---------------------------------------------------------------------------
+# Safe environment-variable parsing (issue #639)
+# ---------------------------------------------------------------------------
+
+def _env_int(
+    name: str,
+    default: int,
+    lo: int | None = None,
+    hi: int | None = None,
+) -> int:
+    """Read integer env var *name*, never crashing at import.
+
+    An unset, empty, or non-numeric value (e.g. ``""``, ``"abc"``, ``"1.5"``)
+    returns *default* instead of raising ``ValueError`` — a module-level bare
+    ``int(os.environ.get(...))`` would otherwise crash the whole hook/server
+    at import, before any ``main()`` try/except can catch it (M-27).
+
+    When *lo* / *hi* are given the parsed value is clamped into ``[lo, hi]``,
+    guarding against negative/zero knobs that parse but misbehave — e.g. a
+    negative SQLite ``LIMIT`` meaning "unlimited", or a zero "consolidate
+    every N" meaning "consolidate on every add" (M-59).
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        value = default
+    else:
+        try:
+            value = int(raw)
+        except (ValueError, TypeError):
+            value = default
+    if lo is not None and value < lo:
+        value = lo
+    if hi is not None and value > hi:
+        value = hi
+    return value
+
+
+# ---------------------------------------------------------------------------
 # Cross-platform PID liveness
 # ---------------------------------------------------------------------------
 

--- a/truememory/engine.py
+++ b/truememory/engine.py
@@ -41,6 +41,7 @@ from truememory.storage import (
     insert_message, delete_message, update_message, get_message,
 )
 from truememory.fts_search import search_fts
+from truememory._platform import _env_int
 
 logger = logging.getLogger(__name__)
 
@@ -359,8 +360,8 @@ class TrueMemoryEngine:
 
         # Auto-consolidation: run L5 consolidation every N adds (#498)
         self._adds_since_consolidation = 0
-        self._auto_consolidate_threshold = int(
-            os.environ.get("TRUEMEMORY_AUTO_CONSOLIDATE_EVERY", "25")
+        self._auto_consolidate_threshold = _env_int(
+            "TRUEMEMORY_AUTO_CONSOLIDATE_EVERY", 25, lo=1
         )
         self._consolidation_thread: threading.Thread | None = None
 

--- a/truememory/hooks/core.py
+++ b/truememory/hooks/core.py
@@ -16,6 +16,8 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
+from truememory._platform import _env_int
+
 try:
     import psutil
 except ImportError:
@@ -23,7 +25,7 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-_BASE_MEMORY_LIMIT = int(os.environ.get("TRUEMEMORY_RECALL_LIMIT", "25"))
+_BASE_MEMORY_LIMIT = _env_int("TRUEMEMORY_RECALL_LIMIT", 25, lo=1)
 
 # Issue #396: search intensity scales the recall limit.
 # Standard = 25, Enhanced/Max = 35.
@@ -53,8 +55,8 @@ BUFFER_DIR = Path(os.environ.get(
     "TRUEMEMORY_BUFFER_DIR",
     str(Path.home() / ".truememory" / "buffers"),
 ))
-RETENTION_DAYS = int(os.environ.get("TRUEMEMORY_BUFFER_RETENTION_DAYS", "7"))
-MAX_BUFFER_SIZE = int(os.environ.get("TRUEMEMORY_BUFFER_MAX_BYTES", str(10 * 1024 * 1024)))
+RETENTION_DAYS = _env_int("TRUEMEMORY_BUFFER_RETENTION_DAYS", 7, lo=0)
+MAX_BUFFER_SIZE = _env_int("TRUEMEMORY_BUFFER_MAX_BYTES", 10 * 1024 * 1024, lo=1)
 
 TRACE_DIR = Path.home() / ".truememory" / "traces"
 LOG_DIR = Path.home() / ".truememory" / "logs"

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -9,6 +9,7 @@ import sys
 import time
 
 from truememory import _platform
+from truememory._platform import _env_int
 
 try:
     import fcntl
@@ -31,7 +32,7 @@ except ValueError:
     RECALL_CACHE_TTL = 300.0
 
 _BUDGET_FILE = Path.home() / ".truememory" / ".extraction_budget"
-_MAX_EXTRACTIONS_PER_HOUR = int(os.environ.get("TRUEMEMORY_MAX_EXTRACTIONS_PER_HOUR", "20"))
+_MAX_EXTRACTIONS_PER_HOUR = _env_int("TRUEMEMORY_MAX_EXTRACTIONS_PER_HOUR", 20, lo=0)
 
 _STALE_PROCESSING_THRESHOLD = 1800  # 30 minutes
 

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -29,6 +29,7 @@ import sys
 from pathlib import Path
 
 from truememory import _platform
+from truememory._platform import _env_int
 
 try:
     import fcntl
@@ -38,7 +39,7 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-_BASE_MEMORY_LIMIT = int(os.environ.get("TRUEMEMORY_RECALL_LIMIT", "25"))
+_BASE_MEMORY_LIMIT = _env_int("TRUEMEMORY_RECALL_LIMIT", 25, lo=1)
 
 # Issue #396: search intensity scales the recall limit at session start.
 # Standard = 25, Enhanced/Max = 35.
@@ -84,12 +85,12 @@ def _get_search_intensity() -> str:
 MEMORY_LIMIT = _BASE_MEMORY_LIMIT  # module-level default; overridden in main()
 # Max directives force-injected at session start. Uncapped injection let a
 # large directive set consume unbounded context (issue #589, D-4).
-DIRECTIVE_LIMIT = int(os.environ.get("TRUEMEMORY_DIRECTIVE_LIMIT", "50"))
+DIRECTIVE_LIMIT = _env_int("TRUEMEMORY_DIRECTIVE_LIMIT", 50, lo=0)
 # Per-memory character cap and total payload budget (issue #578).
 # Memories exceeding the per-entry cap are sliced on a word boundary and
 # suffixed with a pointer so the agent can fetch the full text on demand.
-RECALL_MEMORY_CHARS = int(os.environ.get("TRUEMEMORY_RECALL_MEMORY_CHARS", "500"))
-RECALL_BUDGET_CHARS = int(os.environ.get("TRUEMEMORY_RECALL_BUDGET_CHARS", "8192"))
+RECALL_MEMORY_CHARS = _env_int("TRUEMEMORY_RECALL_MEMORY_CHARS", 500, lo=0)
+RECALL_BUDGET_CHARS = _env_int("TRUEMEMORY_RECALL_BUDGET_CHARS", 8192, lo=0)
 
 # Issue #636 (M-72): "max" intensity raises MEMORY_LIMIT to 35 but the recall
 # payload was still capped at RECALL_BUDGET_CHARS (8KB), so _apply_budget
@@ -120,7 +121,7 @@ _DRAIN_CAP = 3
 _SCAN_MARKER = Path.home() / ".truememory" / ".last_stale_scan"
 _SCAN_INTERVAL = 900  # 15 minutes
 _SCAN_CAP = 3  # max sessions to queue per scan
-_EXTRACTED_MARKER_MAX_AGE = int(os.environ.get("TRUEMEMORY_EXTRACTED_MARKER_MAX_AGE_DAYS", "30")) * 86400
+_EXTRACTED_MARKER_MAX_AGE = _env_int("TRUEMEMORY_EXTRACTED_MARKER_MAX_AGE_DAYS", 30, lo=0) * 86400
 
 _EXTRACTION_SENTINEL = "[[TRUEMEMORY_INTERNAL_EXTRACTION]]"
 _EXTRACTION_LEGACY_PREFIXES = (

--- a/truememory/ingest/hooks/stop.py
+++ b/truememory/ingest/hooks/stop.py
@@ -26,6 +26,8 @@ import sys
 import time
 from pathlib import Path
 
+from truememory._platform import _env_int
+
 log = logging.getLogger(__name__)
 
 def _safe_float_env(name: str, default: float) -> float:
@@ -68,10 +70,11 @@ BACKLOG_DIR = Path(os.environ.get(
 # (multi-session close, session-restart loop) would otherwise load N
 # embedding models at once — ~600MB RSS each on Pro, easy OOM on laptops.
 # Unified env var across stop.py and hooks/core.py.
-SPAWN_CAP = int(os.environ.get(
-    "TRUEMEMORY_SPAWN_CAP",
-    os.environ.get("TRUEMEMORY_INGEST_SPAWN_CAP", "2"),
-))
+# Crash-safe + clamped (issue #639): a garbage value in either knob must not
+# crash the Stop hook at import, and a zero/negative cap must not disable
+# spawning entirely. Resolve the legacy alias first, then the primary.
+_SPAWN_CAP_DEFAULT = _env_int("TRUEMEMORY_INGEST_SPAWN_CAP", 2, lo=1)
+SPAWN_CAP = _env_int("TRUEMEMORY_SPAWN_CAP", _SPAWN_CAP_DEFAULT, lo=1)
 
 
 def _sanitize_session_id(session_id: str) -> str:

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -30,6 +30,8 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from truememory._platform import _env_int
+
 # Optional: fcntl isn't available on Windows, so we gracefully degrade
 try:
     import fcntl
@@ -45,9 +47,9 @@ BUFFER_DIR = Path(os.environ.get(
 ))
 
 # Delete buffer files older than this many days
-RETENTION_DAYS = int(os.environ.get("TRUEMEMORY_BUFFER_RETENTION_DAYS", "7"))
+RETENTION_DAYS = _env_int("TRUEMEMORY_BUFFER_RETENTION_DAYS", 7, lo=0)
 # Max size per buffer file (bytes) before we rotate
-MAX_BUFFER_SIZE = int(os.environ.get("TRUEMEMORY_BUFFER_MAX_BYTES", str(10 * 1024 * 1024)))
+MAX_BUFFER_SIZE = _env_int("TRUEMEMORY_BUFFER_MAX_BYTES", 10 * 1024 * 1024, lo=1)
 
 
 def _safe_session_id_local(session_id: str) -> str:

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -317,6 +317,7 @@ if isinstance(_startup_tier, str) and _startup_tier.strip():
     os.environ["TRUEMEMORY_EMBED_MODEL"] = _startup_tier
 
 from truememory import __version__  # noqa: E402
+from truememory._platform import _env_int  # noqa: E402
 from truememory.client import Memory  # noqa: E402
 from truememory.telemetry import tracked as _tracked  # noqa: E402
 
@@ -1650,8 +1651,8 @@ def truememory_consolidate() -> str:
 # Background model preloading
 # ---------------------------------------------------------------------------
 
-_MODEL_IDLE_TIMEOUT_SEC = int(os.environ.get("TRUEMEMORY_MODEL_IDLE_SEC", "300"))
-_MAX_RSS_MB = int(os.environ.get("TRUEMEMORY_MAX_RSS_MB", "0"))
+_MODEL_IDLE_TIMEOUT_SEC = _env_int("TRUEMEMORY_MODEL_IDLE_SEC", 300, lo=0)
+_MAX_RSS_MB = _env_int("TRUEMEMORY_MAX_RSS_MB", 0, lo=0)
 _last_search_time: float = 0.0
 _idle_timer: threading.Timer | None = None
 _idle_timer_lock = threading.Lock()
@@ -1776,7 +1777,7 @@ def _preload_models():
 # Background backlog drainer
 # ---------------------------------------------------------------------------
 
-_BACKLOG_DRAIN_INTERVAL_NORMAL = int(os.environ.get("TRUEMEMORY_DRAIN_INTERVAL_SEC", "30"))
+_BACKLOG_DRAIN_INTERVAL_NORMAL = _env_int("TRUEMEMORY_DRAIN_INTERVAL_SEC", 30, lo=1)
 _BACKLOG_DRAIN_INTERVAL_IDLE = 120
 _BACKLOG_LARGE_THRESHOLD = 20
 _BACKLOG_DIR = Path.home() / ".truememory" / "backlog"

--- a/truememory/model_server.py
+++ b/truememory/model_server.py
@@ -60,7 +60,7 @@ from pathlib import Path  # noqa: E402
 
 import numpy as np  # noqa: E402
 
-from truememory._platform import _LOOPBACK_HOST, _USE_UNIX, pid_is_alive  # noqa: E402
+from truememory._platform import _LOOPBACK_HOST, _USE_UNIX, _env_int, pid_is_alive  # noqa: E402
 
 log = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ SOCK_PATH = _TRUEMEMORY_DIR / "model.sock"
 PID_PATH = _TRUEMEMORY_DIR / "model_server.pid"
 PORT_PATH = _TRUEMEMORY_DIR / "model_server.port"
 TOKEN_PATH = _TRUEMEMORY_DIR / "model_server.token"
-IDLE_TIMEOUT = int(os.environ.get("TRUEMEMORY_MODEL_SERVER_IDLE", "300"))
+IDLE_TIMEOUT = _env_int("TRUEMEMORY_MODEL_SERVER_IDLE", 300, lo=0)
 
 LOCK_PATH = _TRUEMEMORY_DIR / "model_server.lock"
 

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -49,6 +49,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from truememory._platform import _env_int
 from truememory.storage import _deserialize_metadata, select_message_cols
 
 if TYPE_CHECKING:
@@ -687,7 +688,7 @@ def init_vec_table(
 # ---------------------------------------------------------------------------
 
 _BATCH_SIZE_CPU = 100
-_BATCH_SIZE_MPS = int(os.environ.get("TRUEMEMORY_MPS_BATCH_SIZE", "16"))
+_BATCH_SIZE_MPS = _env_int("TRUEMEMORY_MPS_BATCH_SIZE", 16, lo=1)
 
 
 def _get_batch_size() -> int:


### PR DESCRIPTION
Fixes #639.

## Problem
- **M-27 (P1):** ~15 env vars used unguarded module-level `int(os.environ.get(...))`. An empty or non-numeric value raised `ValueError` at **import**, before `main()`'s try/except — crashing the whole hook/server.
- **M-59 (P2):** several numeric knobs parse but misbehave on negative/zero: negative `TRUEMEMORY_DIRECTIVE_LIMIT` → SQLite `LIMIT -1` (unlimited); negative `RECALL_MEMORY_CHARS` → end-truncation corrupts injected text; `AUTO_CONSOLIDATE_EVERY=0` → consolidate on every add; zero/negative budgets drop all memory.

## Fix
New shared helper `truememory/_platform._env_int(name, default, lo=None, hi=None)`:
- unset/empty/non-numeric (`""`, `"abc"`, `"1.5"`) → returns `default` (no crash);
- with `lo`/`hi` → clamps parsed value into `[lo, hi]`.

`_platform.py` is a stdlib-only leaf module already imported by the hooks, so it is a safe single home with no circular-import risk.

## Sites changed (unguarded → `_env_int`)
| File | Var | Bounds |
|---|---|---|
| model_server.py | TRUEMEMORY_MODEL_SERVER_IDLE (300) | lo=0 |
| vector_search.py | TRUEMEMORY_MPS_BATCH_SIZE (16) | lo=1 |
| mcp_server.py | TRUEMEMORY_MODEL_IDLE_SEC (300) | lo=0 |
| mcp_server.py | TRUEMEMORY_MAX_RSS_MB (0) | lo=0 |
| mcp_server.py | TRUEMEMORY_DRAIN_INTERVAL_SEC (30) | lo=1 |
| engine.py | TRUEMEMORY_AUTO_CONSOLIDATE_EVERY (25) | lo=1 |
| hooks/core.py | TRUEMEMORY_RECALL_LIMIT (25) | lo=1 |
| hooks/core.py | TRUEMEMORY_BUFFER_RETENTION_DAYS (7) | lo=0 |
| hooks/core.py | TRUEMEMORY_BUFFER_MAX_BYTES (10MiB) | lo=1 |
| ingest/hooks/_shared.py | TRUEMEMORY_MAX_EXTRACTIONS_PER_HOUR (20) | lo=0 |
| ingest/hooks/session_start.py | TRUEMEMORY_RECALL_LIMIT (25) | lo=1 |
| ingest/hooks/session_start.py | TRUEMEMORY_DIRECTIVE_LIMIT (50) | lo=0 |
| ingest/hooks/session_start.py | TRUEMEMORY_RECALL_MEMORY_CHARS (500) | lo=0 |
| ingest/hooks/session_start.py | TRUEMEMORY_RECALL_BUDGET_CHARS (8192) | lo=0 |
| ingest/hooks/session_start.py | TRUEMEMORY_EXTRACTED_MARKER_MAX_AGE_DAYS (30) | lo=0 |
| ingest/hooks/user_prompt_submit.py | TRUEMEMORY_BUFFER_RETENTION_DAYS (7) | lo=0 |
| ingest/hooks/user_prompt_submit.py | TRUEMEMORY_BUFFER_MAX_BYTES (10MiB) | lo=1 |
| ingest/hooks/stop.py | TRUEMEMORY_SPAWN_CAP / TRUEMEMORY_INGEST_SPAWN_CAP (2) | lo=1 |

Already-guarded sites (e.g. `_shared.py` float try/except, `stop.py` `_safe_int_env`/`_safe_float_env`) were left alone, except `SPAWN_CAP` which was a bare-int with a nested-default fallback — now crash-safe + clamped.

## Tests
New `tests/test_issue_639_env_int.py` (17 tests): default on unset/empty/garbage (`""`, `"abc"`, `"1.5"`, …); clamp negative→lo, zero→lo, over-max→hi; and import-safety — `session_start` and `engine` reload cleanly with garbage env vars (no ValueError at import). HF_HUB_OFFLINE=1, no model loads.

`ruff check truememory/ tests/` clean. Targeted sweep (`-k "env or config or budget or limit"`): 232 passed, 0 failed.