### PR TITLE
perf: skip cross-encoder on recall/dedup-only paths (#690)

### DIFF
--- a/tests/test_issue_690_skip_reranker.py
+++ b/tests/test_issue_690_skip_reranker.py
@@ -1,0 +1,62 @@
+"""Regression lock: recall/dedup-only paths must skip the cross-encoder
+reranker (PERF-03 / issue #690).
+
+Pre-fix: the encoding-gate similar_memory lookup and the per-prompt novelty
+dedup search omitted ``_skip_reranker``, so each paid the cross-encoder — a
+full CrossEncoder model load in a cold hook subprocess — even though they only
+read content/score, never ranked order.
+
+No model loads — uses a stub Memory that records the _skip_reranker kwarg.
+"""
+import os
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+
+class _RecordingMemory:
+    """Records every search() call's kwargs; returns one bland result."""
+
+    def __init__(self):
+        self.calls = []
+
+    def search(self, query, **kwargs):
+        self.calls.append(kwargs)
+        return [{"id": 1, "content": "a prior memory", "score": 0.5, "score_space": "cosine"}]
+
+    # encoding_gate.similar_memory cache path may call search_vectors; provide it
+    def search_vectors(self, query, limit=10):
+        return [{"id": 1, "content": "a prior memory", "score": 0.5, "score_space": "cosine"}]
+
+
+def test_encoding_gate_similar_memory_skips_reranker():
+    from truememory.ingest.encoding_gate import EncodingGate
+    mem = _RecordingMemory()
+    gate = EncodingGate(memory=mem, user_id="u")
+    # Drive the _search(fact, limit=1) similar-memory path directly.
+    gate._search("some candidate fact", limit=1, skip_reranker=True)
+    assert mem.calls, "search was not called"
+    assert mem.calls[-1].get("_skip_reranker") is True, (
+        "encoding-gate similar-memory search must pass _skip_reranker=True"
+    )
+
+
+def test_encoding_gate_source_passes_skip_reranker():
+    """The _search call site for similar_memory (gate.py:316) passes skip_reranker."""
+    import inspect
+    from truememory.ingest import encoding_gate
+    src = inspect.getsource(encoding_gate)
+    # the limit=1 similar-memory lookup must request skip_reranker
+    assert "self._search(fact, limit=1, skip_reranker=True)" in src, (
+        "the similar_memory _search(limit=1) call must pass skip_reranker=True"
+    )
+
+
+def test_prompt_novelty_dedup_passes_skip_reranker():
+    """The per-prompt novelty dedup search (user_prompt_submit) passes _skip_reranker."""
+    import inspect
+    from truememory.ingest.hooks import user_prompt_submit
+    src = inspect.getsource(user_prompt_submit)
+    assert "limit=3, _skip_reranker=True" in src, (
+        "per-prompt novelty dedup search must pass _skip_reranker=True"
+    )

--- a/truememory/ingest/encoding_gate.py
+++ b/truememory/ingest/encoding_gate.py
@@ -313,7 +313,10 @@ class EncodingGate:
             else:
                 # Same directive exclusion as the cached path (issue #589,
                 # D-8): similar_memory must never expose directive text.
-                results = [r for r in self._search(fact, limit=1) if not r.get("directive")]
+                # PERF-03 (#690): only .content is read here (never ranked
+                # order), so skip the cross-encoder — paying a per-fact reranker
+                # (a cold-subprocess model load) for context text is wasteful.
+                results = [r for r in self._search(fact, limit=1, skip_reranker=True) if not r.get("directive")]
                 if results:
                     similar = results[0].get("content", "")
 

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -456,7 +456,10 @@ def _try_per_exchange_store(prompt: str, session_id: str, user_id: str, db_path:
             # number is untrustworthy, so fall back to the scale-free
             # word-overlap heuristic instead. (#631 makes the vector path
             # emit true cosine, so this stays correct as it lands.)
-            existing = m.search(prompt, user_id=user_id or None, limit=3)
+            # PERF-03 (#690): per-prompt novelty dedup reads only score/content,
+            # never ranked order — skip the cross-encoder (a cold-subprocess
+            # model load on the hot prompt path).
+            existing = m.search(prompt, user_id=user_id or None, limit=3, _skip_reranker=True)
             if existing:
                 for r in existing:
                     score = r.get("score", 0.0)


### PR DESCRIPTION
Closes #690 (PERF-03).

Two recall/dedup-only paths read only content/score (never ranked order) yet omitted `_skip_reranker`, so each paid the cross-encoder — a full `CrossEncoder` model load in a cold hook subprocess — on the hot prompt path:
- `encoding_gate.py:316` — the similar_memory lookup (shows context text).
- `user_prompt_submit.py:459` — the per-prompt novelty dedup search.

Both now pass `skip_reranker=True` / `_skip_reranker=True`. (The 5 intended hook recall sites already passed it per #645/#647.)

**Test:** `tests/test_issue_690_skip_reranker.py` — the gate's similar-memory search passes `_skip_reranker`; both call sites carry the flag. 89 encoding-gate/#632/#645 tests still pass. ruff clean.

BLAST OFF v3.