### PR TITLE
chore: bump version to 0.7.6.2 (BLAST OFF v3 hardening release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truememory"
-version = "0.7.6.1"
+version = "0.7.6.2"
 description = "SOTA-level agent memory at zero infrastructure cost."
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump for the **v0.7.6.2** BLAST OFF v3 hardening release.

16 fixes shipped across PRs #698–713 (issues #684–697): all 7 P1 + 9 P2, including the 3 incomplete v2 fixes now closed (#638→#698, #649→#708, #653→#699). No functional changes here — version string only. Release notes on the GitHub release.