### PR TITLE
fix: declare hdbscan extra + sanitize untrusted log content (#696)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,13 @@ dependencies = [
 reranker = []
 gpu = []
 agentic = []
+# A2-1 (#696): HDBSCAN scene clustering is an optional feature — clustering.py
+# imports `hdbscan` lazily and degrades gracefully when absent. Declare it as an
+# extra so `pip install truememory[clustering]` resolves it, instead of users
+# guessing the off-resolver package name from a docstring.
+clustering = ["hdbscan>=0.8,<0.9"]
 dev = ["pytest>=7.0,<10.0", "pytest-timeout>=2.2,<3.0", "ruff>=0.4,<1.0", "build>=1.2,<2.0", "twine>=5.0,<7.0"]
-all = ["truememory[agentic]"]
+all = ["truememory[agentic,clustering]"]
 
 [project.scripts]
 truememory-mcp = "truememory.mcp_server:main"

--- a/tests/test_issue_696_hdbscan_logsanitize.py
+++ b/tests/test_issue_696_hdbscan_logsanitize.py
@@ -1,14 +1,8 @@
 """Regression locks for #696: hdbscan declared as an optional extra (A2-1) and
 log sanitization of untrusted content (S1-3).
 
-No model loads.
+No model loads. Offline mode is set in conftest.py (#697), not here.
 """
-import os
-
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
-
-import tomllib
 from pathlib import Path
 
 
@@ -16,13 +10,12 @@ from pathlib import Path
 # ── A2-1: hdbscan declared as an extra ───────────────────────────────────────
 
 def test_hdbscan_declared_as_extra():
-    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
-    data = tomllib.loads(pyproject.read_text())
-    extras = data["project"]["optional-dependencies"]
-    assert "clustering" in extras, "a 'clustering' extra must exist"
-    assert any("hdbscan" in dep for dep in extras["clustering"]), (
-        "the clustering extra must declare hdbscan"
-    )
+    # Text-based (no tomllib — that's 3.11+, but the matrix includes 3.10).
+    text = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text()
+    assert "clustering = [" in text, "a 'clustering' extra must exist"
+    # the clustering extra line must name hdbscan
+    line = next(ln for ln in text.splitlines() if ln.strip().startswith("clustering = ["))
+    assert "hdbscan" in line, "the clustering extra must declare hdbscan"
 
 
 # ── S1-3: log sanitization ───────────────────────────────────────────────────

--- a/tests/test_issue_696_hdbscan_logsanitize.py
+++ b/tests/test_issue_696_hdbscan_logsanitize.py
@@ -1,0 +1,54 @@
+"""Regression locks for #696: hdbscan declared as an optional extra (A2-1) and
+log sanitization of untrusted content (S1-3).
+
+No model loads.
+"""
+import os
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+import tomllib
+from pathlib import Path
+
+
+
+# ── A2-1: hdbscan declared as an extra ───────────────────────────────────────
+
+def test_hdbscan_declared_as_extra():
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+    extras = data["project"]["optional-dependencies"]
+    assert "clustering" in extras, "a 'clustering' extra must exist"
+    assert any("hdbscan" in dep for dep in extras["clustering"]), (
+        "the clustering extra must declare hdbscan"
+    )
+
+
+# ── S1-3: log sanitization ───────────────────────────────────────────────────
+
+def test_safe_log_strips_control_chars():
+    from truememory.ingest.pipeline import _safe_log
+    # newline / CR / ANSI / NUL must not survive into a log line
+    out = _safe_log("line one\nFORGED LOG LINE\r\x1b[31mred\x00\ttab")
+    assert "\n" not in out and "\r" not in out
+    assert "\x1b" not in out and "\x00" not in out and "\t" not in out
+    # the visible text is preserved (control chars replaced with spaces)
+    assert "line one" in out and "FORGED LOG LINE" in out and "red" in out
+
+
+def test_safe_log_handles_non_str():
+    from truememory.ingest.pipeline import _safe_log
+    assert _safe_log(None) == "None"
+    assert _safe_log(123) == "123"
+
+
+def test_pipeline_log_calls_use_safe_log():
+    """The user-content log args (fact.content / dedup.fact) route through _safe_log."""
+    import inspect
+    from truememory.ingest import pipeline
+    src = inspect.getsource(pipeline)
+    # no RAW user-content slice remains as a bare log arg
+    assert "_safe_log(fact.content[:50])" in src
+    assert "_safe_log(dedup.fact[:80])" in src
+    assert "_safe_log(dedup.fact[:120])" in src

--- a/tests/test_issue_696_hdbscan_logsanitize.py
+++ b/tests/test_issue_696_hdbscan_logsanitize.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 def test_hdbscan_declared_as_extra():
     # Text-based (no tomllib — that's 3.11+, but the matrix includes 3.10).
-    text = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text()
+    text = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(encoding="utf-8")
     assert "clustering = [" in text, "a 'clustering' extra must exist"
     # the clustering extra line must name hdbscan
     line = next(ln for ln in text.splitlines() if ln.strip().startswith("clustering = ["))

--- a/tests/test_issue_697_docs_packaging.py
+++ b/tests/test_issue_697_docs_packaging.py
@@ -6,9 +6,10 @@ No model loads.
 import glob
 import os
 import re
-import tomllib
 from pathlib import Path
 # NOTE: offline mode is set in conftest.py (V-cigate-1 / #697), not here.
+# NOTE: pyproject is parsed as text, not tomllib — tomllib is 3.11+ and the CI
+# matrix includes 3.10.
 
 _ROOT = Path(__file__).resolve().parents[1]
 
@@ -40,9 +41,9 @@ def test_python_api_doc_metadata_not_reserved():
 # ── A2-4: sdist excludes tests/ ──────────────────────────────────────────────
 
 def test_sdist_excludes_tests():
-    data = tomllib.loads((_ROOT / "pyproject.toml").read_text())
-    excludes = data["tool"]["hatch"]["build"]["targets"]["sdist"]["exclude"]
-    assert "/tests" in excludes, "sdist must exclude /tests"
+    text = (_ROOT / "pyproject.toml").read_text()
+    # the hatch sdist exclude list must contain "/tests"
+    assert '"/tests"' in text, "sdist must exclude /tests"
 
 
 # ── V-cigate-1 / §3.5: no test module sets offline mode at import ────────────

--- a/tests/test_issue_697_docs_packaging.py
+++ b/tests/test_issue_697_docs_packaging.py
@@ -17,15 +17,15 @@ _ROOT = Path(__file__).resolve().parents[1]
 # ── X1: docs report the real MCP tool count (11) ─────────────────────────────
 
 def _actual_tool_count() -> int:
-    src = (_ROOT / "truememory" / "mcp_server.py").read_text()
+    src = (_ROOT / "truememory" / "mcp_server.py").read_text(encoding="utf-8")
     return len(set(re.findall(r"def (truememory_[a-z_]+)\(", src)))
 
 
 def test_docs_report_correct_tool_count():
     n = _actual_tool_count()
     assert n == 11, f"expected 11 truememory_* tools, found {n} — update this test + the docs"
-    readme = (_ROOT / "README.md").read_text()
-    mcp_doc = (_ROOT / "docs" / "mcp-tools.md").read_text()
+    readme = (_ROOT / "README.md").read_text(encoding="utf-8")
+    mcp_doc = (_ROOT / "docs" / "mcp-tools.md").read_text(encoding="utf-8")
     assert "8 MCP tools" not in readme, "README still claims 8 MCP tools"
     assert "exposes 9 tools" not in mcp_doc, "docs/mcp-tools.md still claims 9 tools"
     assert f"{n} MCP tools" in readme or f"All {n} MCP tools" in readme
@@ -33,7 +33,7 @@ def test_docs_report_correct_tool_count():
 
 
 def test_python_api_doc_metadata_not_reserved():
-    doc = (_ROOT / "docs" / "python-api.md").read_text()
+    doc = (_ROOT / "docs" / "python-api.md").read_text(encoding="utf-8")
     assert "Reserved for future use" not in doc, "metadata is a live field, not reserved"
     assert "directive" in doc, "m.add docs should mention the directive param"
 
@@ -41,7 +41,7 @@ def test_python_api_doc_metadata_not_reserved():
 # ── A2-4: sdist excludes tests/ ──────────────────────────────────────────────
 
 def test_sdist_excludes_tests():
-    text = (_ROOT / "pyproject.toml").read_text()
+    text = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     # the hatch sdist exclude list must contain "/tests"
     assert '"/tests"' in text, "sdist must exclude /tests"
 
@@ -59,7 +59,7 @@ def test_no_test_module_sets_hf_offline_at_import():
         name = os.path.basename(f)
         if name == "conftest.py":
             continue  # conftest is the sanctioned single source
-        if pat.search(Path(f).read_text()):
+        if pat.search(Path(f).read_text(encoding="utf-8")):
             offenders.append(os.path.relpath(f, _ROOT))
     assert not offenders, (
         "these test modules set offline mode at import (move it to conftest.py): " + ", ".join(offenders)

--- a/truememory/ingest/pipeline.py
+++ b/truememory/ingest/pipeline.py
@@ -28,6 +28,7 @@ import datetime
 import json
 import logging
 import os
+import re
 import sqlite3
 import time
 from dataclasses import dataclass, field
@@ -40,6 +41,19 @@ from truememory.ingest.dedup import check_duplicate, DedupAction
 from truememory.ingest.models import LLMConfig, auto_detect
 
 log = logging.getLogger(__name__)
+
+
+# S1-3 (#696): memory/transcript text (fact.content, dedup.fact) is logged for
+# diagnostics. Logging it raw lets embedded newlines / CR / ANSI escapes forge
+# extra log lines or inject terminal control sequences. _safe_log strips all
+# control characters (incl. newline/CR/tab → space) so a logged value stays on
+# one line and can't spoof log structure.
+_LOG_UNSAFE_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _safe_log(value: object) -> str:
+    """Neutralize control chars in untrusted text before it reaches a log line."""
+    return _LOG_UNSAFE_RE.sub(" ", str(value))
 
 
 # Optional: fcntl for cross-process locking of the dedup-store critical
@@ -481,7 +495,7 @@ class IngestionPipeline:
                 result.facts_skipped_gate += 1
                 trace_entry["action"] = "skipped_gate"
                 result.trace.append(trace_entry)
-                log.debug("Gate blocked: %s — %s", fact.content[:50], decision.reason)
+                log.debug("Gate blocked: %s — %s", _safe_log(fact.content[:50]), decision.reason)
                 continue
 
             result.facts_encoded += 1
@@ -523,7 +537,7 @@ class IngestionPipeline:
                             "Storage failed for fact (db=%s): %s — fact=%r",
                             getattr(self.memory, "db_path", "<unknown>"),
                             e,
-                            dedup.fact[:120],
+                            _safe_log(dedup.fact[:120]),
                         )
                         trace_entry["action"] = "storage_failed"
                         trace_entry["storage_error"] = {
@@ -533,7 +547,7 @@ class IngestionPipeline:
                     else:
                         result.facts_stored += 1
                         trace_entry["action"] = "stored"
-                        log.info("Stored: %s", dedup.fact[:80])
+                        log.info("Stored: %s", _safe_log(dedup.fact[:80]))
 
                 elif dedup.action == DedupAction.UPDATE:
                     try:
@@ -544,7 +558,7 @@ class IngestionPipeline:
                             dedup.existing_id,
                             getattr(self.memory, "db_path", "<unknown>"),
                             e,
-                            dedup.fact[:120],
+                            _safe_log(dedup.fact[:120]),
                         )
                         trace_entry["action"] = "storage_failed"
                         trace_entry["storage_error"] = {
@@ -554,12 +568,12 @@ class IngestionPipeline:
                     else:
                         result.facts_updated += 1
                         trace_entry["action"] = "updated"
-                        log.info("Updated [%s]: %s", dedup.existing_id, dedup.fact[:80])
+                        log.info("Updated [%s]: %s", dedup.existing_id, _safe_log(dedup.fact[:80]))
 
                 elif dedup.action == DedupAction.SKIP:
                     result.facts_skipped_dedup += 1
                     trace_entry["action"] = "skipped_dedup"
-                    log.debug("Dedup skipped: %s — %s", fact.content[:50], dedup.reason)
+                    log.debug("Dedup skipped: %s — %s", _safe_log(fact.content[:50]), dedup.reason)
 
             result.trace.append(trace_entry)
 
@@ -642,7 +656,7 @@ class IngestionPipeline:
                     try:
                         self._store_fact(dedup.fact, fact, session_id)
                     except sqlite3.OperationalError as e:
-                        log.error("Storage failed in ingest_text: %s — fact=%r", e, dedup.fact[:120])
+                        log.error("Storage failed in ingest_text: %s — fact=%r", e, _safe_log(dedup.fact[:120]))
                         continue
                     result.facts_stored += 1
                 elif dedup.action == DedupAction.UPDATE:
@@ -651,7 +665,7 @@ class IngestionPipeline:
                     except sqlite3.OperationalError as e:
                         log.error(
                             "Update failed in ingest_text for memory id=%s: %s — fact=%r",
-                            dedup.existing_id, e, dedup.fact[:120],
+                            dedup.existing_id, e, _safe_log(dedup.fact[:120]),
                         )
                         continue
                     result.facts_updated += 1
@@ -730,7 +744,7 @@ class IngestionPipeline:
                 if callable(updater):
                     result = updater(existing_id, new_content)
                     if result is not None:
-                        log.debug("Updated memory %d with: %s", existing_id, new_content[:60])
+                        log.debug("Updated memory %d with: %s", existing_id, _safe_log(new_content[:60]))
                         return
                 else:
                     log.warning("Memory.update() not available; storing as new")


### PR DESCRIPTION
Closes #696 (A2-1 + S1-3).

- **A2-1** — `clustering.py` imports `hdbscan` lazily but it was declared **nowhere** in `pyproject.toml`, so the clustering feature silently no-op'd for every install and the docstring told users to `pip install hdbscan` off-resolver (a typosquat surface). Declared a `clustering = ["hdbscan>=0.8,<0.9"]` optional extra and added it to `[all]`.
- **S1-3** — memory/transcript text (`fact.content`, `dedup.fact`) was logged raw, so embedded newlines/CR/ANSI could forge log lines or inject terminal escapes (`pipeline.py:484/536/557/562`, …). Added `_safe_log()` (strips all control chars incl. newline/CR/tab → space) and routed the 9 user-content log args through it.

**Tests** (`tests/test_issue_696_hdbscan_logsanitize.py`): the `clustering` extra declares hdbscan; `_safe_log` strips control chars and handles non-str; the user-content log args use `_safe_log`. 12 pipeline/clustering tests still pass. ruff clean.

BLAST OFF v3.