### PR TITLE
chore: set version to 0.7.6.0 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truememory"
-version = "0.8.0.0"
+version = "0.7.6.0"
 description = "SOTA-level agent memory at zero infrastructure cost."
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Sets version 0.8.0.0 → 0.7.6.0 for the release. Code unchanged — this is the version string only. PyPI latest is 0.7.5.0; 0.7.6.0 is the next unpublished version and carries the full BLAST OFF v2 hardening pass (25 issues, #630–#654).