### PR TITLE
fix: single-memory forget purges derived entity aggregates (#685)

### DIFF
--- a/tests/test_issue_685_forget_derived.py
+++ b/tests/test_issue_685_forget_derived.py
@@ -1,0 +1,112 @@
+"""Regression lock: single-memory forget must not leave the forgotten content
+behind in derived aggregate tables (S1-1 / issue #685).
+
+Pre-fix: delete_message removed the messages row + FK-linked vec/FTS + a few
+message-keyed tables, but NOT the entity-keyed aggregates summaries /
+entity_profiles / entity_style_vectors / entity_relationships, so a forgotten
+fact survived verbatim inside a consolidated summary or entity profile.
+Post-fix: delete_message also purges the involved entities' derived rows (and
+any summary that lists the message id).
+
+FTS-only / no model loads — exercises delete_message directly against
+hand-seeded derived rows.
+"""
+import os
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+import json
+
+from truememory.storage import create_db, insert_message, delete_message
+
+
+def _seed(conn):
+    mid = insert_message(conn, {
+        "content": "my social security number is 555-00-1234",
+        "sender": "josh", "recipient": "assistant",
+        "timestamp": "2026-01-01T00:00:00Z", "category": "s", "modality": "conversation",
+    })
+    # Hand-build derived aggregates that reference the message / entity.
+    conn.execute(
+        "INSERT INTO summaries (period, entity, summary, key_facts, message_ids, created_at) "
+        "VALUES ('all', 'josh', ?, ?, ?, '2026-01-01T00:00:00Z')",
+        ("josh's SSN is 555-00-1234", json.dumps(["555-00-1234"]), json.dumps([mid])),
+    )
+    conn.execute(
+        "INSERT INTO entity_profiles (entity, message_count, traits) VALUES ('josh', 1, ?)",
+        (json.dumps({"ssn": "555-00-1234"}),),
+    )
+    conn.execute(
+        "INSERT INTO entity_style_vectors (entity, vector, message_count) VALUES ('josh', '[0.1]', 1)"
+    )
+    conn.execute(
+        "INSERT INTO entity_relationships (entity_a, entity_b, relationship_type) "
+        "VALUES ('josh', 'assistant', 'self')"
+    )
+    conn.commit()
+    return mid
+
+
+def test_forget_purges_derived_aggregates(tmp_path):
+    conn = create_db(tmp_path / "forget.db")
+    mid = _seed(conn)
+
+    # Sanity: the forgotten content is present in derived tables before delete.
+    assert conn.execute("SELECT COUNT(*) FROM summaries WHERE entity='josh'").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM entity_profiles WHERE entity='josh'").fetchone()[0] == 1
+
+    assert delete_message(conn, mid) is True
+
+    # The message and every entity-keyed aggregate for 'josh' are gone.
+    assert conn.execute("SELECT COUNT(*) FROM messages WHERE id=?", (mid,)).fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM summaries WHERE entity='josh'").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM entity_profiles WHERE entity='josh'").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM entity_style_vectors WHERE entity='josh'").fetchone()[0] == 0
+    assert conn.execute(
+        "SELECT COUNT(*) FROM entity_relationships WHERE entity_a='josh' OR entity_b='josh'"
+    ).fetchone()[0] == 0
+
+    # The SSN string survives nowhere in summaries/profiles.
+    leaked = conn.execute(
+        "SELECT COUNT(*) FROM summaries WHERE summary LIKE '%555-00-1234%' OR key_facts LIKE '%555-00-1234%'"
+    ).fetchone()[0]
+    assert leaked == 0
+    conn.close()
+
+
+def test_forget_summary_by_message_id_even_for_other_entity(tmp_path):
+    """A summary that lists the message id is purged even if its `entity` differs."""
+    conn = create_db(tmp_path / "forget2.db")
+    mid = insert_message(conn, {
+        "content": "secret fact", "sender": "alice", "recipient": "bob",
+        "timestamp": "2026-01-01T00:00:00Z", "category": "s", "modality": "conversation",
+    })
+    # Summary attributed to a THIRD entity but built from this message id.
+    conn.execute(
+        "INSERT INTO summaries (period, entity, summary, message_ids, created_at) "
+        "VALUES ('all', 'carol', 'mentions secret fact', ?, '2026-01-01T00:00:00Z')",
+        (json.dumps([mid]),),
+    )
+    conn.commit()
+    assert delete_message(conn, mid) is True
+    assert conn.execute("SELECT COUNT(*) FROM summaries").fetchone()[0] == 0
+    conn.close()
+
+
+def test_forget_unrelated_entity_summary_preserved(tmp_path):
+    """Deleting josh's message must NOT wipe an unrelated entity's summary."""
+    conn = create_db(tmp_path / "forget3.db")
+    mid = insert_message(conn, {
+        "content": "josh fact", "sender": "josh", "recipient": "assistant",
+        "timestamp": "2026-01-01T00:00:00Z", "category": "s", "modality": "conversation",
+    })
+    conn.execute(
+        "INSERT INTO summaries (period, entity, summary, message_ids, created_at) "
+        "VALUES ('all', 'dylan', 'dylan likes climbing', '[]', '2026-01-01T00:00:00Z')"
+    )
+    conn.commit()
+    assert delete_message(conn, mid) is True
+    # dylan's unrelated summary is untouched.
+    assert conn.execute("SELECT COUNT(*) FROM summaries WHERE entity='dylan'").fetchone()[0] == 1
+    conn.close()

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -1072,6 +1072,46 @@ def delete_message(conn: sqlite3.Connection, msg_id: int) -> bool:
         except sqlite3.OperationalError:
             pass
 
+    # Right-to-be-forgotten (S1-1): summaries / entity_profiles /
+    # entity_style_vectors / entity_relationships are derived AGGREGATES keyed
+    # by entity (not message_id), so a forgotten message's content can survive
+    # verbatim inside them. They aren't reachable by FK cascade. Remove the
+    # involved entities' derived rows (plus any summary that literally lists
+    # this message) so they are rebuilt clean — without the forgotten fact —
+    # on the next consolidation. Bounded to the message's own sender/recipient.
+    try:
+        _row = conn.execute(
+            "SELECT sender, recipient FROM messages WHERE id = ?", (msg_id,)
+        ).fetchone()
+    except sqlite3.OperationalError:
+        _row = None
+    _entities = {e for e in (_row or ()) if e}
+
+    # Summaries that explicitly reference this message id (precise).
+    try:
+        conn.execute(
+            "DELETE FROM summaries WHERE id IN ("
+            " SELECT s.id FROM summaries s, json_each(s.message_ids) j"
+            " WHERE CAST(j.value AS INTEGER) = ?)",
+            (msg_id,),
+        )
+    except sqlite3.OperationalError:
+        pass  # no json1 / no summaries table — entity sweep below still covers it
+
+    for _ent in _entities:
+        for _tbl in ("summaries", "entity_profiles", "entity_style_vectors"):
+            try:
+                conn.execute(f"DELETE FROM {_tbl} WHERE entity = ?", (_ent,))
+            except sqlite3.OperationalError:
+                pass
+        try:
+            conn.execute(
+                "DELETE FROM entity_relationships WHERE entity_a = ? OR entity_b = ?",
+                (_ent, _ent),
+            )
+        except sqlite3.OperationalError:
+            pass
+
     cursor = conn.execute("DELETE FROM messages WHERE id = ?", (msg_id,))
     deleted = cursor.rowcount > 0
 


### PR DESCRIPTION
Closes #685.

`delete_message` (storage.py) removed the `messages` row, FK-linked vec/FTS, and the message-keyed tables (fact_timeline, landmark_events, surprise_scores, message_clusters, causal_edges) — but **not** the entity-keyed aggregates `summaries`, `entity_profiles`, `entity_style_vectors`, `entity_relationships`. Those have no FK to `messages`, so a "forgotten" fact could survive verbatim inside a consolidated summary or entity profile. (`delete_all` already wiped these; only the single-memory path was incomplete.)

**Fix:** `delete_message` now also removes the involved entities' (sender/recipient) derived rows, plus any summary that explicitly lists the message id (via `json_each(message_ids)`), so they rebuild clean on the next consolidation. Bounded to the message's own entities — unrelated entities' aggregates are preserved. All table touches are guarded with `OperationalError` for installs missing a table / json1.

**Tests** (`tests/test_issue_685_forget_derived.py`): the forgotten content is gone from all four tables; a summary listing the msg id is purged even under a different `entity`; an unrelated entity's summary survives. 31 existing delete/forget tests still pass. ruff clean.

BLAST OFF v3.