### PR TITLE
chore: bump version to 0.7.6.1 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truememory"
-version = "0.7.6.0"
+version = "0.7.6.1"
 description = "SOTA-level agent memory at zero infrastructure cost."
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version 0.7.6.0 → 0.7.6.1. Code unchanged — version string only. Releasing the BLAST OFF v2 hardening pass (25 issues, #630–#654) as 0.7.6.1 (clean version; the prior 0.7.6.0 tag was stale and was removed).