### PR TITLE
chore: docs accuracy + sdist excludes tests/ + centralize test offline-env (#697)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ results = m.search_deep("career history?", user_id="alex")  # multi-round, highe
 |---|---|
 | [Getting Started](docs/guides/getting-started.md) | Install to first memory |
 | [Python API Reference](docs/python-api.md) | Full `Memory` class reference |
-| [MCP Tool Reference](docs/mcp-tools.md) | All 8 MCP tools |
+| [MCP Tool Reference](docs/mcp-tools.md) | All 11 MCP tools |
 | [CLI Reference](docs/cli.md) | `truememory-mcp` and `truememory-ingest` |
 | [Environment Variables](docs/env-vars.md) | All `TRUEMEMORY_*` config options |
 | [Architecture Deep Dive](docs/architecture.md) | 6-layer retrieval pipeline, encoding gate |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tool Reference
 
-TrueMemory exposes 9 tools via the Model Context Protocol. These are called by Claude Code, Claude Desktop, and other MCP-compatible clients.
+TrueMemory exposes 11 tools via the Model Context Protocol. These are called by Claude Code, Claude Desktop, and other MCP-compatible clients.
 
 ---
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -31,15 +31,16 @@ with Memory() as m:
 
 ---
 
-## m.add(content, user_id=None, metadata=None) → dict
+## m.add(content, user_id=None, metadata=None, directive=False) → dict
 
-Store a memory. Returns a dict with the new memory's `id`, `content`, `user_id`, and `created_at`. Empty or whitespace-only content is silently skipped (returns `{"id": None}`).
+Store a memory. Returns a dict with the new memory's `id`, `content`, `user_id`, and `created_at`. Empty or whitespace-only content is skipped (a warning is issued and a skip-marker `{"id": None}` is returned).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `content` | `str` | required | The fact or preference to store. Write as a clear, atomic statement. |
 | `user_id` | `str \| None` | `None` | Scope this memory to a specific user. |
-| `metadata` | `dict \| None` | `None` | Reserved for future use. |
+| `metadata` | `dict \| None` | `None` | JSON-serializable metadata persisted with the memory and round-tripped on retrieval (live since v0.7.x). |
+| `directive` | `bool` | `False` | Store as a standing directive (an always-injected instruction) rather than a recallable fact. |
 
 ```python
 result = m.add("Prefers TypeScript over JavaScript", user_id="alice")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ packages = ["truememory"]
 # _working/ (149MB of paper drafts, audit logs, bench archives).
 exclude = [
     "/_working",
+    "/tests",  # A2-4 (#697): tests are not needed in the source distribution
     "/.claude",
     "/dist",
     "/build",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,17 @@ import sqlite3
 
 import pytest
 
+# V-cigate-1 (#697): offline mode is set ONCE here, in the single conftest that
+# pytest imports before any test module, instead of each test module doing its
+# own module-level os.environ.setdefault("HF_HUB_OFFLINE", "1"). Those scattered
+# import-time mutations were the §3.5 class behind the original network-tests
+# leak (#654): pytest imports every module during collection, so an offline
+# setdefault leaked into the online job. setdefault (not [...]=) so the
+# network-tests job's explicit HF_HUB_OFFLINE="0" still wins. A guard test
+# (test_ci_isolation) fails if a test module reintroduces the antipattern.
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
 
 def _can_load_sqlite_vec() -> bool:
     """True if sqlite-vec can be loaded into a connection."""

--- a/tests/test_issue_630_search_supplement_merge.py
+++ b/tests/test_issue_630_search_supplement_merge.py
@@ -26,12 +26,9 @@ module namespace. No model loads.
 """
 from __future__ import annotations
 
-import os
 
 import pytest
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 
 @pytest.fixture

--- a/tests/test_issue_634_per_exchange_store.py
+++ b/tests/test_issue_634_per_exchange_store.py
@@ -17,11 +17,9 @@ All tests mock the model/embedding layer (no real model loads).
 from __future__ import annotations
 
 import json
-import os
 
 import pytest
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_635_per_exchange_coordination.py
+++ b/tests/test_issue_635_per_exchange_coordination.py
@@ -18,11 +18,9 @@ All tests mock the model/embedding layer (no real model loads).
 """
 from __future__ import annotations
 
-import os
 
 import pytest
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_636_intensity_validation.py
+++ b/tests/test_issue_636_intensity_validation.py
@@ -24,11 +24,9 @@ All tests mock the model/embedding layer (no real model loads).
 from __future__ import annotations
 
 import json
-import os
 
 import pytest
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_638_directive_injection.py
+++ b/tests/test_issue_638_directive_injection.py
@@ -18,10 +18,7 @@ FTS-only / in-memory. HF_HUB_OFFLINE=1, no embedding model loads.
 
 from __future__ import annotations
 
-import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 import sqlite3
 

--- a/tests/test_issue_645_recall_cache.py
+++ b/tests/test_issue_645_recall_cache.py
@@ -17,12 +17,9 @@ Covers the three M-findings plus the deferred M-47 (#652):
 """
 from __future__ import annotations
 
-import os
 
 import pytest
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 from truememory.ingest.hooks import _shared
 

--- a/tests/test_issue_649_dedup_gate_hygiene.py
+++ b/tests/test_issue_649_dedup_gate_hygiene.py
@@ -28,7 +28,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
 
 import truememory.ingest.markers as markers
 import truememory.ingest.dedup as dedup

--- a/tests/test_issue_684_db_reconnect.py
+++ b/tests/test_issue_684_db_reconnect.py
@@ -9,10 +9,7 @@ Post-fix: _ensure_connection probes the cached handle and reconnects on failure.
 
 FTS-only / no model loads.
 """
-import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 import sqlite3
 

--- a/tests/test_issue_685_forget_derived.py
+++ b/tests/test_issue_685_forget_derived.py
@@ -11,10 +11,7 @@ any summary that lists the message id).
 FTS-only / no model loads — exercises delete_message directly against
 hand-seeded derived rows.
 """
-import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 import json
 

--- a/tests/test_issue_687_dedup_near_token.py
+++ b/tests/test_issue_687_dedup_near_token.py
@@ -9,10 +9,7 @@ divergence keeps both facts (ADD) and only true paraphrases fast-SKIP.
 
 No model loads — drives check_duplicate with a stubbed search function.
 """
-import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 from truememory.ingest.dedup import (
     check_duplicate,

--- a/tests/test_issue_689_recall_scaling.py
+++ b/tests/test_issue_689_recall_scaling.py
@@ -9,10 +9,7 @@ Post-fix: it returns [] early without touching FTS.
 
 FTS-only / no model loads.
 """
-import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 import truememory.consolidation as consolidation
 from truememory.consolidation import search_consolidated

--- a/tests/test_issue_690_skip_reranker.py
+++ b/tests/test_issue_690_skip_reranker.py
@@ -8,10 +8,7 @@ read content/score, never ranked order.
 
 No model loads — uses a stub Memory that records the _skip_reranker kwarg.
 """
-import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 
 class _RecordingMemory:

--- a/tests/test_issue_691_atomic_writes.py
+++ b/tests/test_issue_691_atomic_writes.py
@@ -5,8 +5,6 @@ No model loads.
 """
 import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 import json
 import sqlite3

--- a/tests/test_issue_692_build_summaries_txn.py
+++ b/tests/test_issue_692_build_summaries_txn.py
@@ -9,10 +9,7 @@ caller's txn without committing it and never touches isolation_level.
 
 No model loads.
 """
-import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 import inspect
 

--- a/tests/test_issue_693_store_ratelimit.py
+++ b/tests/test_issue_693_store_ratelimit.py
@@ -10,10 +10,7 @@ captures everything from the transcript, so no data is lost.
 
 No model loads — exercises the debounce gate directly.
 """
-import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 import time
 

--- a/tests/test_issue_694_marker_prune.py
+++ b/tests/test_issue_694_marker_prune.py
@@ -11,8 +11,6 @@ No model loads.
 """
 import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 import time
 

--- a/tests/test_issue_697_docs_packaging.py
+++ b/tests/test_issue_697_docs_packaging.py
@@ -1,0 +1,65 @@
+"""Regression locks for #697: docs accuracy (X1), sdist hygiene (A2-4), and the
+test-module import-time env-leak class (V-cigate-1 / §3.5).
+
+No model loads.
+"""
+import glob
+import os
+import re
+import tomllib
+from pathlib import Path
+# NOTE: offline mode is set in conftest.py (V-cigate-1 / #697), not here.
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ── X1: docs report the real MCP tool count (11) ─────────────────────────────
+
+def _actual_tool_count() -> int:
+    src = (_ROOT / "truememory" / "mcp_server.py").read_text()
+    return len(set(re.findall(r"def (truememory_[a-z_]+)\(", src)))
+
+
+def test_docs_report_correct_tool_count():
+    n = _actual_tool_count()
+    assert n == 11, f"expected 11 truememory_* tools, found {n} — update this test + the docs"
+    readme = (_ROOT / "README.md").read_text()
+    mcp_doc = (_ROOT / "docs" / "mcp-tools.md").read_text()
+    assert "8 MCP tools" not in readme, "README still claims 8 MCP tools"
+    assert "exposes 9 tools" not in mcp_doc, "docs/mcp-tools.md still claims 9 tools"
+    assert f"{n} MCP tools" in readme or f"All {n} MCP tools" in readme
+    assert f"exposes {n} tools" in mcp_doc
+
+
+def test_python_api_doc_metadata_not_reserved():
+    doc = (_ROOT / "docs" / "python-api.md").read_text()
+    assert "Reserved for future use" not in doc, "metadata is a live field, not reserved"
+    assert "directive" in doc, "m.add docs should mention the directive param"
+
+
+# ── A2-4: sdist excludes tests/ ──────────────────────────────────────────────
+
+def test_sdist_excludes_tests():
+    data = tomllib.loads((_ROOT / "pyproject.toml").read_text())
+    excludes = data["tool"]["hatch"]["build"]["targets"]["sdist"]["exclude"]
+    assert "/tests" in excludes, "sdist must exclude /tests"
+
+
+# ── V-cigate-1 / §3.5: no test module sets offline mode at import ────────────
+
+def test_no_test_module_sets_hf_offline_at_import():
+    """Offline mode is centralized in conftest.py. A test module doing its own
+    module-level os.environ.setdefault("HF_HUB_OFFLINE", ...) is the §3.5 leak
+    class (#654) — pytest imports every module during collection, so it would
+    leak offline-mode into the online network-tests job."""
+    offenders = []
+    pat = re.compile(r'(?m)^os\.environ\.setdefault\(\s*["\'](?:HF_HUB_OFFLINE|TRANSFORMERS_OFFLINE)["\']')
+    for f in glob.glob(str(_ROOT / "tests" / "**" / "*.py"), recursive=True):
+        name = os.path.basename(f)
+        if name == "conftest.py":
+            continue  # conftest is the sanctioned single source
+        if pat.search(Path(f).read_text()):
+            offenders.append(os.path.relpath(f, _ROOT))
+    assert not offenders, (
+        "these test modules set offline mode at import (move it to conftest.py): " + ", ".join(offenders)
+    )

--- a/tests/test_memory_render_escape.py
+++ b/tests/test_memory_render_escape.py
@@ -8,10 +8,7 @@ block. These tests fail pre-fix, pass post-fix.
 
 FTS-only / no model loads.
 """
-import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 from truememory._sanitize import sanitize_injection_content
 

--- a/tests/test_transcript_guard_stop_drain.py
+++ b/tests/test_transcript_guard_stop_drain.py
@@ -9,10 +9,7 @@ tests fail pre-fix, pass post-fix.
 
 FTS-only / no model loads.
 """
-import os
 
-os.environ.setdefault("HF_HUB_OFFLINE", "1")
-os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 
 from truememory.ingest.hooks._shared import is_allowed_transcript, _transcript_roots
 


### PR DESCRIPTION
Closes #697 (X1 docs + A2-4 sdist + V-cigate-1).

- **X1 (docs)** — README ("All 8 MCP tools") + `docs/mcp-tools.md` ("exposes 9 tools") → **11** (the real count, adding `truememory_status` + `truememory_consolidate`). `docs/python-api.md`: `metadata` is a **live persisted field** (was "Reserved for future use" — live since #629) and `m.add`'s `directive` param is now documented.
- **A2-4 (sdist)** — add `/tests` to the hatch sdist exclude list (the source distribution was shipping the whole test tree).
- **V-cigate-1 / §3.5** — move the per-module `os.environ.setdefault("HF_HUB_OFFLINE", "1")` to a single `conftest.py` setdefault (pytest imports it before any test module) and strip it from **18** test modules. Those scattered import-time mutations were the leak class behind the original network-tests failure (#654). A guard test now fails if any test module reintroduces the antipattern. `setdefault` (not `=`) so the network-tests job's explicit `HF_HUB_OFFLINE="0"` still wins.

**Tests** (`tests/test_issue_697_docs_packaging.py`): docs report 11 tools + metadata not "reserved"; sdist excludes `/tests`; no test module sets offline mode at import. Full gate suite: **1937 passed** (only the 2 env-only `test_cli_help` failures). ruff clean.

BLAST OFF v3 — final fix of the 16.