### PR TITLE
fix: Path.rename → Path.replace sweep at atomic-write sites (#643)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,17 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[all,dev]"
       - name: Run network-marked tests (retried for transient HF flakes)
+        # This job MUST run online -- its whole purpose is real HuggingFace
+        # downloads + the real-embedding smoke test (#654/M-52). Force offline
+        # mode OFF: two test modules call os.environ.setdefault("HF_HUB_OFFLINE",
+        # "1") at import, and pytest imports every module during collection, so
+        # that default leaked offline-mode into this job and made the network
+        # tests fail 100% deterministically (LocalEntryNotFoundError), silently
+        # turning the real-vector gate into a no-op. Setting it "0" here makes
+        # the setdefault a no-op so downloads actually happen.
+        env:
+          HF_HUB_OFFLINE: "0"
+          TRANSFORMERS_OFFLINE: "0"
         run: |
           for attempt in 1 2 3; do
             echo "::group::network-tests attempt $attempt"

--- a/tests/test_issue_643_path_replace.py
+++ b/tests/test_issue_643_path_replace.py
@@ -1,0 +1,70 @@
+"""Issue #643 (M-49): atomic-write sites must use os.replace, not Path.rename.
+
+On POSIX, ``Path.rename(dst)`` silently overwrites an existing destination, so
+the bug was latent. On Windows, ``Path.rename`` raises ``FileExistsError`` when
+the destination exists, which broke every atomic tmp-write-then-swap site
+(update notices, config writes, telemetry, spawn-cap state, buffer rotation).
+``os.replace`` / ``Path.replace`` overwrites atomically on *both* platforms.
+
+These tests assert the replace-onto-existing-destination semantics the fix
+relies on, and guard the converted source sites against regressing back to
+``.rename``. Backlog-claim sites (``marker -> .processing``) intentionally keep
+``.rename`` for their fail-if-exists exclusive-claim guarantee and are NOT
+covered here.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def test_path_replace_overwrites_existing_destination(tmp_path):
+    """The primitive the fix depends on: replace tolerates an existing dst."""
+    src = tmp_path / "src.tmp"
+    dst = tmp_path / "dst"
+    src.write_text("new", encoding="utf-8")
+    dst.write_text("old", encoding="utf-8")
+
+    # Path.replace must NOT raise when dst exists (Path.rename would on Windows).
+    src.replace(dst)
+
+    assert dst.read_text(encoding="utf-8") == "new"
+    assert not src.exists()
+
+
+def _source(rel: str) -> str:
+    root = Path(__file__).resolve().parent.parent / "truememory"
+    return (root / rel).read_text(encoding="utf-8")
+
+
+def test_atomic_write_sites_use_replace_not_rename():
+    """The converted atomic-write sites must use .replace (M-49 regression guard)."""
+    checks = {
+        "telemetry.py": r"_tmp\.replace\(_p\)",
+        "mcp_server.py": r"_CONFIG_PATH\.replace\(backup\)",
+        "ingest/hooks/session_start.py": r"tmp\.replace\(update_path\)",
+        "ingest/hooks/user_prompt_submit.py": r"tmp\.replace\(config_path\)",
+        "hooks/core.py": r"tmp\.replace\(_SPAWN_CAP_STATE_PATH\)",
+    }
+    for rel, pattern in checks.items():
+        src = _source(rel)
+        assert re.search(pattern, src), f"{rel}: expected atomic .replace ({pattern})"
+
+
+def test_buffer_rotation_uses_replace():
+    """Buffer rotation (timestamped dest) also uses replace for Windows safety."""
+    for rel in ("hooks/core.py", "ingest/hooks/user_prompt_submit.py"):
+        src = _source(rel)
+        assert "buffer_file.replace(rotated)" in src, f"{rel}: buffer rotation must use .replace"
+
+
+def test_claim_sites_still_use_rename():
+    """Backlog-claim sites MUST keep .rename (fail-if-exists exclusive claim).
+
+    Converting these to .replace would silently overwrite a live worker's
+    .processing claim — reintroducing the M-15 duplicate-ingest race.
+    """
+    for rel in ("ingest/cli.py", "ingest/hooks/_shared.py"):
+        src = _source(rel)
+        assert ".replace(claimed_path)" not in src, f"{rel}: claim site must NOT use .replace"
+        assert ".replace(marker_path)" not in src, f"{rel}: claim restore must NOT use .replace"

--- a/truememory/hooks/core.py
+++ b/truememory/hooks/core.py
@@ -209,7 +209,7 @@ def _save_cap_state(
         if last_ramp_time is not None:
             data["last_ramp_time"] = last_ramp_time
         tmp.write_text(_json.dumps(data), encoding="utf-8")
-        tmp.rename(_SPAWN_CAP_STATE_PATH)
+        tmp.replace(_SPAWN_CAP_STATE_PATH)
     except Exception:
         pass
 
@@ -590,7 +590,7 @@ def buffer_message(session_id: str, prompt: str) -> None:
     try:
         if buffer_file.exists() and buffer_file.stat().st_size > MAX_BUFFER_SIZE:
             rotated = buffer_file.with_suffix(f".{int(time.time())}.jsonl")
-            buffer_file.rename(rotated)
+            buffer_file.replace(rotated)
     except OSError:
         pass
 

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -193,7 +193,8 @@ def _check_for_update() -> str:
             try:
                 tmp = update_path.with_suffix(".tmp")
                 tmp.write_text(json.dumps(data), encoding="utf-8")
-                tmp.rename(update_path)
+                # M-49: os.replace tolerates an existing file on Windows.
+                tmp.replace(update_path)
             except Exception:
                 pass
             return (

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -671,7 +671,8 @@ def _try_capture_email(prompt: str) -> None:
         config["email"] = email
         tmp = config_path.with_suffix(".tmp")
         tmp.write_text(json.dumps(config, indent=2), encoding="utf-8")
-        tmp.rename(config_path)
+        # M-49: os.replace tolerates an existing config on Windows.
+        tmp.replace(config_path)
     except Exception:
         pass
 
@@ -801,7 +802,9 @@ def buffer_message(session_id: str, prompt: str):
     try:
         if buffer_file.exists() and buffer_file.stat().st_size > MAX_BUFFER_SIZE:
             rotated = buffer_file.with_suffix(f".{int(time.time())}.jsonl")
-            buffer_file.rename(rotated)
+            # M-49: os.replace tolerates a same-second rotation collision
+            # on Windows (Path.rename raises FileExistsError there).
+            buffer_file.replace(rotated)
     except OSError:
         pass
 

--- a/truememory/mcp_server.py
+++ b/truememory/mcp_server.py
@@ -188,7 +188,8 @@ def _load_config() -> dict:
         else:
             _reason = str(e)
         try:
-            _CONFIG_PATH.rename(backup)
+            # M-49: os.replace tolerates an existing backup on Windows.
+            _CONFIG_PATH.replace(backup)
             print(
                 f"truememory: config.json is corrupt ({_reason}). "
                 f"Saved corrupt file to {backup} — your API keys may be "

--- a/truememory/telemetry.py
+++ b/truememory/telemetry.py
@@ -143,7 +143,9 @@ def init(config: dict) -> dict | None:
                 _p = Path.home() / ".truememory" / ".update_available"
                 _tmp = _p.with_suffix(".tmp")
                 _tmp.write_text(json.dumps(info), encoding="utf-8")
-                _tmp.rename(_p)
+                # M-49: os.replace tolerates an existing destination on
+                # Windows (Path.rename raises FileExistsError there).
+                _tmp.replace(_p)
             except Exception:
                 pass
 


### PR DESCRIPTION
Fixes #643 (M-49). Converts the 7 atomic tmp-write-then-swap sites to `Path.replace` so they tolerate an existing destination on Windows (where `Path.rename` raises FileExistsError): telemetry update-available, mcp_server corrupt-config backup, session_start update notice, user_prompt_submit email config + buffer rotation, hooks/core spawn-cap state + buffer rotation.

Backlog-claim sites (`marker -> .processing`, claim restore) deliberately KEEP `.rename` — their fail-if-exists behavior is the exclusive-claim guarantee; converting them to `.replace` would reintroduce the M-15 duplicate-ingest race (#644). A regression test asserts the claim sites stay `.rename`.

New tests/test_issue_643_path_replace.py (4 tests): replace-onto-existing-dest semantics + source-site guards for both the converted atomic sites and the preserved claim sites.