### PR TITLE
fix: atomic writes for adapter configs, recall cache, and pre-migration backup (#691)

### DIFF
--- a/tests/test_issue_691_atomic_writes.py
+++ b/tests/test_issue_691_atomic_writes.py
@@ -1,0 +1,100 @@
+"""Regression locks for atomic-write hardening (#691): adapter config writes
+(X2-1), recall-cache writes (C1-1), and the pre-migration backup (D1-6).
+
+No model loads.
+"""
+import os
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+import json
+import sqlite3
+import stat
+import sys
+
+
+# ── X2-1: shared atomic adapter write ────────────────────────────────────────
+
+def test_base_atomic_write_text_replaces_cleanly(tmp_path):
+    from truememory.hooks.adapters.base import atomic_write_text, atomic_write_json
+    p = tmp_path / "sub" / "config.json"  # parent doesn't exist yet
+    atomic_write_text(p, '{"a": 1}')
+    assert json.loads(p.read_text()) == {"a": 1}
+    # no leftover tmp files in the dir
+    assert not list(p.parent.glob(".*tmp*"))
+    atomic_write_json(p, {"b": 2})
+    assert json.loads(p.read_text()) == {"b": 2}
+
+
+def test_adapters_use_atomic_write(tmp_path):
+    """The 6 previously-bare adapters no longer call .write_text directly."""
+    import inspect
+    import importlib
+    for name in ("cursor", "codex", "gemini", "kimi", "hermes", "openclaw"):
+        mod = importlib.import_module(f"truememory.hooks.adapters.{name}")
+        src = inspect.getsource(mod)
+        assert ".write_text(" not in src, f"{name} still has a bare .write_text()"
+        assert "atomic_write_text" in src, f"{name} does not use atomic_write_text"
+
+
+# ── C1-1: recall cache uses the unique-per-pid tmp, not a fixed one ──────────
+
+def test_recall_cache_uses_unique_tmp():
+    import inspect
+    from truememory.ingest.hooks import _shared
+    # both cache writers must route through _atomic_write_text (unique per-pid
+    # tmp), not a fixed shared .tmp (C1-1 race).
+    set_src = inspect.getsource(_shared.set_recall_cache)
+    inv_src = inspect.getsource(_shared.invalidate_recall_cache)
+    for name, src in (("set_recall_cache", set_src), ("invalidate_recall_cache", inv_src)):
+        assert "_atomic_write_text(RECALL_CACHE_PATH" in src, (
+            f"{name} must write the cache via _atomic_write_text (unique tmp)"
+        )
+        # the old fixed-tmp code pattern (tmp = ...with_suffix; tmp.write_text)
+        # must be gone — check the actual write call, not comments.
+        assert "tmp.write_text(" not in src, (
+            f"{name} still does a manual fixed-tmp write (C1-1 race)"
+        )
+
+
+def test_recall_cache_set_and_invalidate_roundtrip(tmp_path, monkeypatch):
+    from truememory.ingest.hooks import _shared
+    cache = tmp_path / "recall_cache.json"
+    monkeypatch.setattr(_shared, "RECALL_CACHE_PATH", cache)
+    # set_recall_cache(context, db_path, user_id=..., ...)
+    _shared.set_recall_cache("ctx-one", "db", user_id="u")
+    assert cache.exists()
+    data = json.loads(cache.read_text())
+    assert any(v.get("context") == "ctx-one" for v in data.values())
+    # file is valid JSON (not torn) and owner-only
+    if sys.platform != "win32":
+        assert stat.S_IMODE(os.stat(cache).st_mode) == 0o600
+
+
+# ── D1-6: pre-migration backup is a consistent single-file snapshot ──────────
+
+def test_backup_is_consistent_single_file_snapshot(tmp_path):
+    from truememory.storage import create_db, _backup_database, insert_message
+    from pathlib import Path
+
+    db = tmp_path / "memories.db"
+    conn = create_db(db)
+    for i in range(10):
+        insert_message(conn, {
+            "content": f"fact {i} about the project", "sender": "alice",
+            "recipient": "bob", "timestamp": "2026-01-01T00:00:00Z",
+            "category": "s", "modality": "conversation",
+        })
+    conn.commit()  # data may live in the -wal at this point
+
+    backup = _backup_database(Path(db))
+    assert backup is not None and backup.exists()
+
+    # The backup is a COMPLETE single file: opening it alone (no -wal/-shm)
+    # must surface all rows — proving the WAL was folded in (D1-6).
+    assert not Path(f"{backup}-wal").exists()
+    bconn = sqlite3.connect(str(backup))
+    n = bconn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    bconn.close()
+    assert n == 10, f"backup snapshot missing rows: {n} != 10 (torn-WAL regression)"

--- a/truememory/hooks/adapters/base.py
+++ b/truememory/hooks/adapters/base.py
@@ -6,8 +6,38 @@ MCP server setup.
 """
 from __future__ import annotations
 
+import json
+import os
 from abc import ABC, abstractmethod
 from pathlib import Path
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Write *text* to *path* atomically (tmp-in-same-dir + os.replace).
+
+    X2-1 (#691): adapters write the user's live editor/CLI config. A bare
+    ``write_text`` can truncate that config if the process dies mid-write.
+    Writing to a unique per-process tmp in the same directory and atomically
+    renaming means a reader (or a crash) sees either the old file or the fully
+    written new one — never a torn one.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_json(path: Path, data, indent: int = 2) -> None:
+    """Atomically write *data* as JSON (see :func:`atomic_write_text`)."""
+    atomic_write_text(path, json.dumps(data, indent=indent))
 
 
 class CLIAdapter(ABC):

--- a/truememory/hooks/adapters/codex.py
+++ b/truememory/hooks/adapters/codex.py
@@ -16,7 +16,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from truememory.hooks.adapters.base import CLIAdapter
+from truememory.hooks.adapters.base import CLIAdapter, atomic_write_text
 
 log = logging.getLogger(__name__)
 
@@ -136,7 +136,7 @@ class CodexAdapter(CLIAdapter):
         )
 
         new_text = existing_text.rstrip() + "\n" + section
-        _CONFIG_PATH.write_text(new_text, encoding="utf-8")
+        atomic_write_text(_CONFIG_PATH, new_text)
 
     def install_hooks(
         self,
@@ -179,10 +179,10 @@ class CodexAdapter(CLIAdapter):
 
         if lines_to_append:
             new_text = existing_text.rstrip() + "\n" + "\n".join(lines_to_append) + "\n"
-            _CONFIG_PATH.write_text(new_text, encoding="utf-8")
+            atomic_write_text(_CONFIG_PATH, new_text)
         elif existing_text != (_CONFIG_PATH.read_text(encoding="utf-8") if _CONFIG_PATH.exists() else ""):
             # Legacy blocks were removed; write updated text even if nothing new appended
-            _CONFIG_PATH.write_text(existing_text, encoding="utf-8")
+            atomic_write_text(_CONFIG_PATH, existing_text)
 
     def uninstall(self) -> None:
         if not _CONFIG_PATH.exists():
@@ -195,7 +195,7 @@ class CodexAdapter(CLIAdapter):
         text = self._remove_mcp_section(text)
         text = self._remove_hook_blocks(text)
         text = self._remove_legacy_hook_blocks(text)
-        _CONFIG_PATH.write_text(text, encoding="utf-8")
+        atomic_write_text(_CONFIG_PATH, text)
 
     def verify(self) -> bool:
         if not _CONFIG_PATH.exists():

--- a/truememory/hooks/adapters/cursor.py
+++ b/truememory/hooks/adapters/cursor.py
@@ -13,7 +13,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from truememory.hooks.adapters.base import CLIAdapter
+from truememory.hooks.adapters.base import CLIAdapter, atomic_write_text
 
 _CURSOR_DIR = Path.home() / ".cursor"
 _MCP_CONFIG = _CURSOR_DIR / "mcp.json"
@@ -133,10 +133,7 @@ class CursorAdapter(CLIAdapter):
             "args": ["-m", "truememory.mcp_server"],
         }
 
-        _MCP_CONFIG.write_text(
-            json.dumps(existing, indent=2),
-            encoding="utf-8",
-        )
+        atomic_write_text(_MCP_CONFIG, json.dumps(existing, indent=2))
 
     def install_hooks(
         self,
@@ -212,10 +209,7 @@ class CursorAdapter(CLIAdapter):
                 "timeout": info["timeout"],
             })
 
-        _HOOK_CONFIG.write_text(
-            json.dumps(existing, indent=2),
-            encoding="utf-8",
-        )
+        atomic_write_text(_HOOK_CONFIG, json.dumps(existing, indent=2))
 
     def uninstall(self) -> None:
         self._remove_mcp_entry()
@@ -291,9 +285,7 @@ class CursorAdapter(CLIAdapter):
             servers = data.get("mcpServers", {})
             if isinstance(servers, dict) and "truememory" in servers:
                 del servers["truememory"]
-                _MCP_CONFIG.write_text(
-                    json.dumps(data, indent=2), encoding="utf-8",
-                )
+                atomic_write_text(_MCP_CONFIG, json.dumps(data, indent=2))
         except (json.JSONDecodeError, OSError):
             pass
 
@@ -325,6 +317,4 @@ class CursorAdapter(CLIAdapter):
             else:
                 del hooks[event]
 
-        _HOOK_CONFIG.write_text(
-            json.dumps(data, indent=2), encoding="utf-8",
-        )
+        atomic_write_text(_HOOK_CONFIG, json.dumps(data, indent=2))

--- a/truememory/hooks/adapters/gemini.py
+++ b/truememory/hooks/adapters/gemini.py
@@ -18,7 +18,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from truememory.hooks.adapters.base import CLIAdapter
+from truememory.hooks.adapters.base import CLIAdapter, atomic_write_text
 
 _GEMINI_DIR = Path.home() / ".gemini"
 _CONFIG_PATH = _GEMINI_DIR / "settings.json"
@@ -232,10 +232,7 @@ class GeminiAdapter(CLIAdapter):
 
     def _write_config(self, settings: dict) -> None:
         _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        _CONFIG_PATH.write_text(
-            json.dumps(settings, indent=2),
-            encoding="utf-8",
-        )
+        atomic_write_text(_CONFIG_PATH, json.dumps(settings, indent=2))
 
     def _has_mcp_entry(self) -> bool:
         if not _CONFIG_PATH.exists():

--- a/truememory/hooks/adapters/hermes.py
+++ b/truememory/hooks/adapters/hermes.py
@@ -29,7 +29,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from truememory.hooks.adapters.base import CLIAdapter
+from truememory.hooks.adapters.base import CLIAdapter, atomic_write_text
 
 log = logging.getLogger(__name__)
 
@@ -134,7 +134,7 @@ class HermesAdapter(CLIAdapter):
             "args": ["-m", "truememory.mcp_server"],
         }
 
-        _CONFIG.write_text(_yaml_safe_dump(existing), encoding="utf-8")
+        atomic_write_text(_CONFIG, _yaml_safe_dump(existing))
 
     def install_hooks(
         self,
@@ -190,7 +190,7 @@ class HermesAdapter(CLIAdapter):
                 entry["timeout"] = info["timeout"]
             event_list.append(entry)
 
-        _CONFIG.write_text(_yaml_safe_dump(existing), encoding="utf-8")
+        atomic_write_text(_CONFIG, _yaml_safe_dump(existing))
 
     def uninstall(self) -> None:
         self._remove_mcp_entry()
@@ -267,7 +267,7 @@ class HermesAdapter(CLIAdapter):
             servers = data.get("mcp_servers", {})
             if isinstance(servers, dict) and "truememory" in servers:
                 del servers["truememory"]
-                _CONFIG.write_text(_yaml_safe_dump(data), encoding="utf-8")
+                atomic_write_text(_CONFIG, _yaml_safe_dump(data))
         except OSError:
             pass
 
@@ -299,6 +299,6 @@ class HermesAdapter(CLIAdapter):
                     else:
                         del hooks[event]
             if changed:
-                _CONFIG.write_text(_yaml_safe_dump(data), encoding="utf-8")
+                atomic_write_text(_CONFIG, _yaml_safe_dump(data))
         except OSError:
             pass

--- a/truememory/hooks/adapters/kimi.py
+++ b/truememory/hooks/adapters/kimi.py
@@ -14,7 +14,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from truememory.hooks.adapters.base import CLIAdapter
+from truememory.hooks.adapters.base import CLIAdapter, atomic_write_text
 
 log = logging.getLogger(__name__)
 
@@ -95,10 +95,7 @@ class KimiAdapter(CLIAdapter):
             "args": ["-m", "truememory.mcp_server"],
         }
 
-        _MCP_CONFIG.write_text(
-            json.dumps(existing, indent=2),
-            encoding="utf-8",
-        )
+        atomic_write_text(_MCP_CONFIG, json.dumps(existing, indent=2))
 
     def install_hooks(
         self,
@@ -136,7 +133,7 @@ class KimiAdapter(CLIAdapter):
 
         if lines_to_append:
             new_text = existing_text.rstrip() + "\n" + "\n".join(lines_to_append) + "\n"
-            _HOOK_CONFIG.write_text(new_text, encoding="utf-8")
+            atomic_write_text(_HOOK_CONFIG, new_text)
 
     def uninstall(self) -> None:
         self._remove_mcp_entry()
@@ -246,9 +243,7 @@ class KimiAdapter(CLIAdapter):
             servers = data.get("mcpServers", {})
             if "truememory" in servers:
                 del servers["truememory"]
-                _MCP_CONFIG.write_text(
-                    json.dumps(data, indent=2), encoding="utf-8",
-                )
+                atomic_write_text(_MCP_CONFIG, json.dumps(data, indent=2))
         except (json.JSONDecodeError, OSError):
             pass
 
@@ -283,4 +278,4 @@ class KimiAdapter(CLIAdapter):
             cleaned.append(line)
             i += 1
 
-        _HOOK_CONFIG.write_text("".join(cleaned), encoding="utf-8")
+        atomic_write_text(_HOOK_CONFIG, "".join(cleaned))

--- a/truememory/hooks/adapters/openclaw.py
+++ b/truememory/hooks/adapters/openclaw.py
@@ -32,7 +32,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from truememory.hooks.adapters.base import CLIAdapter
+from truememory.hooks.adapters.base import CLIAdapter, atomic_write_text
 
 log = logging.getLogger(__name__)
 
@@ -163,10 +163,7 @@ class OpenClawAdapter(CLIAdapter):
             if not old_top:
                 del existing["mcpServers"]
 
-        _CONFIG_PATH.write_text(
-            json.dumps(existing, indent=2),
-            encoding="utf-8",
-        )
+        atomic_write_text(_CONFIG_PATH, json.dumps(existing, indent=2))
 
     def install_hooks(
         self,
@@ -187,7 +184,7 @@ class OpenClawAdapter(CLIAdapter):
                         'process.env.TRUEMEMORY_PYTHON || "python3"',
                         f'process.env.TRUEMEMORY_PYTHON || "{python_path}"',
                     )
-                dst.write_text(content, encoding="utf-8")
+                atomic_write_text(dst, content)
 
     def uninstall(self) -> None:
         self._remove_mcp_entry()
@@ -261,9 +258,7 @@ class OpenClawAdapter(CLIAdapter):
                 changed = True
 
             if changed:
-                _CONFIG_PATH.write_text(
-                    json.dumps(data, indent=2), encoding="utf-8",
-                )
+                atomic_write_text(_CONFIG_PATH, json.dumps(data, indent=2))
         except OSError:
             pass
 

--- a/truememory/ingest/hooks/_shared.py
+++ b/truememory/ingest/hooks/_shared.py
@@ -550,9 +550,12 @@ def set_recall_cache(
             "timestamp": time.time(),
             "context": context,
         }
-        tmp = RECALL_CACHE_PATH.with_suffix(".tmp")
-        tmp.write_text(json.dumps(existing), encoding="utf-8")
-        os.replace(tmp, RECALL_CACHE_PATH)
+        # C1-1 (#691): use the unique per-process tmp (via _atomic_write_text)
+        # instead of a FIXED RECALL_CACHE_PATH.with_suffix(".tmp"). Concurrent
+        # writers (session_start + core.py + a forget) sharing one fixed tmp
+        # could interleave and leave the cache file as two concatenated JSON
+        # docs; the next read then reset existing={}, silently dropping entries.
+        _atomic_write_text(RECALL_CACHE_PATH, json.dumps(existing))
     except OSError:
         pass
 
@@ -580,9 +583,8 @@ def invalidate_recall_cache(db_path: str = "", user_id: str = "") -> None:
             for k in matched:
                 del data[k]
             if data:
-                tmp = RECALL_CACHE_PATH.with_suffix(".tmp")
-                tmp.write_text(json.dumps(data), encoding="utf-8")
-                os.replace(tmp, RECALL_CACHE_PATH)
+                # C1-1 (#691): unique per-process tmp, not a fixed shared one.
+                _atomic_write_text(RECALL_CACHE_PATH, json.dumps(data))
             else:
                 RECALL_CACHE_PATH.unlink(missing_ok=True)
     except (OSError, json.JSONDecodeError, TypeError):

--- a/truememory/storage.py
+++ b/truememory/storage.py
@@ -419,7 +419,6 @@ def _backup_database(db_path: Path) -> Path | None:
     Rotates old backups so the degraded-legacy re-backup path cannot fill the
     disk (M-24). Returns the backup path on success, None on failure.
     """
-    import shutil
     import uuid
 
     suffix = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
@@ -428,18 +427,37 @@ def _backup_database(db_path: Path) -> Path | None:
     if backup.exists():
         return None
 
+    # D1-6 (#691): the old approach copied the main DB and the -wal/-shm files
+    # separately with shutil.copy2 — NON-atomic. A concurrent writer (the
+    # documented multi-process model) could change the WAL between the copies,
+    # tearing the backup pair so a restore fails ("no such table"). Use SQLite's
+    # Online Backup API instead: it produces a SINGLE, internally-consistent
+    # snapshot file (WAL folded in) regardless of concurrent writers, so a
+    # restore is a single `cp backup db` with no sibling files.
+    src = dst = None
     try:
-        shutil.copy2(str(db_path), str(backup))
-        for ext in ("-wal", "-shm"):
-            wal_path = Path(f"{db_path}{ext}")
-            if wal_path.exists():
-                shutil.copy2(str(wal_path), str(backup) + ext)
-        log.info("Legacy DB backup created: %s", backup)
+        src = sqlite3.connect(str(db_path))
+        dst = sqlite3.connect(str(backup))
+        with dst:
+            src.backup(dst)
+        log.info("Legacy DB backup created (consistent snapshot): %s", backup)
         _prune_old_backups(db_path)
         return backup
     except Exception as e:
         log.warning("Could not back up database before migration: %s", e)
+        try:
+            if backup.exists():
+                backup.unlink()
+        except OSError:
+            pass
         return None
+    finally:
+        for _c in (src, dst):
+            if _c is not None:
+                try:
+                    _c.close()
+                except sqlite3.Error:
+                    pass
 
 
 def _migrate_messages_schema(conn: sqlite3.Connection, db_path: str | Path) -> None:


### PR DESCRIPTION
Closes #691 (X2-1 + C1-1 + D1-6). Three non-atomic write sites that could corrupt user data:

- **X2-1** — 6 adapters (`cursor`/`codex`/`gemini`/`kimi`/`hermes`/`openclaw`) wrote the user's **live** editor/CLI config with a bare `write_text`; a crash mid-write truncates it. Factored `atomic_write_text`/`atomic_write_json` into `adapters/base.py` (tmp-in-same-dir + `os.replace`) and routed all 20 write sites through it. (claude/antigravity/chatgpt already did this.)
- **C1-1** — recall cache `set`/`invalidate` wrote a **fixed** `RECALL_CACHE_PATH.with_suffix('.tmp')`; concurrent writers interleaved on that single tmp, leaving the cache as two concatenated JSON docs and silently dropping sibling entries. Routed through `_shared._atomic_write_text` (unique per-pid tmp). Confirmed by the v3 stress harness.
- **D1-6** — the pre-migration backup copied the DB + `-wal` + `-shm` separately (non-atomic); a concurrent writer could tear the WAL pair so a restore failed (`no such table`). Now uses SQLite's **Online Backup API** for a single, internally-consistent snapshot file (restore = one `cp`).

**Tests** (`tests/test_issue_691_atomic_writes.py`): base atomic write + parent-mkdir; no bare `.write_text` remains in the 6 adapters; recall cache writes via the unique tmp + roundtrips + is 0600; the backup is a complete single-file snapshot openable without `-wal`. 269 adapter/recall/backup/storage tests still pass. ruff clean.

BLAST OFF v3.