### PR TITLE
fix: crash-safe L2→cosine vector migration staging (#686)

### DIFF
--- a/tests/test_issue_631_cosine_metric.py
+++ b/tests/test_issue_631_cosine_metric.py
@@ -175,6 +175,11 @@ class TestIssue631CosineMetric:
         conn.execute("CREATE TABLE vec_messages_cos_stage (rowid INTEGER PRIMARY KEY, embedding BLOB)")
         conn.execute("INSERT INTO vec_messages_cos_stage VALUES (1, ?)", (_ser([1.0, 0.0]),))
         conn.execute("INSERT INTO vec_messages_cos_stage VALUES (9, ?)", (_ser([0.0, 1.0]),))
+        # D1-2 (#686): a resumable stage must carry the "done" marker written in
+        # the same commit as its rows. Construct the stage the way Phase 1 now
+        # leaves it on a completed copy, so it is promoted rather than re-staged.
+        conn.execute("CREATE TABLE vec_messages_cos_stage_done (done INTEGER PRIMARY KEY)")
+        conn.execute("INSERT INTO vec_messages_cos_stage_done(done) VALUES (1)")
         conn.commit()
 
         assert migrate_to_cosine_metric(conn) is True

--- a/tests/test_issue_686_migration_sentinel.py
+++ b/tests/test_issue_686_migration_sentinel.py
@@ -1,0 +1,117 @@
+"""Regression lock: the L2->cosine vector migration must not lose vectors when
+a prior run crashed mid-staging (D1-2 / issue #686).
+
+Pre-fix: Phase 1 created+committed an empty staging table; if the process died
+before the rows were staged, the resume path trusted ANY existing stage and
+swapped it over the intact L2 table -> all vectors silently lost (0 rows).
+Post-fix: staging writes a "done" marker in the same commit as the rows, so an
+interrupted stage is detected and the migration re-stages from the intact
+original instead of promoting an empty stage.
+
+Synthetic vectors / no model loads. Gated on sqlite-vec loadability.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+
+def _can_load_vec() -> bool:
+    try:
+        import sqlite_vec
+        c = sqlite3.connect(":memory:")
+        c.enable_load_extension(True)
+        sqlite_vec.load(c)
+        c.close()
+        return True
+    except Exception:
+        return False
+
+
+_HAS_VEC = _can_load_vec()
+pytestmark = pytest.mark.skipif(not _HAS_VEC, reason="sqlite-vec cannot load")
+
+DIM = 8
+
+
+def _conn(tmp_path):
+    import sqlite_vec
+    c = sqlite3.connect(str(tmp_path / "vec.db"))
+    c.enable_load_extension(True)
+    sqlite_vec.load(c)
+    c.enable_load_extension(False)
+    return c
+
+
+def _make_l2_table(c, n=5):
+    """Create an OLD-format (L2-default, no distance_metric=cosine) vec0 table."""
+    from truememory.vector_search import serialize_f32
+    c.execute(f"CREATE VIRTUAL TABLE vec_messages USING vec0(embedding float[{DIM}])")
+    for i in range(1, n + 1):
+        vec = [float((i + j) % 5 + 1) for j in range(DIM)]  # nonzero, finite
+        c.execute("INSERT INTO vec_messages(rowid, embedding) VALUES (?, ?)", (i, serialize_f32(vec)))
+    c.commit()
+
+
+def test_happy_path_migrates_and_preserves_vectors(tmp_path):
+    from truememory.vector_search import migrate_to_cosine_metric, _table_uses_cosine
+    c = _conn(tmp_path)
+    _make_l2_table(c, n=5)
+    assert not _table_uses_cosine(c, "vec_messages")
+
+    assert migrate_to_cosine_metric(c) is True
+    assert _table_uses_cosine(c, "vec_messages")
+    n = c.execute("SELECT COUNT(*) FROM vec_messages").fetchone()[0]
+    assert n == 5, f"expected 5 vectors carried over, got {n}"
+    c.close()
+
+
+def test_interrupted_stage_does_not_lose_vectors(tmp_path):
+    """The D1-2 scenario: an empty stage left by a mid-copy crash must NOT be
+    promoted over the intact original."""
+    from truememory.vector_search import migrate_to_cosine_metric, _table_uses_cosine
+    c = _conn(tmp_path)
+    _make_l2_table(c, n=5)
+
+    # Simulate a crash DURING Phase 1: the stage table exists but is empty and
+    # has NO done marker (the row inserts + marker never committed). The
+    # original L2 table is still fully intact.
+    c.execute("CREATE TABLE vec_messages_cos_stage (rowid INTEGER PRIMARY KEY, embedding BLOB)")
+    c.commit()
+
+    assert migrate_to_cosine_metric(c) is True
+    # Vectors must survive (re-staged from the intact original), NOT be wiped.
+    n = c.execute("SELECT COUNT(*) FROM vec_messages").fetchone()[0]
+    assert n == 5, f"interrupted stage lost vectors: got {n}, expected 5 (D1-2 regression)"
+    assert _table_uses_cosine(c, "vec_messages")
+    # the partial stage + its (absent) marker are cleaned up
+    leftover = c.execute(
+        "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'vec_messages_cos_stage%'"
+    ).fetchone()[0]
+    assert leftover == 0
+    c.close()
+
+
+def test_complete_stage_resume_finishes_swap(tmp_path):
+    """A stage with rows + a done marker (durable crash AFTER staging) is
+    promoted to finish the swap."""
+    from truememory.vector_search import migrate_to_cosine_metric, serialize_f32, _table_uses_cosine
+    c = _conn(tmp_path)
+    _make_l2_table(c, n=3)
+
+    # Simulate a crash AFTER staging completed (rows + done marker present) but
+    # before the swap. Build the stage exactly as Phase 1 leaves it.
+    c.execute("CREATE TABLE vec_messages_cos_stage (rowid INTEGER PRIMARY KEY, embedding BLOB)")
+    c.execute("CREATE TABLE vec_messages_cos_stage_done (done INTEGER PRIMARY KEY)")
+    for i in range(1, 4):
+        v = [1.0 / (DIM ** 0.5)] * DIM  # unit vector
+        c.execute("INSERT INTO vec_messages_cos_stage(rowid, embedding) VALUES (?, ?)", (i, serialize_f32(v)))
+    c.execute("INSERT INTO vec_messages_cos_stage_done(done) VALUES (1)")
+    c.commit()
+
+    assert migrate_to_cosine_metric(c) is True
+    assert _table_uses_cosine(c, "vec_messages")
+    n = c.execute("SELECT COUNT(*) FROM vec_messages").fetchone()[0]
+    assert n == 3, f"complete-stage resume should carry 3, got {n}"
+    c.close()

--- a/truememory/vector_search.py
+++ b/truememory/vector_search.py
@@ -1338,13 +1338,21 @@ def _rebuild_table_as_cosine(conn: sqlite3.Connection, table_name: str) -> int:
         return 0
 
     stage = f"{table_name}_cos_stage"
+    stage_done = f"{stage}_done"
     fmt = f"{dim}f"
 
     # Phase 1: copy normalized vectors into a durable plain staging table.
+    # D1-2 crash-safety: a separate "done" marker row is written in the SAME
+    # commit as the staged rows. An interrupted stage (crash mid-copy) leaves an
+    # empty/partial stage with NO done marker, so resume can tell it apart from a
+    # complete stage and re-stage from the still-intact original instead of
+    # swapping an empty stage over it and losing every vector.
     conn.execute(f"DROP TABLE IF EXISTS {stage}")
+    conn.execute(f"DROP TABLE IF EXISTS {stage_done}")
     conn.execute(
         f"CREATE TABLE {stage} (rowid INTEGER PRIMARY KEY, embedding BLOB)"
     )
+    conn.execute(f"CREATE TABLE {stage_done} (done INTEGER PRIMARY KEY)")
     rows = conn.execute(
         f"SELECT rowid, embedding FROM {table_name}"
     ).fetchall()
@@ -1363,7 +1371,10 @@ def _rebuild_table_as_cosine(conn: sqlite3.Connection, table_name: str) -> int:
             (rowid, serialize_f32(normed)),
         )
         staged += 1
-    conn.commit()  # staging durable before we touch the original
+    # Mark staging complete in the SAME transaction as the staged rows, so the
+    # marker is durable iff every row is.
+    conn.execute(f"INSERT INTO {stage_done}(done) VALUES (1)")
+    conn.commit()  # staged rows + completeness marker durable before we touch the original
 
     # Phase 2: replace the vec0 table with a cosine one and refill it.
     carried = _finish_cosine_swap(conn, table_name, dim)
@@ -1403,6 +1414,7 @@ def _finish_cosine_swap(
         )
         carried = len(staged_rows)
     conn.execute(f"DROP TABLE IF EXISTS {stage}")
+    conn.execute(f"DROP TABLE IF EXISTS {stage}_done")
     return carried
 
 
@@ -1437,17 +1449,35 @@ def migrate_to_cosine_metric(conn: sqlite3.Connection) -> bool:
             (stage,),
         ).fetchone()
         if has_stage:
-            # A prior run was interrupted between staging and swap. The staging
-            # table holds the already-normalized vectors — finish the swap.
-            dim = (
-                _detect_existing_vec_dim(conn, table)
-                or _detect_existing_vec_dim(conn, stage)
-                or _embedding_dim
+            # A prior run was interrupted between staging and swap. Only finish
+            # the swap if the staging completed durably (the "done" marker is
+            # present); otherwise the stage is empty/partial and the ORIGINAL
+            # table is still intact, so drop the partial stage and re-stage from
+            # scratch below rather than swapping an empty stage over the original
+            # and losing every vector (D1-2).
+            stage_done = f"{stage}_done"
+            stage_complete = bool(
+                conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE name = ? AND type='table'",
+                    (stage_done,),
+                ).fetchone()
+                and conn.execute(f"SELECT 1 FROM {stage_done} LIMIT 1").fetchone()
             )
-            _finish_cosine_swap(conn, table, dim)
+            if stage_complete:
+                dim = (
+                    _detect_existing_vec_dim(conn, table)
+                    or _detect_existing_vec_dim(conn, stage)
+                    or _embedding_dim
+                )
+                _finish_cosine_swap(conn, table, dim)
+                conn.commit()
+                migrated = True
+                continue
+            # Incomplete stage from an interrupted copy — discard it and fall
+            # through to a fresh rebuild from the intact original table.
+            conn.execute(f"DROP TABLE IF EXISTS {stage}")
+            conn.execute(f"DROP TABLE IF EXISTS {stage_done}")
             conn.commit()
-            migrated = True
-            continue
 
         exists = conn.execute(
             "SELECT 1 FROM sqlite_master WHERE name = ? AND type='table'",


### PR DESCRIPTION
Closes #686.

The #631 L2→cosine migration stages normalized vectors into `{table}_cos_stage`, then swaps it over the original (vec0 tables can't be renamed). Phase 1's `CREATE TABLE {stage}` + commit could leave an **empty/partial** stage if the process died mid-copy, and the resume path in `migrate_to_cosine_metric` promoted **any** existing stage over the still-intact L2 table — silently losing every vector (D1-2; repro ended with 0 rows).

**Fix:** write a `{table}_cos_stage_done` marker row in the **same commit** as the staged rows. Resume finishes the swap only when the marker is present; an interrupted stage (no marker) is discarded and re-staged from the intact original. The marker is written in Phase 1 before `_finish_cosine_swap` touches the original, so a crash *during* the swap is still resumable.

**Tests** (`tests/test_issue_686_migration_sentinel.py`): happy-path migrate preserves all vectors; an interrupted (markerless) stage does **not** lose vectors — the D1-2 regression; a complete stage (rows + marker) resumes the swap. The #631 resume test was updated to build the stage with the done marker (matching the new protocol). ruff clean.

BLAST OFF v3.