### PR TITLE
fix: dedup no longer silently drops near-token distinct facts on Base/Pro (#687)

### DIFF
--- a/tests/test_issue_687_dedup_near_token.py
+++ b/tests/test_issue_687_dedup_near_token.py
@@ -1,0 +1,92 @@
+"""Regression lock: dedup must not silently drop factually-distinct memories
+that differ only by a number at high cosine similarity (C2-DEDUP / issue #687).
+
+Pre-fix: a >0.92 cosine match (non-correction) returned DedupAction.SKIP BEFORE
+the LLM-arbitration path, so on Base/Pro "Project deadline is October 15th" vs
+"...16th" (cosine ~0.99) silently dropped the second fact. Post-fix: a >0.92
+match routes to the LLM when a config is present; without one, a digit-run
+divergence keeps both facts (ADD) and only true paraphrases fast-SKIP.
+
+No model loads — drives check_duplicate with a stubbed search function.
+"""
+import os
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+from truememory.ingest.dedup import (
+    check_duplicate,
+    DedupAction,
+    _has_divergent_numbers,
+)
+
+
+class _FakeMemory:
+    """Stub Memory whose search_vectors surfaces one candidate at a fixed cosine."""
+
+    def __init__(self, top_content, score=0.99):
+        self._top_content = top_content
+        self._score = score
+
+    def search_vectors(self, _query, limit=3):
+        return [{"id": 7, "content": self._top_content, "score": self._score, "score_space": "cosine"}]
+
+
+# ── the helper ───────────────────────────────────────────────────────────────
+
+def test_divergent_numbers_helper():
+    assert _has_divergent_numbers("deadline October 15th", "deadline October 16th") is True
+    assert _has_divergent_numbers("paid $116", "paid $117") is True
+    assert _has_divergent_numbers("version 1.2.0", "version 1.3.0") is True
+    # same numbers / pure paraphrase -> not divergent
+    assert _has_divergent_numbers("deadline is October 15th", "the deadline: October 15th") is False
+    assert _has_divergent_numbers("likes coffee", "enjoys coffee") is False
+
+
+# ── no-LLM (heuristic) path: divergent numbers must be kept ──────────────────
+
+def test_near_token_numeric_fact_not_dropped_without_llm():
+    decision = check_duplicate(
+        "Project deadline is October 16th",
+        memory=_FakeMemory("Project deadline is October 15th", score=0.99),
+        config=None,
+    )
+    assert decision.action == DedupAction.ADD, (
+        f"distinct-date fact was dropped: {decision.action} ({decision.reason})"
+    )
+
+
+def test_true_paraphrase_still_skipped_without_llm():
+    """A genuine paraphrase (no numeric divergence) still fast-SKIPs."""
+    decision = check_duplicate(
+        "the user really likes coffee",
+        memory=_FakeMemory("user likes coffee", score=0.99),
+        config=None,
+    )
+    assert decision.action == DedupAction.SKIP
+
+
+# ── LLM path: >0.92 routes to arbitration instead of silent SKIP ─────────────
+
+def test_high_similarity_routes_to_llm_when_config_present(monkeypatch):
+    """With an LLM config, a >0.92 match is arbitrated, not auto-SKIPped."""
+    import truememory.ingest.dedup as dedup_mod
+
+    called = {"n": 0}
+
+    def _fake_llm(fact, existing, existing_id, config):
+        called["n"] += 1
+        return dedup_mod.DedupDecision(action=DedupAction.ADD, fact=fact, reason="llm: distinct")
+
+    monkeypatch.setattr(dedup_mod, "_llm_dedup", _fake_llm)
+
+    class _Cfg:  # any truthy LLMConfig-ish object
+        pass
+
+    decision = check_duplicate(
+        "Project deadline is October 16th",
+        memory=_FakeMemory("Project deadline is October 15th", score=0.99),
+        config=_Cfg(),
+    )
+    assert called["n"] == 1, "the >0.92 match must reach LLM arbitration"
+    assert decision.action == DedupAction.ADD

--- a/truememory/ingest/dedup.py
+++ b/truememory/ingest/dedup.py
@@ -97,6 +97,23 @@ def _is_correction(fact: str, category: str = "") -> bool:
     return _has_update_markers(fact)
 
 
+_NUMBER_RE = re.compile(r"\d+")
+
+
+def _has_divergent_numbers(a: str, b: str) -> bool:
+    """True if *a* and *b* contain different multisets of digit runs.
+
+    C2-DEDUP (#687): on real Base/Pro embeddings two factually DISTINCT memories
+    that differ only by a number — a date digit ("October 15th" vs "16th"), a
+    dollar amount, a version, a count, an id — embed to cosine well above the
+    0.92 dedup threshold. Treating them as duplicates silently drops one fact.
+    A difference in the digit runs is a strong signal the facts are distinct and
+    must not be auto-SKIPped. Returns False when both sides have the same numbers
+    (or none), so genuine paraphrases still take the fast duplicate path.
+    """
+    return sorted(_NUMBER_RE.findall(a or "")) != sorted(_NUMBER_RE.findall(b or ""))
+
+
 def check_duplicate(
     fact: str,
     memory,
@@ -175,6 +192,26 @@ def check_duplicate(
                 return _llm_dedup(fact, top_content, top_id, config)
             return _heuristic_dedup(
                 fact, top_content, top_id, top_score, is_correction=True
+            )
+        # C2-DEDUP (#687): a >0.92 cosine match is NOT proof of the same fact —
+        # near-token differences (a date digit, dollar amount, version, id)
+        # embed this close yet are distinct. Don't silently SKIP:
+        #  - with an LLM config, let it arbitrate (canonical paraphrase
+        #    authority), exactly as the relative-score path below already does;
+        #  - without one, only fast-SKIP genuine paraphrases (identical digit
+        #    runs) and keep both facts when the numbers diverge.
+        if config:
+            return _llm_dedup(fact, top_content, top_id, config)
+        if _has_divergent_numbers(fact, top_content):
+            log.debug(
+                "High-similarity candidate (%.2f) has divergent numbers vs "
+                "existing — keeping as a distinct fact instead of SKIP",
+                top_score,
+            )
+            return DedupDecision(
+                action=DedupAction.ADD,
+                fact=fact,
+                reason=f"numeric divergence at high similarity ({top_score:.2f})",
             )
         return DedupDecision(
             action=DedupAction.SKIP,


### PR DESCRIPTION
Closes #687.

In `check_duplicate` (dedup.py), a `>0.92` cosine match (non-correction) returned `DedupAction.SKIP` **before** the LLM-arbitration path. On real Base/Pro (Qwen3) embeddings, two factually **distinct** memories that differ only by a number — a date digit ("October 15th" vs "16th"), a dollar amount, a version, a count, an id — embed to ~0.99, so the second fact was silently dropped. Tier-specific: upgrading edge→pro *starts* losing near-token facts.

**Fix:**
- With an LLM config present, a `>0.92` match now routes to `_llm_dedup` (the canonical paraphrase authority — matching what the relative-score path already does), instead of an unconditional SKIP.
- Without an LLM, a new `_has_divergent_numbers` guard keeps both facts (`ADD`) when their digit runs differ; genuine paraphrases (identical digit runs) still take the fast SKIP.

**Tests** (`tests/test_issue_687_dedup_near_token.py`): a divergent-number fact is kept without an LLM; a true paraphrase still SKIPs; a `>0.92` match reaches the LLM when a config is present. 105 existing dedup tests still pass. ruff clean.

BLAST OFF v3.