### PR TITLE
perf: skip redundant FTS re-scan in search_consolidated when empty (#689)

### DIFF
--- a/tests/test_issue_689_recall_scaling.py
+++ b/tests/test_issue_689_recall_scaling.py
@@ -1,0 +1,65 @@
+"""Regression lock: search_consolidated must not re-run the broad-OR FTS query
+when there is no consolidated data (PERF-01 / issue #689).
+
+Pre-fix: with empty summaries + fact_timeline (the default until consolidate()
+runs, and always in FTS-only mode) search_consolidated fell through to an FTS
+fallback that re-ran the same broad-OR query the primary search pipeline had
+already run — doubling recall latency (~44% of search cost at scale).
+Post-fix: it returns [] early without touching FTS.
+
+FTS-only / no model loads.
+"""
+import os
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+import truememory.consolidation as consolidation
+from truememory.consolidation import search_consolidated
+from truememory.storage import create_db, insert_message
+
+
+def test_empty_consolidation_skips_fts_fallback(tmp_path, monkeypatch):
+    conn = create_db(tmp_path / "c.db")
+    # Seed messages so FTS *would* return hits if the fallback ran.
+    for i in range(5):
+        insert_message(conn, {
+            "content": f"the carbonsense journey milestone {i} funding round",
+            "sender": "alice", "recipient": "bob",
+            "timestamp": f"2026-0{i+1}-01T10:00:00Z", "category": "s", "modality": "conversation",
+        })
+    conn.commit()
+
+    # summaries + fact_timeline are empty (never consolidated).
+    assert conn.execute("SELECT COUNT(*) FROM summaries").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM fact_timeline").fetchone()[0] == 0
+
+    # Spy on the FTS fallback — it must NOT be called.
+    called = {"n": 0}
+    real = consolidation._fts_search
+
+    def _spy(*a, **k):
+        called["n"] += 1
+        return real(*a, **k)
+
+    monkeypatch.setattr(consolidation, "_fts_search", _spy)
+
+    res = search_consolidated(conn, "summarize the carbonsense journey funding", limit=10)
+    assert res == [], "search_consolidated should return [] when no consolidated data exists"
+    assert called["n"] == 0, "the redundant FTS fallback must not run on empty consolidation tables"
+    conn.close()
+
+
+def test_with_consolidated_data_still_searches(tmp_path):
+    """When a summary exists, search_consolidated still returns it (no regression)."""
+    import json
+    conn = create_db(tmp_path / "c2.db")
+    conn.execute(
+        "INSERT INTO summaries (period, entity, summary, key_facts, message_ids, created_at) "
+        "VALUES ('all', 'alice', ?, ?, '[]', '2026-01-01T00:00:00Z')",
+        ("alice raised a Series A funding round for carbonsense", json.dumps(["Series A"])),
+    )
+    conn.commit()
+    res = search_consolidated(conn, "alice funding carbonsense", limit=10)
+    assert any("Series A" in r.get("content", "") or "funding" in r.get("content", "") for r in res)
+    conn.close()

--- a/truememory/consolidation.py
+++ b/truememory/consolidation.py
@@ -1222,6 +1222,23 @@ def search_consolidated(conn: sqlite3.Connection, query: str,
     results: list[dict] = []
     lower_query = query.lower()
 
+    # PERF-01 (#689): search_consolidated is a SUPPLEMENT that surfaces
+    # consolidated artifacts (summaries / fact_timeline). When NEITHER table has
+    # any rows — the default until consolidate() runs, and always in FTS-only
+    # mode — there is nothing to surface, and the FTS fallback at the bottom
+    # would otherwise re-run the same broad-OR query the primary search pipeline
+    # already ran, doubling recall latency (≈44% of search cost at scale). Skip
+    # all of it when there's no consolidated data.
+    try:
+        has_consolidated = conn.execute(
+            "SELECT EXISTS(SELECT 1 FROM summaries) "
+            "OR EXISTS(SELECT 1 FROM fact_timeline)"
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        has_consolidated = 0
+    if not has_consolidated:
+        return []
+
     # ---- Search summaries table ----
     # Check for entity mentions in query to filter entity summaries
     target_entity = None


### PR DESCRIPTION
Closes #689 (PERF-01).

`search_consolidated` surfaces consolidated artifacts (summaries / fact_timeline). When **neither** table has rows — the default until `consolidate()` runs, and always in FTS-only mode — it fell through to an FTS fallback that re-ran the **same broad-OR query the primary search pipeline already ran**, doubling recall latency. This was the ~44% double-scan measured at scale and the dominant contributor to the superlinear recall growth (p50 168ms@1k → 2697ms@10k).

**Fix:** return `[]` early when `summaries` AND `fact_timeline` are both empty (O(1) EXISTS check), so the redundant fallback never runs. Users with consolidated data are unaffected.

(PERF-02, the broad-OR token union in fts_search, is a deeper FTS-ranking change tracked separately; this PR removes the duplicate scan, which is the measured 44%.)

**Test:** `tests/test_issue_689_recall_scaling.py` — empty consolidation tables → no `_fts_search` call and `[]`; a present summary is still returned. 58 consolidation tests still pass. ruff clean.

BLAST OFF v3.