### PR TITLE
fix: rate-limit the per-exchange store at store_intensity=max (#693)

### DIFF
--- a/tests/test_issue_693_store_ratelimit.py
+++ b/tests/test_issue_693_store_ratelimit.py
@@ -1,0 +1,57 @@
+"""Regression lock: the per-exchange store at store_intensity=max must be
+rate-limited so a prompt flood can't pile up unbounded synchronous embed/dedup
+work (SRE-02 / issue #693).
+
+Pre-fix: _try_per_exchange_store ran a full Memory-open + search-embed +
+EncodingGate + check_duplicate + add on EVERY storable prompt with no spacing.
+Post-fix: a per-session time debounce (_store_debounced) skips the eager store
+when one ran within the window — the Stop-hook background extraction still
+captures everything from the transcript, so no data is lost.
+
+No model loads — exercises the debounce gate directly.
+"""
+import os
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+import time
+
+
+def test_store_debounce_skips_rapid_second_store(tmp_path, monkeypatch):
+    import truememory.ingest.hooks.user_prompt_submit as ups
+    monkeypatch.setattr(ups, "_STORE_MARKER_DIR", tmp_path / "store_markers")
+    monkeypatch.setattr(ups, "_STORE_DEBOUNCE_SECONDS", 2)
+
+    # First store for the session is allowed; an immediate second is debounced.
+    assert ups._store_debounced("sess-A") is False  # allowed (records time)
+    assert ups._store_debounced("sess-A") is True    # within window -> skip
+    assert ups._store_debounced("sess-A") is True    # still within window
+
+
+def test_store_debounce_is_per_session(tmp_path, monkeypatch):
+    import truememory.ingest.hooks.user_prompt_submit as ups
+    monkeypatch.setattr(ups, "_STORE_MARKER_DIR", tmp_path / "store_markers")
+    monkeypatch.setattr(ups, "_STORE_DEBOUNCE_SECONDS", 5)
+    assert ups._store_debounced("sess-A") is False
+    # A different session is independent (not debounced by sess-A's store).
+    assert ups._store_debounced("sess-B") is False
+
+
+def test_store_debounce_window_expires(tmp_path, monkeypatch):
+    import truememory.ingest.hooks.user_prompt_submit as ups
+    monkeypatch.setattr(ups, "_STORE_MARKER_DIR", tmp_path / "store_markers")
+    monkeypatch.setattr(ups, "_STORE_DEBOUNCE_SECONDS", 1)
+    assert ups._store_debounced("sess-C") is False
+    assert ups._store_debounced("sess-C") is True
+    time.sleep(1.1)
+    assert ups._store_debounced("sess-C") is False  # window elapsed -> allowed again
+
+
+def test_store_debounce_disabled_when_zero(tmp_path, monkeypatch):
+    import truememory.ingest.hooks.user_prompt_submit as ups
+    monkeypatch.setattr(ups, "_STORE_MARKER_DIR", tmp_path / "store_markers")
+    monkeypatch.setattr(ups, "_STORE_DEBOUNCE_SECONDS", 0)
+    # disabled: never debounces
+    assert ups._store_debounced("sess-D") is False
+    assert ups._store_debounced("sess-D") is False

--- a/truememory/ingest/hooks/user_prompt_submit.py
+++ b/truememory/ingest/hooks/user_prompt_submit.py
@@ -402,6 +402,39 @@ def _check_conversation_depth(session_id: str, prompt: str, window: int = 5) -> 
         return False
 
 
+# SRE-02 (#693): minimum spacing between per-exchange stores for one session.
+# 0 disables the debounce. Configurable for tests / power users.
+_STORE_DEBOUNCE_SECONDS = _env_int("TRUEMEMORY_STORE_DEBOUNCE_SECONDS", 2, lo=0)
+_STORE_MARKER_DIR = Path.home() / ".truememory" / "store_markers"
+
+
+def _store_debounced(session_id: str) -> bool:
+    """Return True if a per-exchange store for *session_id* ran within the last
+    ``_STORE_DEBOUNCE_SECONDS`` (so this one should be skipped).
+
+    When it returns False (store allowed) it records the current time so the
+    next call within the window is debounced. Never blocks on marker I/O error.
+    """
+    if _STORE_DEBOUNCE_SECONDS <= 0:
+        return False
+    try:
+        safe = _safe_session_id_local(session_id)
+        marker = _STORE_MARKER_DIR / f"{safe}.ts"
+        now = time.time()
+        if marker.exists():
+            try:
+                if now - float(marker.read_text(encoding="utf-8").strip()) < _STORE_DEBOUNCE_SECONDS:
+                    return True
+            except (OSError, ValueError):
+                pass
+        from truememory.ingest.hooks._shared import _secure_mkdir
+        _secure_mkdir(_STORE_MARKER_DIR)
+        marker.write_text(str(now), encoding="utf-8")
+        return False
+    except OSError:
+        return False
+
+
 def _try_per_exchange_store(prompt: str, session_id: str, user_id: str, db_path: str, store_intensity: str) -> None:
     """Per-exchange evaluator: detect storable content and store via encoding gate.
 
@@ -418,6 +451,16 @@ def _try_per_exchange_store(prompt: str, session_id: str, user_id: str, db_path:
     # The depth check excludes the current prompt (already buffered by main())
     # so "enhanced" does not trivially match itself (issue #634, M-17).
     if store_intensity == "enhanced" and not _check_conversation_depth(session_id, prompt):
+        return
+
+    # SRE-02 (#693): bound the per-exchange store RATE. The work below
+    # (Memory open + embed + dedup + add) runs SYNCHRONOUSLY on prompt
+    # submission; without a limit a rapid flood of storable prompts at
+    # store_intensity=max piles up unbounded synchronous work and starves the
+    # model-server recall fast-lane. Debounce per session — the Stop-hook
+    # background extraction still captures everything from the transcript, so
+    # this only drops the redundant *eager* store, never data.
+    if _store_debounced(session_id):
         return
 
     # Issue #634 (M-18): arm the same model-server deadline the recall paths


### PR DESCRIPTION
Closes #693 (SRE-02).

`_try_per_exchange_store` ran a full Memory-open + search-embed + EncodingGate + `check_duplicate` + `add` **synchronously** on every storable prompt, with no spacing — unlike the background extraction path (gated by `check_extraction_budget`, 20/hr). A rapid flood of storable prompts at `store_intensity=max` piled up unbounded synchronous work and could starve the model-server recall fast-lane.

**Fix:** a per-session time debounce (`_store_debounced`, `TRUEMEMORY_STORE_DEBOUNCE_SECONDS`, default 2s) — skip the eager store when one already ran for the session within the window. Chosen over consuming `check_extraction_budget` so it does **not** contend with / starve background extraction in normal sessions. No data loss: the Stop-hook background extraction still captures everything from the transcript, so this only drops the redundant *eager* store.

**Test** (`tests/test_issue_693_store_ratelimit.py`): a rapid second store is debounced; the debounce is per-session; the window expires; `0` disables it. 145 per-exchange-store / #634 / #635 tests still pass. ruff clean.

BLAST OFF v3.