### PR TITLE
fix: prune extracted/ markers independent of the stale-session scan (#694)

### DIFF
--- a/tests/test_issue_694_marker_prune.py
+++ b/tests/test_issue_694_marker_prune.py
@@ -1,0 +1,49 @@
+"""Regression lock: extracted/ marker pruning must run even when there is
+nothing to scan (SRE-03 / issue #694).
+
+Pre-fix: _cleanup_extracted_markers ran only at the very END of
+_scan_stale_sessions, after a claude_dir-missing early return (and others), so
+when ~/.claude/projects was absent the markers were never pruned and grew
+unbounded (54K+ observed in prod). Post-fix it runs right after the scan
+interval gate, before the claude_dir check.
+
+No model loads.
+"""
+import os
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+import time
+
+
+def test_pruning_runs_when_claude_projects_absent(tmp_path, monkeypatch):
+    import truememory.ingest.hooks.session_start as ss
+    import truememory.ingest.hooks._shared as shared
+
+    # Isolate all of ~/.truememory + ~/.claude into tmp, with NO ~/.claude/projects.
+    fake_home = tmp_path / "home"
+    extracted = fake_home / ".truememory" / "extracted"
+    extracted.mkdir(parents=True)
+    scan_marker = fake_home / ".truememory" / ".last_stale_scan"
+    monkeypatch.setattr(shared, "EXTRACTED_DIR", extracted)
+    monkeypatch.setattr(ss, "_SCAN_MARKER", scan_marker)
+    monkeypatch.setattr(ss, "_EXTRACTED_MARKER_MAX_AGE", 30 * 86400)
+    # Point Path.home() at fake_home so claude_dir = fake_home/.claude/projects (absent).
+    monkeypatch.setattr(ss.Path, "home", staticmethod(lambda: fake_home))
+
+    # Seed an OLD marker (older than the max age) and a FRESH one.
+    old = extracted / "old-session"
+    old.write_text("{}")
+    old_time = time.time() - 40 * 86400
+    os.utime(old, (old_time, old_time))
+    fresh = extracted / "fresh-session"
+    fresh.write_text("{}")
+
+    assert not (fake_home / ".claude" / "projects").exists()  # nothing to scan
+
+    ss._scan_stale_sessions()
+
+    # The old marker is pruned even though there was no claude_dir to scan.
+    assert not old.exists(), "old marker not pruned when ~/.claude/projects absent (SRE-03 regression)"
+    assert fresh.exists(), "fresh marker should be kept"

--- a/truememory/ingest/hooks/session_start.py
+++ b/truememory/ingest/hooks/session_start.py
@@ -486,6 +486,14 @@ def _scan_stale_sessions() -> None:
         except OSError:
             return
 
+        # SRE-03 (#694): prune old extracted/ markers here — gated by the scan
+        # interval (so it runs at most once per _SCAN_INTERVAL) but BEFORE the
+        # claude_dir early-return below. Previously cleanup ran only at the very
+        # end of this function, so when ~/.claude/projects was missing (or any
+        # other early return fired) markers were never pruned and grew unbounded
+        # (54K+ observed in prod). Marker cleanup doesn't need claude_dir.
+        _cleanup_extracted_markers()
+
         # Fall back to 24-hour lookback when no previous watermark exists
         # (first scan or corrupted marker).
         cutoff = watermark if watermark > 0 else (now - 86400)
@@ -606,11 +614,9 @@ def _scan_stale_sessions() -> None:
             _commit_watermark(oldest_deferred_mtime)
         else:
             _commit_watermark(now)
-
-        # Piggyback on the scan window to prune stale extracted/ markers
-        # (issue #579). Runs at most once per _SCAN_INTERVAL alongside the
-        # stale-session scan so it adds no extra scheduling overhead.
-        _cleanup_extracted_markers()
+        # NOTE: extracted/ marker pruning now runs earlier (right after the
+        # interval gate, before the claude_dir early-return) so it can't be
+        # skipped when there's nothing to scan (SRE-03 / #694).
     finally:
         try:
             os.close(scan_fd)


### PR DESCRIPTION
Closes #694 (SRE-03).

`_cleanup_extracted_markers` ran only at the **end** of `_scan_stale_sessions`, after the `claude_dir`-missing early return (and other early returns). When `~/.claude/projects` was absent the scan returned before pruning ever ran, so `extracted/` markers grew unbounded (**54K+** observed in prod — slow directory listings, inode pressure).

**Fix:** move the cleanup to run right after the scan-interval gate — still rate-limited to once per `_SCAN_INTERVAL`, but **before** the `claude_dir` check — so pruning happens on cadence regardless of whether there's anything to scan.

**Test** (`tests/test_issue_694_marker_prune.py`): with `~/.claude/projects` absent, an over-age marker is still pruned and a fresh one kept. 112 session_start / stale-scan tests still pass. ruff clean.

BLAST OFF v3.