### PR TITLE
security: owner-only permissions for the DB and ~/.truememory tree (#688)

### DIFF
--- a/tests/test_issue_688_file_perms.py
+++ b/tests/test_issue_688_file_perms.py
@@ -1,0 +1,69 @@
+"""Regression lock: at-rest files/dirs holding memories or prompt text must be
+owner-only (S1-2 / issue #688).
+
+Pre-fix: the DB (all memories), recall cache, buffers, and several
+~/.truememory mkdirs were created world-readable (0644 files / 0755 dirs), so
+another local user could read stored memories on a shared host.
+
+POSIX-only — skipped on Windows where chmod modes don't apply.
+"""
+import os
+import sys
+import stat
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes only")
+
+
+def _mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def test_db_file_is_owner_only(tmp_path):
+    from truememory.storage import create_db
+    db = tmp_path / "memories.db"
+    conn = create_db(db)
+    conn.execute("CREATE TABLE IF NOT EXISTS t (x)")
+    conn.commit()
+    conn.close()
+    assert _mode(db) == 0o600, f"DB file mode {oct(_mode(db))} != 0o600"
+    # WAL/SHM, if present, must also be owner-only.
+    for suffix in ("-wal", "-shm"):
+        p = tmp_path / f"memories.db{suffix}"
+        if p.exists():
+            assert _mode(p) == 0o600, f"{p.name} mode {oct(_mode(p))} != 0o600"
+
+
+def test_atomic_write_text_is_owner_only(tmp_path):
+    from truememory.ingest.hooks._shared import _atomic_write_text
+    p = tmp_path / "marker.json"
+    _atomic_write_text(p, '{"x": 1}')
+    assert _mode(p) == 0o600, f"atomic-written file mode {oct(_mode(p))} != 0o600"
+    # explicit mode honored
+    p2 = tmp_path / "marker2.json"
+    _atomic_write_text(p2, "data", mode=0o644)
+    assert _mode(p2) == 0o644
+
+
+def test_secure_mkdir_sets_0700_on_leaf_and_root(tmp_path, monkeypatch):
+    import truememory.ingest.hooks._shared as shared
+    # Point the "root" at a temp dir so we don't touch the real ~/.truememory.
+    fake_root = tmp_path / ".truememory"
+    monkeypatch.setattr(shared, "_TRUEMEMORY_ROOT", fake_root)
+    leaf = fake_root / "extracted"
+    shared._secure_mkdir(leaf)
+    assert leaf.is_dir()
+    assert _mode(leaf) == 0o700, f"leaf mode {oct(_mode(leaf))} != 0o700"
+    assert _mode(fake_root) == 0o700, f"root mode {oct(_mode(fake_root))} != 0o700"
+
+
+def test_secure_mkdir_repairs_loose_root(tmp_path, monkeypatch):
+    """If ~/.truememory already exists world-traversable, it is tightened."""
+    import truememory.ingest.hooks._shared as shared
+    fake_root = tmp_path / ".truememory"
+    fake_root.mkdir()
+    os.chmod(fake_root, 0o755)  # the "hook-first ordering left it 0755" state
+    monkeypatch.setattr(shared, "_TRUEMEMORY_ROOT", fake_root)
+    shared._secure_mkdir(fake_root / "recall_markers")
+    assert _mode(fake_root) == 0o700, "loose root not tightened to 0700"

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -121,17 +121,25 @@ def _safe_session_id(session_id: str) -> str:
     return "".join(c for c in session_id if c.isalnum() or c in "-_")[:64]
 
 
-def _atomic_write_text(path: Path, text: str) -> None:
+def _atomic_write_text(path: Path, text: str, mode: int = 0o600) -> None:
     """Write ``text`` to ``path`` atomically via tmp file + os.replace.
 
     A reader can never observe a torn / partially-written marker: it sees
     either the old contents or the fully-written new contents. The tmp file
     is unique per-process so concurrent writers do not clobber each other's
     temp file before the rename (issue #644 / M-14).
+
+    The file is created owner-only (``mode``, default 0o600) so cache / marker
+    contents (which can include memory or prompt text) are not world-readable
+    on a multi-user host (S1-2 / #688). No-op on Windows.
     """
     tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
     try:
         tmp.write_text(text, encoding="utf-8")
+        try:
+            os.chmod(tmp, mode)
+        except OSError:
+            pass
         os.replace(tmp, path)
     except OSError:
         try:
@@ -139,6 +147,26 @@ def _atomic_write_text(path: Path, text: str) -> None:
         except OSError:
             pass
         raise
+
+
+_TRUEMEMORY_ROOT = Path.home() / ".truememory"
+
+
+def _secure_mkdir(path: Path) -> None:
+    """``mkdir -p`` *path*, then ensure both it and the ~/.truememory root are
+    owner-only (0700) (S1-2 / #688).
+
+    A hook can be the FIRST process to create ~/.truememory; without this it was
+    left 0755 (world-traversable), exposing the DB / caches under it on a
+    multi-user host even after the dir-level mitigation elsewhere. No-op on
+    Windows (POSIX modes don't apply).
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    for d in (_TRUEMEMORY_ROOT, path):
+        try:
+            d.chmod(0o700)
+        except OSError:
+            pass
 
 
 def should_extract_session(session_id: str, transcript_path: str) -> bool:
@@ -163,7 +191,7 @@ def should_extract_session(session_id: str, transcript_path: str) -> bool:
     if not safe_id:
         return True
 
-    EXTRACTED_DIR.mkdir(parents=True, exist_ok=True)
+    _secure_mkdir(EXTRACTED_DIR)
     marker = EXTRACTED_DIR / safe_id
 
     if not marker.exists():
@@ -236,7 +264,7 @@ def check_extraction_budget() -> bool:
         return True
     fd = -1
     try:
-        _BUDGET_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _secure_mkdir(_BUDGET_FILE.parent)
         fd = os.open(str(_BUDGET_FILE), os.O_RDWR | os.O_CREAT)
         if _HAS_FCNTL:
             fcntl.flock(fd, fcntl.LOCK_EX)
@@ -423,7 +451,7 @@ def mark_session_extracted(session_id: str, transcript_path: str, spawned_pid: i
         return
 
     try:
-        EXTRACTED_DIR.mkdir(parents=True, exist_ok=True)
+        _secure_mkdir(EXTRACTED_DIR)
         current_size = Path(transcript_path).stat().st_size
         marker = EXTRACTED_DIR / safe_id
         _atomic_write_text(marker, json.dumps({
@@ -445,7 +473,7 @@ def mark_recall_injected(session_id: str) -> None:
     if not safe_id:
         return
     try:
-        RECALL_MARKER_DIR.mkdir(parents=True, exist_ok=True)
+        _secure_mkdir(RECALL_MARKER_DIR)
         # Opportunistic sweep: markers from sessions that never sent a prompt
         # are never consumed; remove anything well past the debounce window so
         # the dir cannot grow unboundedly (mirrors _prune_old_buffers).
@@ -507,7 +535,7 @@ def set_recall_cache(
     if RECALL_CACHE_TTL <= 0:
         return
     try:
-        RECALL_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _secure_mkdir(RECALL_CACHE_PATH.parent)
         # Read existing entries (best-effort)
         existing: dict = {}
         try:

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -273,7 +273,8 @@ def _increment_prompt_count(session_id: str) -> int:
     safe_id = _safe_session_id_local(session_id)
     counter_file = _PROMPT_COUNTER_DIR / f"{safe_id}.count"
     try:
-        _PROMPT_COUNTER_DIR.mkdir(parents=True, exist_ok=True)
+        from truememory.ingest.hooks._shared import _secure_mkdir
+        _secure_mkdir(_PROMPT_COUNTER_DIR)  # S1-2 (#688): owner-only dir + ~/.truememory root 0700
     except OSError:
         pass
 

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -558,6 +558,16 @@ def create_db(db_path: str | Path) -> sqlite3.Connection:
     _check_dir_writable(db_path)
 
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    # S1-2 (#688): the DB file holds every stored memory (PII). Restrict it to
+    # owner-only so it isn't world-readable on a multi-user host. No-op on
+    # Windows (POSIX modes don't apply) and for :memory:.
+    if str(db_path) != ":memory:":
+        for _p in (Path(db_path), Path(f"{db_path}-wal"), Path(f"{db_path}-shm")):
+            try:
+                if _p.exists():
+                    os.chmod(_p, 0o600)
+            except OSError:
+                pass
     try:
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")


### PR DESCRIPTION
Closes #688 (the all-P1 portion: DB + dir tree). Recall-cache/buffer **file** perms are additionally tightened where written through `_atomic_write_text`; #691 reroutes the remaining cache write through it.

On POSIX, content holding memories/prompts was created world-readable: the DB (0644), and several `~/.truememory` `mkdir`s left the tree 0755 — so on a multi-user host another local user could read stored memories.

- `storage.create_db`: `chmod` the DB file (+ `-wal`/`-shm`) to **0600**.
- `_shared._atomic_write_text`: new `mode` param (default `0o600`) chmods the tmp before `os.replace`, so markers/caches written through it are owner-only.
- `_shared._secure_mkdir`: `mkdir -p` + chmod both the leaf **and** the `~/.truememory` root to **0700**, closing the "a hook created the root first at 0755" gap. Applied at the extracted/recall-marker/budget/recall-cache dir sites and the prompt-counter dir. (`BUFFER_DIR` already self-chmods 0700.)

All no-ops on Windows. **Tests** (`tests/test_issue_688_file_perms.py`): DB is 0600 (+ WAL/SHM); `_atomic_write_text` is 0600 and honors an explicit mode; `_secure_mkdir` sets 0700 on leaf + root; a pre-existing 0755 root is tightened. 86 storage/recall/hook regression tests still pass. ruff clean.

BLAST OFF v3.