### PR TITLE
chore: bump version to 0.8.0.0 (hardening release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truememory"
-version = "0.7.6.0"
+version = "0.8.0.0"
 description = "SOTA-level agent memory at zero infrastructure cost."
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Closes the BLAST OFF v2 hardening pass. All 25 hardening issues (#630–#654) merged via PRs #655–#680: 4 P0 correctness fixes (cosine/L2 distance, score-space contract, search-crash, per-exchange store DOA), the full P1/P2/P3 set, plus a CI fix that makes the real-vector regression gate actually run online for the first time.

Version 0.7.6.0 → 0.8.0.0.