### PR TITLE
fix: build_summaries uses #649 SAVEPOINT transaction hygiene (#692)

### DIFF
--- a/tests/test_issue_692_build_summaries_txn.py
+++ b/tests/test_issue_692_build_summaries_txn.py
@@ -1,0 +1,72 @@
+"""Regression lock: build_summaries must use the #649 SAVEPOINT transaction
+hygiene (D1-4 / issue #692) — completing the fix that landed on
+detect_contradictions / build_structured_facts but missed build_summaries.
+
+Pre-fix build_summaries did `if conn.in_transaction: conn.commit()` (committing
+the CALLER's open transaction) and mutated `conn.isolation_level`. Post-fix it
+wraps its writes in `_consolidation_write` (a SAVEPOINT), which nests in the
+caller's txn without committing it and never touches isolation_level.
+
+No model loads.
+"""
+import os
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+import inspect
+
+from truememory.consolidation import build_summaries
+from truememory.storage import create_db, insert_message
+
+
+def test_build_summaries_uses_savepoint_helper():
+    # writes go through the SAVEPOINT helper (the no-commit / no-isolation-level
+    # behavior is asserted directly in the two behavioral tests below).
+    src = inspect.getsource(build_summaries)
+    assert "_consolidation_write(conn" in src, "build_summaries must use the _consolidation_write SAVEPOINT"
+
+
+def _seed(conn, n=6):
+    for i in range(n):
+        insert_message(conn, {
+            "content": f"alice decided to migrate to clickhouse in month {i}",
+            "sender": "alice", "recipient": "bob",
+            "timestamp": f"2026-{(i % 12) + 1:02d}-01T10:00:00Z",
+            "category": "s", "modality": "conversation",
+        })
+    conn.commit()
+
+
+def test_build_summaries_does_not_commit_caller_writes(tmp_path):
+    """A caller's UNCOMMITTED write must survive build_summaries and still be
+    rollback-able (proving build_summaries didn't commit it)."""
+    conn = create_db(tmp_path / "s.db")
+    _seed(conn)
+
+    # Begin a caller transaction with an uncommitted insert.
+    conn.execute(
+        "INSERT INTO messages (content, sender, recipient, timestamp, category, modality) "
+        "VALUES ('UNCOMMITTED caller row', 'x', 'y', '2026-01-01T00:00:00Z', 's', 'conversation')"
+    )
+    assert conn.in_transaction
+
+    build_summaries(conn)  # must NOT commit the caller's open transaction
+
+    # The caller's row is still in the open txn and can be rolled back.
+    assert conn.in_transaction, "build_summaries committed/closed the caller's transaction"
+    conn.rollback()
+    leaked = conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE content = 'UNCOMMITTED caller row'"
+    ).fetchone()[0]
+    assert leaked == 0, "caller's uncommitted row was committed by build_summaries (leaked txn)"
+    conn.close()
+
+
+def test_build_summaries_isolation_level_unchanged(tmp_path):
+    conn = create_db(tmp_path / "s2.db")
+    _seed(conn)
+    before = conn.isolation_level
+    build_summaries(conn)
+    assert conn.isolation_level == before, "build_summaries leaked an isolation_level change"
+    conn.close()

--- a/truememory/consolidation.py
+++ b/truememory/consolidation.py
@@ -1043,23 +1043,19 @@ def build_summaries(conn: sqlite3.Connection) -> int:
                 now,
             ))
 
-    # Short, explicit, atomic write: hold the write lock only for the clear +
-    # bulk insert, not the computation above. We drive the transaction manually
-    # and switch the connection to autocommit (isolation_level=None) for the
-    # duration so pysqlite does NOT also manage transactions implicitly — this
-    # makes our BEGIN IMMEDIATE / COMMIT / ROLLBACK authoritative regardless of
-    # the connection's configured isolation_level (avoids both "cannot start a
-    # transaction within a transaction" and pysqlite's commit()/rollback()
-    # becoming no-ops after a manual BEGIN). Any pending implicit transaction is
-    # flushed first so the write lock is acquired cleanly, and isolation_level
-    # is always restored. Rollback-on-error guarantees the summaries table is
-    # never left emptied without its replacement rows.
-    if conn.in_transaction:
-        conn.commit()
-    prev_isolation = conn.isolation_level
-    try:
-        conn.isolation_level = None
-        conn.execute("BEGIN IMMEDIATE")
+    # Short, atomic write: hold the write lock only for the clear + bulk insert,
+    # not the computation above.
+    #
+    # D1-4 (#692): complete the #649 transaction-hygiene fix. This used to
+    # `conn.commit()` the CALLER's open transaction (committing writes they may
+    # have intended to roll back — the leaked-txn root cause behind a live lock)
+    # and mutate the shared connection's isolation_level. Use the same
+    # _consolidation_write SAVEPOINT wrapper as detect_contradictions /
+    # build_structured_facts: it nests inside the caller's transaction WITHOUT
+    # committing it, rolls back ONLY our own rows on error (so the summaries
+    # table is never left emptied without its replacement), and never touches
+    # isolation_level.
+    with _consolidation_write(conn, "summaries"):
         conn.execute("DELETE FROM summaries")
         if rows:
             conn.executemany(
@@ -1069,15 +1065,6 @@ def build_summaries(conn: sqlite3.Connection) -> int:
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 rows,
             )
-        conn.execute("COMMIT")
-    except Exception:
-        try:
-            conn.execute("ROLLBACK")
-        except Exception:
-            pass
-        raise
-    finally:
-        conn.isolation_level = prev_isolation
     return len(rows)
 
 


### PR DESCRIPTION
Closes #692 (D1-4). **Completes the v2 #649 fix.**

#649 wrapped consolidation writes in the `_consolidation_write` SAVEPOINT helper (no commit of the caller's txn, no `isolation_level` mutation) — but applied it to `detect_contradictions` and `build_structured_facts` and **missed `build_summaries`**, which still did `if conn.in_transaction: conn.commit()` (committing the **caller's** open transaction — the leaked-txn root cause behind the v2 live-lock incident) plus an `isolation_level=None` mutation on the shared connection.

`build_summaries` now wraps its `DELETE FROM summaries` + bulk insert in `_consolidation_write(conn, "summaries")`, identical to the other two consolidation writers.

**Tests** (`tests/test_issue_692_build_summaries_txn.py`): it uses the SAVEPOINT helper; a caller's uncommitted write survives `build_summaries` and is still rollback-able (proving it wasn't committed); `isolation_level` is unchanged. 114 consolidation/#649 tests still pass. ruff clean.

This is the last of the 3 incomplete v2 fixes from the v3 validation (the other two — #638→#698, #653→#699 — already landed).

BLAST OFF v3.