### PR TITLE
security: enforce transcript-path allowlist on the stop hook + backlog drain

### DIFF
--- a/tests/ingest/test_backlog_drain_no_unlink_422.py
+++ b/tests/ingest/test_backlog_drain_no_unlink_422.py
@@ -29,6 +29,14 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _allow_tmp_transcripts(tmp_path, monkeypatch):
+    # BLAST OFF v3 (A1-2): the stop hook + backlog drain now require
+    # transcript_path to resolve inside an allowed transcripts root. These
+    # tests stage transcripts under tmp_path, so point the allowlist there.
+    monkeypatch.setenv("TRUEMEMORY_TRANSCRIPT_DIR", str(tmp_path))
+
+
 @contextmanager
 def _gate_allows():
     yield True

--- a/tests/ingest/test_stop_hook_mark_guard.py
+++ b/tests/ingest/test_stop_hook_mark_guard.py
@@ -16,6 +16,15 @@ from __future__ import annotations
 import io
 import json
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_transcripts(tmp_path, monkeypatch):
+    # BLAST OFF v3 (A1-2): stop hook now requires transcript_path inside an
+    # allowed transcripts root; these tests stage transcripts under tmp_path.
+    monkeypatch.setenv("TRUEMEMORY_TRANSCRIPT_DIR", str(tmp_path))
+
 
 def _make_transcript(tmp_path, n=6):
     p = tmp_path / "transcript.jsonl"

--- a/tests/test_issue_644_ingest_races.py
+++ b/tests/test_issue_644_ingest_races.py
@@ -30,6 +30,13 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _allow_tmp_transcripts(tmp_path, monkeypatch):
+    # BLAST OFF v3 (A1-2): stop/drain now require transcript_path inside an
+    # allowed transcripts root; these tests stage transcripts under tmp_path.
+    monkeypatch.setenv("TRUEMEMORY_TRANSCRIPT_DIR", str(tmp_path))
+
+
 @contextmanager
 def _gate_allows():
     yield True

--- a/tests/test_spawn_gate.py
+++ b/tests/test_spawn_gate.py
@@ -22,6 +22,13 @@ def _disable_ramp_cooldown(monkeypatch):
     monkeypatch.setattr(core, "_RAMP_UP_COOLDOWN_SECONDS", 0)
 
 
+@pytest.fixture(autouse=True)
+def _allow_tmp_transcripts(tmp_path, monkeypatch):
+    # BLAST OFF v3 (A1-2): the backlog drain now requires transcript_path inside
+    # an allowed transcripts root; these tests stage transcripts under tmp_path.
+    monkeypatch.setenv("TRUEMEMORY_TRANSCRIPT_DIR", str(tmp_path))
+
+
 # ---------------------------------------------------------------------------
 # Spawn gate tests
 # ---------------------------------------------------------------------------

--- a/tests/test_transcript_guard_stop_drain.py
+++ b/tests/test_transcript_guard_stop_drain.py
@@ -1,0 +1,97 @@
+"""Regression locks: the M-90 transcript-path allowlist must guard the stop
+hook and the SessionStart backlog drain, not just the compact hook (A1-2).
+
+Pre-fix: #653/M-90 added ``_is_allowed_transcript`` to compact.py ONLY; stop.py
+and the drain gated solely on ``Path.exists()``, so a crafted hook stdin /
+backlog marker with ``transcript_path=/etc/passwd`` (or any readable file) was
+parsed into the memory store via parse_transcript's plaintext fallback. These
+tests fail pre-fix, pass post-fix.
+
+FTS-only / no model loads.
+"""
+import os
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+from truememory.ingest.hooks._shared import is_allowed_transcript, _transcript_roots
+
+
+def test_allowed_transcript_rejects_outside_root(tmp_path, monkeypatch):
+    # Constrain the allowed root to a temp dir.
+    root = tmp_path / "projects"
+    root.mkdir()
+    monkeypatch.setenv("TRUEMEMORY_TRANSCRIPT_DIR", str(root))
+
+    # An arbitrary readable file outside the root is rejected.
+    evil = tmp_path / "secret.txt"
+    evil.write_text("user: root\npassword: hunter2\n" * 50)
+    assert is_allowed_transcript(str(evil)) is False
+
+    # A real /etc/passwd-style absolute path is rejected.
+    assert is_allowed_transcript("/etc/passwd") is False
+
+    # Empty / missing is rejected (not crash).
+    assert is_allowed_transcript("") is False
+
+
+def test_allowed_transcript_accepts_inside_root(tmp_path, monkeypatch):
+    root = tmp_path / "projects"
+    root.mkdir()
+    monkeypatch.setenv("TRUEMEMORY_TRANSCRIPT_DIR", str(root))
+    good = root / "session-abc.jsonl"
+    good.write_text("{}")
+    assert is_allowed_transcript(str(good)) is True
+
+
+def test_allowed_transcript_rejects_symlink_escape(tmp_path, monkeypatch):
+    """A symlink INSIDE the root pointing OUTSIDE must be rejected (resolve())."""
+    root = tmp_path / "projects"
+    root.mkdir()
+    monkeypatch.setenv("TRUEMEMORY_TRANSCRIPT_DIR", str(root))
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret")
+    link = root / "innocent.jsonl"
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        return  # platform without symlink support
+    assert is_allowed_transcript(str(link)) is False
+
+
+def test_allowed_transcript_rejects_dotdot_escape(tmp_path, monkeypatch):
+    root = tmp_path / "projects"
+    root.mkdir()
+    monkeypatch.setenv("TRUEMEMORY_TRANSCRIPT_DIR", str(root))
+    escape = root / ".." / "secret.txt"
+    (tmp_path / "secret.txt").write_text("x")
+    assert is_allowed_transcript(str(escape)) is False
+
+
+def test_stop_hook_imports_and_uses_guard():
+    """stop.py main() calls is_allowed_transcript (guard is wired in)."""
+    import inspect
+    from truememory.ingest.hooks import stop
+    src = inspect.getsource(stop)
+    assert "is_allowed_transcript" in src, "stop hook must gate on the transcript allowlist"
+
+
+def test_drain_imports_and_uses_guard():
+    """session_start drain calls is_allowed_transcript (guard is wired in)."""
+    import inspect
+    from truememory.ingest.hooks import session_start
+    src = inspect.getsource(session_start)
+    assert "is_allowed_transcript" in src, "drain must gate on the transcript allowlist"
+
+
+def test_compact_shim_still_works(tmp_path, monkeypatch):
+    """#653 backward-compat: compact._is_allowed_transcript still resolves (delegates)."""
+    root = tmp_path / "projects"
+    root.mkdir()
+    monkeypatch.setenv("TRUEMEMORY_TRANSCRIPT_DIR", str(root))
+    from truememory.ingest.hooks import compact
+    assert compact._is_allowed_transcript("/etc/passwd") is False
+    good = root / "s.jsonl"
+    good.write_text("{}")
+    assert compact._is_allowed_transcript(str(good)) is True
+    assert _transcript_roots()  # shared roots non-empty

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -19,6 +19,53 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Transcript-path allowlist (M-90, shared)
+# ---------------------------------------------------------------------------
+# A hook's stdin and the backlog markers are attacker-influenceable in a
+# local-control scenario. ``parse_transcript`` reads any user-readable file
+# into the memory store via its plaintext fallback, so every code path that
+# feeds a ``transcript_path`` into ingestion must first confirm the path is
+# inside an expected transcripts root. #653/M-90 added this guard to the
+# compact hook only; it is hoisted here so stop.py and the SessionStart
+# backlog drain share the same check.
+
+def _transcript_roots() -> list[Path]:
+    """Directories a ``transcript_path`` is allowed to live under.
+
+    Defaults to Claude Code's ``~/.claude/projects``. An explicit
+    ``TRUEMEMORY_TRANSCRIPT_DIR`` override (tests / non-default installs) is
+    honored when set.
+    """
+    roots = [Path.home() / ".claude" / "projects"]
+    override = os.environ.get("TRUEMEMORY_TRANSCRIPT_DIR", "")
+    if override:
+        roots.insert(0, Path(override))
+    return roots
+
+
+def is_allowed_transcript(transcript_path: str) -> bool:
+    """Return True only if *transcript_path* resolves inside a transcripts root.
+
+    Resolves symlinks (``.resolve()``) and requires containment, so neither a
+    ``..`` escape nor a symlink whose target is outside the root passes.
+    """
+    if not transcript_path:
+        return False
+    try:
+        resolved = Path(transcript_path).resolve()
+    except (OSError, ValueError):
+        return False
+    for root in _transcript_roots():
+        try:
+            if resolved.is_relative_to(root.resolve()):
+                return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
 EXTRACTED_DIR = Path.home() / ".truememory" / "extracted"
 BACKLOG_DIR = Path.home() / ".truememory" / "backlog"
 RECALL_MARKER_DIR = Path.home() / ".truememory" / "recall_markers"

--- a/truememory/ingest/hooks/compact.py
+++ b/truememory/ingest/hooks/compact.py
@@ -29,39 +29,20 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 
-def _transcript_roots() -> list[Path]:
-    """Directories a transcript_path is allowed to live under (M-90).
+# M-90 transcript allowlist now lives in truememory.ingest.hooks._shared
+# (hoisted so stop.py and the SessionStart backlog drain share the same guard).
+# These thin shims keep the original names working for callers/tests.
 
-    Defaults to Claude Code's ``~/.claude/projects``. An explicit
-    ``TRUEMEMORY_TRANSCRIPT_DIR`` override (e.g. for tests or non-default
-    installs) is honored when set.
-    """
-    roots = [Path.home() / ".claude" / "projects"]
-    override = os.environ.get("TRUEMEMORY_TRANSCRIPT_DIR", "")
-    if override:
-        roots.insert(0, Path(override))
-    return roots
+def _transcript_roots() -> list[Path]:
+    """Shim — see ``_shared._transcript_roots``."""
+    from truememory.ingest.hooks._shared import _transcript_roots as _shared_roots
+    return _shared_roots()
 
 
 def _is_allowed_transcript(transcript_path: str) -> bool:
-    """Return True only if *transcript_path* is inside an expected root (M-90).
-
-    The hook's stdin / backlog is attacker-influenceable in a local-control
-    scenario; ``parse_transcript`` would otherwise read any user-readable file
-    into the memory store via its plaintext fallback. Resolve symlinks and
-    require containment under a known transcripts root.
-    """
-    try:
-        resolved = Path(transcript_path).resolve()
-    except (OSError, ValueError):
-        return False
-    for root in _transcript_roots():
-        try:
-            if resolved.is_relative_to(root.resolve()):
-                return True
-        except (OSError, ValueError):
-            continue
-    return False
+    """Shim — delegates to the shared M-90 guard (``_shared.is_allowed_transcript``)."""
+    from truememory.ingest.hooks._shared import is_allowed_transcript
+    return is_allowed_transcript(transcript_path)
 
 
 def _parse_args() -> argparse.Namespace:

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -251,6 +251,7 @@ def _drain_backlog() -> None:
         record_stale_processing_pid,
         mark_session_extracted,
         _quarantine_marker,
+        is_allowed_transcript,
     )
     cleanup_stale_processing(BACKLOG_DIR)
 
@@ -288,6 +289,13 @@ def _drain_backlog() -> None:
         try:
             transcript = data.get("transcript_path", "")
             if not transcript or not Path(transcript).exists():
+                claimed_path.unlink(missing_ok=True)
+                continue
+            # M-90: a backlog marker's transcript_path is attacker-influenceable;
+            # confirm containment in an allowed transcripts root before parsing
+            # (parse_transcript's plaintext fallback would read any readable file).
+            if not is_allowed_transcript(transcript):
+                log.warning("Drain: transcript_path %r outside allowed roots; dropping marker", transcript)
                 claimed_path.unlink(missing_ok=True)
                 continue
 

--- a/truememory/ingest/hooks/stop.py
+++ b/truememory/ingest/hooks/stop.py
@@ -140,6 +140,14 @@ def main():
 
     if not transcript_path or not Path(transcript_path).exists():
         return
+    # M-90: transcript_path comes from attacker-influenceable hook stdin.
+    # parse_transcript's plaintext fallback would read ANY readable file into
+    # the memory store, so confirm containment in an allowed transcripts root
+    # (the compact hook already did this; stop/drain previously did not).
+    from truememory.ingest.hooks._shared import is_allowed_transcript
+    if not is_allowed_transcript(transcript_path):
+        log.warning("stop hook: transcript_path %r outside allowed roots; skipping", transcript_path)
+        return
 
     # Pre-flight check: ensure our write directories exist and are writable
     # so we fail early with a clear message instead of silently losing work


### PR DESCRIPTION
## Summary
The M-90 transcript-root allowlist (#653) was applied to the **compact** hook only. The **stop** hook and the **SessionStart backlog drain** gated solely on `Path.exists()` before passing `transcript_path` to `parse_transcript`, whose plaintext fallback will read any readable file into the memory store. This extends the same containment guard to those two paths.

## Changes
- `_shared.py` — hoist `is_allowed_transcript()` + `_transcript_roots()` (resolves symlinks, requires containment under an allowed transcripts root; honors `TRUEMEMORY_TRANSCRIPT_DIR`).
- `stop.py` — gate on `is_allowed_transcript(transcript_path)` after the existence check.
- `session_start.py` — gate the backlog-drain path the same way (drops a marker whose path is outside the allowed root).
- `compact.py` — its `_is_allowed_transcript` / `_transcript_roots` become thin shims delegating to `_shared` (dedups the logic; preserves the names #653's tests use).

## Tests
`tests/test_transcript_guard_stop_drain.py` (8): a path outside the allowed root — including `/etc/passwd`, a symlink-escape, and a `..` escape — is rejected; a path inside `TRUEMEMORY_TRANSCRIPT_DIR` is accepted; stop + drain wire the guard; the #653 compact shim still resolves. #653 suite still green (21 passed). ruff clean.

Hardening pass: BLAST OFF v3.